### PR TITLE
Resolve and run cocotb profiles through the simulate task

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -315,7 +315,7 @@ class SimulateTask(ModuleSelectionModel):
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        if self.simulator == "verilator" and self.profile and self.spec_path is None:
+        if self.simulator in ("verilator", "cocotb") and self.profile and self.spec_path is None:
             return self._run_registered_profile()
         if self.spec_path is None or not self.module:
             raise BuildStepError("task=simulate requires spec_path and module (or simulator=verilator profile=<name> for a registered profile)")
@@ -352,6 +352,7 @@ class SimulateTask(ModuleSelectionModel):
         return BuildStepResult(step="simulate", message=f"{result.message} task=simulate simulator=verilator module={self.module}")
 
     def _run_registered_profile(self) -> BuildStepResult:
+        from dau_sim.integrations.cocotb import CocotbProfile, run_cocotb_testbench
         from dau_sim.integrations.verilator import run_verilator_testbench
 
         from dau_build.simulation_profiles import resolve_profile
@@ -360,6 +361,18 @@ class SimulateTask(ModuleSelectionModel):
         work_root = self.output_root or Path.cwd() / ".dau-build-sim"
         work_dir = work_root / profile.name
         work_dir.mkdir(parents=True, exist_ok=True)
+        if isinstance(profile, CocotbProfile):
+            # the cocotb runner raises on any failing test
+            run_cocotb_testbench(
+                sources=profile.sources,
+                hdl_toplevel=profile.hdl_toplevel,
+                test_module=profile.test_module,
+                build_dir=work_dir,
+            )
+            return BuildStepResult(
+                step="simulate",
+                message=f"dau-build-simulate	task=simulate simulator=cocotb profile={profile.name} status=passed",
+            )
         result = run_verilator_testbench(sources=profile.sources, top_module=profile.top_module, work_dir=work_dir)
         marker = self.expect_stdout or profile.expect_stdout
         if marker not in result.stdout:

--- a/dau_build/simulation_profiles.py
+++ b/dau_build/simulation_profiles.py
@@ -107,17 +107,27 @@ def _verilator_profile_from_mapping(
     *,
     artifacts_by_id: Mapping[str, Artifact],
     root: Path,
-) -> VerilatorProfile:
+):
     name = _required_str(profile, "name")
     simulator = _required_str(profile, "simulator")
-    if simulator != "verilator":
-        raise SimulationProfileError(f"profile {name!r} uses unsupported simulator {simulator!r}; expected verilator")
-    return VerilatorProfile(
-        name=name,
-        sources=_profile_sources(profile.get("sources", ()), artifacts_by_id=artifacts_by_id, root=root),
-        top_module=_required_str(profile, "top_module"),
-        expect_stdout=_required_str(profile, "expect_stdout"),
-    )
+    sources = _profile_sources(profile.get("sources", ()), artifacts_by_id=artifacts_by_id, root=root)
+    if simulator == "verilator":
+        return VerilatorProfile(
+            name=name,
+            sources=sources,
+            top_module=_required_str(profile, "top_module"),
+            expect_stdout=_required_str(profile, "expect_stdout"),
+        )
+    if simulator == "cocotb":
+        from dau_sim.integrations.cocotb import CocotbProfile
+
+        return CocotbProfile(
+            name=name,
+            sources=sources,
+            hdl_toplevel=_required_str(profile, "top_module"),
+            test_module=_required_str(profile, "test_module"),
+        )
+    raise SimulationProfileError(f"profile {name!r} uses unsupported simulator {simulator!r}; expected verilator or cocotb")
 
 
 def _profile_sources(value: Any, *, artifacts_by_id: Mapping[str, Artifact], root: Path) -> tuple[Path, ...]:

--- a/dau_build/tests/test_simulation_profiles.py
+++ b/dau_build/tests/test_simulation_profiles.py
@@ -75,3 +75,53 @@ def test_custom_verilator_profile_loads_sources_from_artlink_manifest(tmp_path: 
 def test_unknown_profile_error_lists_available_profiles() -> None:
     with pytest.raises(SimulationProfileError, match="expected one of: $"):
         resolve_verilator_profile("missing-profile")
+
+
+def test_cocotb_profile_parses_and_runs_through_simulate_task(tmp_path) -> None:
+    """A simulator: cocotb profile resolves through the same manifest chain
+    and task=simulate runs it via dau-sim's canonical cocotb launcher."""
+    from shutil import which
+
+    import pytest as _pytest
+    from dau_sim.integrations.cocotb import CocotbProfile
+
+    from dau_build.build_steps import SimulateTask
+    from dau_build.simulation_profiles import resolve_profile
+
+    profiles_yaml = tmp_path / "profiles.yaml"
+    profiles_yaml.write_text(
+        "schema: dau.simulation-profile/v0\n"
+        "profiles:\n"
+        "  - name: ready-valid-sum-cocotb\n"
+        "    simulator: cocotb\n"
+        "    top_module: ready_valid_sum\n"
+        "    test_module: dau_sim.tests.cocotb_benches.ready_valid_sum_tb\n"
+        "    sources:\n"
+        "      - uri: package://dau_sim/tests/sv/ready_valid_sum.sv\n"
+    )
+    manifest_yaml = tmp_path / "profiles.artifacts.yaml"
+    manifest_yaml.write_text(
+        "schema: artlink.manifest/v0\n"
+        "name: test-cocotb-profiles\n"
+        "intent: simulation-profiles\n"
+        "artifacts:\n"
+        "  - id: profiles\n"
+        f"    path: {profiles_yaml.name}\n"
+        "    kind: metadata\n"
+        "    role: simulation-profile\n"
+        "    format: dau.simulation-profile/v0\n"
+    )
+
+    profile = resolve_profile("ready-valid-sum-cocotb", profile_manifests=(manifest_yaml,))
+    assert isinstance(profile, CocotbProfile)
+    assert profile.hdl_toplevel == "ready_valid_sum"
+
+    if which("verilator") is None:
+        _pytest.skip("verilator not found")
+    result = SimulateTask(
+        simulator="cocotb",
+        profile="ready-valid-sum-cocotb",
+        profile_manifest=(manifest_yaml,),
+        output_root=tmp_path / "work",
+    )(None)
+    assert "simulator=cocotb" in result.message and "status=passed" in result.message


### PR DESCRIPTION
Completes the F47 follow-up: profile manifests accept simulator: cocotb entries (same manifest chain, same resolver), and task=simulate executes them through dau_sim.integrations.cocotb.run_cocotb_testbench. End-to-end test uses dau-sim's generic ready-valid-sum bench. Depends on dau-sim#36 (CocotbProfile).