### PR TITLE
Package built overlay runs as artlink manifests on validation

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -760,7 +760,12 @@ class ValidateVivadoArtifactsTask(OverlayArtifactValidationTask):
         )
         if not validation.ok:
             raise BuildStepError(_vivado_artifact_validation_message(validation))
-        return BuildStepResult(step="validate-vivado-artifacts", message=_vivado_artifact_validation_message(validation))
+        from dau_build.shell_build import write_overlay_build_manifest
+
+        resolved_manifest = manifest_path if manifest_path.is_absolute() else self.work_root / manifest_path
+        packaged = write_overlay_build_manifest(self.work_root, resolved_manifest, name=self.artifact_stem) if resolved_manifest.is_file() else None
+        packaged_segment = f" artlink={packaged}" if packaged else ""
+        return BuildStepResult(step="validate-vivado-artifacts", message=_vivado_artifact_validation_message(validation) + packaged_segment)
 
     def _toolchain_config(self) -> HardwareToolchainConfig:
         return HardwareToolchainConfig(

--- a/dau_build/shell_build.py
+++ b/dau_build/shell_build.py
@@ -177,3 +177,53 @@ def write_shell_build_manifest(
     manifest_path = output_root / SHELL_BUILD_MANIFEST_NAME
     manifest_path.write_text(yaml.safe_dump(manifest.model_dump(mode="json", exclude_defaults=True), sort_keys=False), encoding="utf-8")
     return manifest_path
+
+
+def write_overlay_build_manifest(work_root: Path, key_value_manifest_path: Path, *, name: str) -> Path | None:
+    """Package a *built* overlay backend run as an artlink manifest beside
+    its key=value handoff (the Tcl-side format stays as the in-band
+    mechanism; provenance converges on artlink). Returns None when the
+    key=value manifest is still ``planned`` — there is nothing to package
+    yet."""
+    from dau_build.vivado_backend import _parse_manifest_text
+
+    items, errors = _parse_manifest_text(key_value_manifest_path.read_text(encoding="utf-8"))
+    if errors:
+        raise ShellBuildError(f"invalid key=value manifest {key_value_manifest_path.as_posix()}: {'; '.join(errors)}")
+    manifest = dict(items)
+    if manifest.get("build_status") != "built":
+        return None
+
+    def resolve(key: str) -> Path | None:
+        value = manifest.get(key)
+        if not value:
+            return None
+        path = Path(value)
+        return path if path.is_absolute() else work_root / path
+
+    bitstream_path = resolve("bitstream")
+    if bitstream_path is None or not bitstream_path.is_file():
+        raise ShellBuildError(f"built manifest names no existing bitstream: {key_value_manifest_path.as_posix()}")
+
+    artifacts: list[Artifact] = [Artifact(path=bitstream_path, kind="binary", role="bitstream", digest=_digest(bitstream_path))]
+    for key, role in (
+        ("resource_summary", "report"),
+        ("timing_summary", "report"),
+        ("vivado_log", "build-log"),
+        ("overlay", "generated-project-input"),
+    ):
+        path = resolve(key)
+        if path is not None and path.is_file():
+            artifacts.append(Artifact(path=path, kind="metadata" if role != "generated-project-input" else "source", role=role))
+
+    packaged = ArtifactManifest(
+        name=name,
+        intent="output",
+        artifacts=tuple(artifacts),
+        metadata={"build_status": "built", **{k: v for k, v in manifest.items() if k not in ("build_status",)}},
+    )
+    import yaml
+
+    manifest_path = key_value_manifest_path.with_suffix(".artifacts.yaml")
+    manifest_path.write_text(yaml.safe_dump(packaged.model_dump(mode="json", exclude_defaults=True), sort_keys=False), encoding="utf-8")
+    return manifest_path

--- a/dau_build/tests/test_shell_build.py
+++ b/dau_build/tests/test_shell_build.py
@@ -143,3 +143,26 @@ def test_task_reachable_from_config_tree() -> None:
     from dau_build.build_steps import available_task_names
 
     assert "build-shell-project" in available_task_names()
+
+
+def test_overlay_build_manifest_packages_built_runs_only(tmp_path: Path) -> None:
+    from dau_build.shell_build import write_overlay_build_manifest
+
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "overlay.bit").write_bytes(b"\x01\x02")
+    (work / "util.rpt").write_text("luts\n")
+    (work / "vivado.log").write_text("done\n")
+    kv = work / "dau-vivado.manifest"
+
+    kv.write_text("build_status=planned\nbitstream=overlay.bit\n")
+    assert write_overlay_build_manifest(work, kv, name="dau-vivado") is None
+
+    kv.write_text("build_status=built\nbitstream=overlay.bit\nresource_summary=util.rpt\nvivado_log=vivado.log\n")
+    packaged = write_overlay_build_manifest(work, kv, name="dau-vivado")
+    manifest = load_artifact_manifest(packaged)
+    assert manifest.metadata["build_status"] == "built"
+    roles = [artifact.role for artifact in manifest.artifacts]
+    assert roles.count("bitstream") == 1 and "report" in roles and "build-log" in roles
+    bitstream = next(a for a in manifest.artifacts if a.role == "bitstream")
+    assert bitstream.digest is not None


### PR DESCRIPTION
Review finding F41 completion: both Vivado paths now converge on artlink provenance. The overlay backend's key=value manifest remains the Tcl-side handoff; validation of a built run packages it (digested bitstream + reports + log) into the same artlink shape the shell-build task emits, so FlashTask digest-verification works for overlay builds too.