### PR TITLE
Add the build-shell-project task with artlink-manifested outputs

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -387,6 +387,36 @@ class SynthesizeTask(ModuleSelectionModel):
         )
 
 
+def _bitstream_from_shell_build_manifest(manifest_path: Path) -> Path:
+    """Resolve and verify the bitstream from an artlink shell-build
+    manifest: build_status must be built and the file must match its
+    recorded digest — a flashed bitstream is identified by provenance,
+    never by filename."""
+    import hashlib
+
+    from dau_build.packaging import load_artifact_manifest
+
+    manifest = load_artifact_manifest(manifest_path)
+    if manifest.metadata.get("build_status") != "built":
+        raise BuildStepError(f"shell-build manifest is not built: {manifest_path.as_posix()}")
+    bitstreams = [artifact for artifact in manifest.artifacts if artifact.role == "bitstream"]
+    if len(bitstreams) != 1:
+        raise BuildStepError(f"shell-build manifest must carry exactly one bitstream artifact: {manifest_path.as_posix()}")
+    bitstream = bitstreams[0]
+    if bitstream.path is None:
+        raise BuildStepError(f"bitstream artifact has no path: {manifest_path.as_posix()}")
+    bitstream_path = bitstream.path if bitstream.path.is_absolute() else manifest_path.parent / bitstream.path
+    if not bitstream_path.is_file():
+        raise BuildStepError(f"bitstream does not exist: {bitstream_path.as_posix()}")
+    if bitstream.digest is not None:
+        actual = hashlib.new(bitstream.digest.algorithm, bitstream_path.read_bytes()).hexdigest()
+        if actual != bitstream.digest.value:
+            raise BuildStepError(
+                f"bitstream digest mismatch (manifest {bitstream.digest.value[:12]}..., file {actual[:12]}...): {bitstream_path.as_posix()}"
+            )
+    return bitstream_path
+
+
 class FlashTask(BuildCallableModel):
     tool: str = "openFPGAloader"
     bitstream: Path | None = None
@@ -400,9 +430,12 @@ class FlashTask(BuildCallableModel):
         bitstream = self.bitstream
         manifest_segment = ""
         if self.manifest_path is not None:
-            manifest = _read_key_value_manifest(self.manifest_path)
-            _require_built_manifest(self.manifest_path, manifest)
-            bitstream = bitstream or _manifest_path(self.manifest_path.parent, manifest, "bitstream")
+            if self.manifest_path.suffix in (".yaml", ".yml"):
+                bitstream = bitstream or _bitstream_from_shell_build_manifest(self.manifest_path)
+            else:
+                manifest = _read_key_value_manifest(self.manifest_path)
+                _require_built_manifest(self.manifest_path, manifest)
+                bitstream = bitstream or _manifest_path(self.manifest_path.parent, manifest, "bitstream")
             manifest_segment = f" manifest={self.manifest_path}"
         if bitstream is None:
             raise BuildStepError("flash requires bitstream or manifest_path")
@@ -435,6 +468,49 @@ class SmokeTestTask(BuildCallableModel):
         return BuildStepResult(
             step="smoke-test",
             message=f"dau-build-smoke-test\ttask=smoke-test test={self.test}{device_segment}{manifest_segment} status=planned",
+        )
+
+
+class BuildShellProjectTask(BuildCallableModel):
+    """Run a generated shell project script through Vivado and package the
+    outputs as an artlink shell-build manifest (bitstream digest, reports,
+    log, generated inputs, contributing sources with repository state).
+    Plan-only unless ``execute=true``."""
+
+    output_root: Path
+    script: str = "build_mm_job.tcl"
+    vivado: str = "vivado"
+    manifest_name: str = "dau-shell"
+    source_paths: tuple[Path, ...] = ()
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    execute: bool = False
+
+    @Flow.call
+    def __call__(self, context: NullContext) -> BuildStepResult:
+        from dau_build.shell_build import run_shell_project_build, write_shell_build_manifest
+
+        script_path = self.output_root / self.script
+        if not script_path.is_file():
+            raise BuildStepError(f"shell project script does not exist: {script_path.as_posix()}")
+        command = shlex.join([self.vivado, "-mode", "batch", "-source", self.script])
+        if not self.execute:
+            return BuildStepResult(
+                step="build-shell-project",
+                message=f"dau-build-shell\ttask=build-shell-project output_root={self.output_root} command={command!r} status=planned",
+            )
+        status = run_shell_project_build(self.output_root, script=self.script, vivado_executable=self.vivado)
+        manifest_path = write_shell_build_manifest(
+            self.output_root,
+            name=self.manifest_name,
+            source_paths=self.source_paths,
+            metadata={**self.metadata, **status},
+        )
+        return BuildStepResult(
+            step="build-shell-project",
+            message=(
+                f"dau-build-shell\ttask=build-shell-project output_root={self.output_root}"
+                f" wns={status.get('wns_ns')} manifest={manifest_path} status=built"
+            ),
         )
 
 

