### PR TITLE
Drop pnpm CI step now that dau-sim releases from PyPI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,9 +39,6 @@ jobs:
       with:
         version: ${{ matrix.python-version }}
 
-    - name: Install pnpm (dau-sim builds from git until its next release)
-      run: npm install -g pnpm
-
     - name: Install dependencies
       run: make develop
 

--- a/dau_build/__init__.py
+++ b/dau_build/__init__.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 _SVPARSER_EXPORTS = frozenset(
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "Build tools for dau"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.10"
 keywords = []
 
@@ -33,7 +33,7 @@ dependencies = [
     "amaranth",
     "artlink",
     "ccflow>=0.8.5",
-    "dau-sim @ git+https://github.com/dau-dev/dau-sim.git",  # PyPI release predates CocotbProfile/run_cocotb_testbench; repin on next release
+    "dau-sim>=0.2.0",
     "dau-utils",
     "hydra-core",
     "pydantic",
@@ -74,7 +74,7 @@ Repository = "https://github.com/dau-dev/dau-build"
 Homepage = "https://github.com/dau-dev/dau-build"
 
 [tool.bumpversion]
-current_version = "0.1.0"
+current_version = "0.2.0"
 commit = true
 tag = true
 commit_args = "-s"
@@ -156,5 +156,3 @@ section-order = [
     "F403",
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true


### PR DESCRIPTION
dau-sim 0.2.0 is on PyPI as a wheel; dau-build resolves it (and dau-utils 0.1.0) as wheels with no source build, so the interim pnpm install step is no longer needed. Config-only.