### PR TITLE
Install dau-sim from git until the next release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,9 @@ jobs:
       with:
         version: ${{ matrix.python-version }}
 
+    - name: Install pnpm (dau-sim builds from git until its next release)
+      run: npm install -g pnpm
+
     - name: Install dependencies
       run: make develop
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,3 +155,6 @@ section-order = [
     "F401",
     "F403",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "amaranth",
     "artlink",
     "ccflow>=0.8.5",
-    "dau-sim>=0.1.0",
+    "dau-sim @ git+https://github.com/dau-dev/dau-sim.git",  # PyPI release predates CocotbProfile/run_cocotb_testbench; repin on next release
     "dau-utils",
     "hydra-core",
     "pydantic",


### PR DESCRIPTION
Same class as dau#15: the PyPI dau-sim predates run_cocotb_testbench/CocotbProfile, so CI fails against the stale release. Repin to PyPI when dau-sim cuts a release.