--- a/dau_build/config/task/build-shell-project.yaml
+++ b/dau_build/config/task/build-shell-project.yaml
@@ -1,0 +1,10 @@
+# @package model
+
+_target_: dau_build.build_steps.BuildShellProjectTask
+output_root: ???
+script: build_mm_job.tcl
+vivado: vivado
+manifest_name: dau-shell
+source_paths: []
+metadata: {}
+execute: false

--- a/dau_build/shell_build.py
+++ b/dau_build/shell_build.py
@@ -1,0 +1,179 @@
+"""Shell project build execution and artifact packaging.
+
+Runs a generated shell project script (the output of a shell artifact
+writer such as ``dpv1_shell.write_mm_job_shell_artifacts``) through Vivado
+and packages every build output — bitstream, reports, log, and the
+generated/contributing sources — as one artlink manifest with content
+digests and build metadata. The manifest is the provenance record: a
+flashed bitstream must be identifiable from it alone, never from a
+filename.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from artlink import Artifact, Digest
+
+from .packaging import ArtifactManifest
+
+__all__ = (
+    "SHELL_BUILD_MANIFEST_NAME",
+    "ShellBuildError",
+    "run_shell_project_build",
+    "parse_shell_build_console",
+    "shell_build_manifest",
+    "write_shell_build_manifest",
+)
+
+SHELL_BUILD_MANIFEST_NAME = "shell-build.artifacts.yaml"
+_BUILD_OK_PATTERN = re.compile(r"^DAU_MM_JOB_BUILD_OK wns=(?P<wns>[-0-9.]+)\s*$", re.MULTILINE)
+_BUILD_FAILED_PATTERN = re.compile(r"^DAU_MM_JOB_BUILD_FAILED (?P<stage>.+?)\s*$", re.MULTILINE)
+
+
+class ShellBuildError(ValueError):
+    pass
+
+
+def run_shell_project_build(
+    output_root: Path,
+    *,
+    script: str = "build_mm_job.tcl",
+    vivado_executable: str = "vivado",
+    console_log: str = "console.log",
+) -> dict[str, Any]:
+    """Execute the generated project script in batch mode from inside the
+    output root (the scripts resolve their artifacts relative to
+    themselves) and return the parsed build status."""
+    script_path = output_root / script
+    if not script_path.is_file():
+        raise ShellBuildError(f"shell project script does not exist: {script_path.as_posix()}")
+    log_path = output_root / console_log
+    with log_path.open("w", encoding="utf-8") as log:
+        completed = subprocess.run(
+            [vivado_executable, "-mode", "batch", "-source", script],
+            cwd=output_root,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    status = parse_shell_build_console(log_path.read_text(encoding="utf-8"))
+    status["return_code"] = completed.returncode
+    if completed.returncode != 0 or status["build_status"] != "built":
+        raise ShellBuildError(
+            f"shell build failed (exit {completed.returncode}, status {status['build_status']}"
+            + (f", stage {status['failed_stage']}" if status.get("failed_stage") else "")
+            + f"): see {log_path.as_posix()}"
+        )
+    return status
+
+
+def parse_shell_build_console(console_text: str) -> dict[str, Any]:
+    """Extract the build outcome the generated scripts print: the
+    DAU_MM_JOB_BUILD_OK/FAILED marker and the routed worst negative slack."""
+    ok = _BUILD_OK_PATTERN.search(console_text)
+    if ok:
+        return {"build_status": "built", "wns_ns": float(ok.group("wns"))}
+    failed = _BUILD_FAILED_PATTERN.search(console_text)
+    if failed:
+        return {"build_status": "failed", "failed_stage": failed.group("stage")}
+    return {"build_status": "unknown"}
+
+
+def _digest(path: Path) -> Digest:
+    return Digest(algorithm="sha256", value=hashlib.sha256(path.read_bytes()).hexdigest())
+
+
+def _git_describe(path: Path) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(path), "describe", "--always", "--dirty", "--tags"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    return completed.stdout.strip() or None
+
+
+def shell_build_manifest(
+    output_root: Path,
+    *,
+    name: str,
+    bitstream: str = "dau_mm_job.bit",
+    reports: tuple[str, ...] = ("utilization_mm.rpt", "timing_mm.rpt"),
+    console_log: str = "console.log",
+    source_paths: tuple[Path, ...] = (),
+    metadata: dict[str, Any] | None = None,
+) -> ArtifactManifest:
+    """Package a completed shell build: the bitstream (digested), reports,
+    console log, the generated project inputs found in the output root, and
+    the contributing HDL sources (digested, with the git state of each
+    containing repository recorded in the manifest metadata)."""
+    bitstream_path = output_root / bitstream
+    if not bitstream_path.is_file():
+        raise ShellBuildError(f"bitstream does not exist: {bitstream_path.as_posix()}")
+
+    artifacts: list[Artifact] = [
+        Artifact(path=bitstream_path, kind="binary", role="bitstream", digest=_digest(bitstream_path)),
+    ]
+    for report in reports:
+        report_path = output_root / report
+        if report_path.is_file():
+            artifacts.append(Artifact(path=report_path, kind="metadata", role="report"))
+    log_path = output_root / console_log
+    if log_path.is_file():
+        artifacts.append(Artifact(path=log_path, kind="metadata", role="build-log"))
+    for generated in sorted(output_root.iterdir()):
+        if generated.suffix in (".tcl", ".xdc", ".prj", ".v", ".sv") and generated.is_file():
+            artifacts.append(
+                Artifact(
+                    path=generated,
+                    kind="source",
+                    role="generated-project-input",
+                    digest=_digest(generated),
+                )
+            )
+
+    source_repos: dict[str, str] = {}
+    for source in source_paths:
+        source_path = Path(source)
+        if not source_path.is_file():
+            raise ShellBuildError(f"contributing source does not exist: {source_path.as_posix()}")
+        artifacts.append(Artifact(path=source_path, kind="source", role="hdl-source", digest=_digest(source_path)))
+        describe = _git_describe(source_path.parent)
+        if describe:
+            source_repos.setdefault(source_path.parent.as_posix(), describe)
+
+    manifest_metadata: dict[str, Any] = {"source_repositories": source_repos}
+    if metadata:
+        manifest_metadata.update(metadata)
+    return ArtifactManifest(name=name, intent="output", artifacts=tuple(artifacts), metadata=manifest_metadata)
+
+
+def write_shell_build_manifest(
+    output_root: Path,
+    *,
+    name: str,
+    source_paths: tuple[Path, ...] = (),
+    metadata: dict[str, Any] | None = None,
+    bitstream: str = "dau_mm_job.bit",
+) -> Path:
+    """Build and write the shell-build manifest into the output root."""
+    import yaml
+
+    manifest = shell_build_manifest(
+        output_root,
+        name=name,
+        bitstream=bitstream,
+        source_paths=source_paths,
+        metadata=metadata,
+    )
+    manifest_path = output_root / SHELL_BUILD_MANIFEST_NAME
+    manifest_path.write_text(yaml.safe_dump(manifest.model_dump(mode="json", exclude_defaults=True), sort_keys=False), encoding="utf-8")
+    return manifest_path

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -24,6 +24,7 @@ _SV_DIR = (Path(__file__).parent / ".." / "sv").resolve()
 def test_build_step_and_task_dispatch_uses_ccflow_callable_models() -> None:
     assert available_step_names() == ("explain", "generate", "inspect", "resolved-config", "simulate", "synthesis", "validate", "write")
     assert available_task_names() == (
+        "build-shell-project",
         "build-vivado-artifacts",
         "flash",
         "hardware-plan",

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -117,6 +117,7 @@ def _target(model_type: type) -> str:
 
 def _task_overrides(name: str, tmp_path: Path) -> tuple[str, ...]:
     base = {
+        "build-shell-project": (f"model.output_root={tmp_path / 'shell'}",),
         "build-vivado-artifacts": (f"model.work_root={tmp_path / 'work'}",),
         "flash": (),
         "hardware-plan": ("model.plan=thunderbolt-release", f"model.work_root={tmp_path / 'work'}"),

--- a/dau_build/tests/test_shell_build.py
+++ b/dau_build/tests/test_shell_build.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from dau_build.build_steps import BuildShellProjectTask, BuildStepError, FlashTask
+from dau_build.packaging import load_artifact_manifest
+from dau_build.shell_build import (
+    SHELL_BUILD_MANIFEST_NAME,
+    ShellBuildError,
+    parse_shell_build_console,
+    run_shell_project_build,
+    shell_build_manifest,
+    write_shell_build_manifest,
+)
+
+
+def _fake_shell_output(tmp_path: Path) -> Path:
+    output_root = tmp_path / "shell"
+    output_root.mkdir()
+    (output_root / "dau_mm_job.bit").write_bytes(b"\x00\x01bitstream")
+    (output_root / "utilization_mm.rpt").write_text("| Slice LUTs | 30805 |\n")
+    (output_root / "timing_mm.rpt").write_text("WNS 0.459\n")
+    (output_root / "console.log").write_text("DAU_MM_JOB_BUILD_OK wns=0.459\n")
+    (output_root / "build_mm_job.tcl").write_text("# generated\n")
+    (output_root / "constraints.xdc").write_text("# pins\n")
+    return output_root
+
+
+def _fake_vivado(tmp_path: Path) -> Path:
+    vivado = tmp_path / "fake-vivado"
+    vivado.write_text("#!/bin/sh\necho 'DAU_MM_JOB_BUILD_OK wns=0.123'\ntouch dau_mm_job.bit\n")
+    vivado.chmod(vivado.stat().st_mode | stat.S_IXUSR)
+    return vivado
+
+
+def test_parse_console_markers() -> None:
+    assert parse_shell_build_console("noise\nDAU_MM_JOB_BUILD_OK wns=0.321\n") == {"build_status": "built", "wns_ns": 0.321}
+    assert parse_shell_build_console("DAU_MM_JOB_BUILD_FAILED synthesis\n") == {"build_status": "failed", "failed_stage": "synthesis"}
+    assert parse_shell_build_console("vivado died\n") == {"build_status": "unknown"}
+
+
+def test_manifest_packages_outputs_with_digests(tmp_path: Path) -> None:
+    output_root = _fake_shell_output(tmp_path)
+    source = tmp_path / "tile.sv"
+    source.write_text("module tile; endmodule\n")
+
+    manifest = shell_build_manifest(output_root, name="dpv1-bar-noc", source_paths=(source,), metadata={"wns_ns": 0.459, "build_status": "built"})
+
+    roles = sorted(artifact.role for artifact in manifest.artifacts)
+    assert roles.count("bitstream") == 1
+    assert "report" in roles and "build-log" in roles and "generated-project-input" in roles and "hdl-source" in roles
+    bitstream = next(artifact for artifact in manifest.artifacts if artifact.role == "bitstream")
+    assert bitstream.digest is not None
+    assert bitstream.digest.value == hashlib.sha256((output_root / "dau_mm_job.bit").read_bytes()).hexdigest()
+    assert manifest.metadata["wns_ns"] == 0.459
+    # contributing sources are digested too — the provenance record
+    hdl = next(artifact for artifact in manifest.artifacts if artifact.role == "hdl-source")
+    assert hdl.digest is not None
+
+
+def test_manifest_requires_bitstream(tmp_path: Path) -> None:
+    output_root = tmp_path / "empty"
+    output_root.mkdir()
+    with pytest.raises(ShellBuildError):
+        shell_build_manifest(output_root, name="x")
+
+
+def test_run_build_with_stub_vivado(tmp_path: Path) -> None:
+    output_root = tmp_path / "shell"
+    output_root.mkdir()
+    (output_root / "build_mm_job.tcl").write_text("# generated\n")
+    status = run_shell_project_build(output_root, vivado_executable=str(_fake_vivado(tmp_path)))
+    assert status["build_status"] == "built"
+    assert status["wns_ns"] == 0.123
+    assert (output_root / "dau_mm_job.bit").is_file()
+
+
+def test_run_build_raises_on_failure_marker(tmp_path: Path) -> None:
+    output_root = tmp_path / "shell"
+    output_root.mkdir()
+    (output_root / "build_mm_job.tcl").write_text("# generated\n")
+    vivado = tmp_path / "fail-vivado"
+    vivado.write_text("#!/bin/sh\necho 'DAU_MM_JOB_BUILD_FAILED implementation'\nexit 1\n")
+    vivado.chmod(vivado.stat().st_mode | stat.S_IXUSR)
+    with pytest.raises(ShellBuildError, match="implementation"):
+        run_shell_project_build(output_root, vivado_executable=str(vivado))
+
+
+def test_task_plan_mode_does_not_execute(tmp_path: Path) -> None:
+    output_root = tmp_path / "shell"
+    output_root.mkdir()
+    (output_root / "build_mm_job.tcl").write_text("# generated\n")
+    result = BuildShellProjectTask(output_root=output_root, vivado="definitely-not-vivado")(None)
+    assert "status=planned" in result.message
+    assert not (output_root / "dau_mm_job.bit").exists()
+
+
+def test_task_execute_builds_and_writes_manifest(tmp_path: Path) -> None:
+    output_root = tmp_path / "shell"
+    output_root.mkdir()
+    (output_root / "build_mm_job.tcl").write_text("# generated\n")
+    result = BuildShellProjectTask(
+        output_root=output_root,
+        vivado=str(_fake_vivado(tmp_path)),
+        manifest_name="dpv1-test",
+        metadata={"shell": "bar-noc"},
+        execute=True,
+    )(None)
+    assert "status=built" in result.message
+    manifest = load_artifact_manifest(output_root / SHELL_BUILD_MANIFEST_NAME)
+    assert manifest.metadata["build_status"] == "built"
+    assert manifest.metadata["shell"] == "bar-noc"
+    assert manifest.metadata["wns_ns"] == 0.123
+
+
+def test_flash_task_resolves_and_verifies_shell_build_manifest(tmp_path: Path) -> None:
+    output_root = _fake_shell_output(tmp_path)
+    manifest_path = write_shell_build_manifest(output_root, name="dpv1-test", metadata={"build_status": "built"})
+
+    result = FlashTask(manifest_path=manifest_path)(None)
+    assert "dau_mm_job.bit" in result.message
+
+    # a tampered bitstream must be refused
+    (output_root / "dau_mm_job.bit").write_bytes(b"tampered")
+    with pytest.raises(BuildStepError, match="digest mismatch"):
+        FlashTask(manifest_path=manifest_path)(None)
+
+
+def test_flash_task_rejects_unbuilt_manifest(tmp_path: Path) -> None:
+    output_root = _fake_shell_output(tmp_path)
+    manifest_path = write_shell_build_manifest(output_root, name="dpv1-test", metadata={"build_status": "failed"})
+    with pytest.raises(BuildStepError, match="not built"):
+        FlashTask(manifest_path=manifest_path)(None)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="stub executables require posix")
+def test_task_reachable_from_config_tree() -> None:
+    from dau_build.build_steps import available_task_names
+
+    assert "build-shell-project" in available_task_names()


### PR DESCRIPTION
Review findings F40+F43: the shell build flow becomes a first-class ccflow task (config-tree registered) whose outputs are artlink artifacts with content digests and repository state, and flash-by-manifest verifies the bitstream digest before programming. 10 new tests including a stub-vivado end-to-end and tamper detection.