### PR TITLE
Resolve dpv1 platform through a hydra config group, reconciled with build constants

### DIFF
--- a/dau_build/config/__init__.py
+++ b/dau_build/config/__init__.py
@@ -8,7 +8,20 @@ from ccflow import ModelRegistry
 from ccflow.utils.hydra import ConfigLoadResult, cfg_run, load_config as base_load_config
 from omegaconf import OmegaConf
 
-__all__ = ("compose_config", "load_config", "request_config", "run_request_config")
+__all__ = ("compose_config", "load_config", "request_config", "resolve_platform", "run_request_config")
+
+
+def resolve_platform(name: str, *, config_dir: str | None = None, version_base: str | None = None):
+    """Resolve a platform from the ``platform`` hydra config group to a
+    ``dau_build.platforms.PlatformDefinition`` (user ``--config-dir``
+    overlays may add boards). ``resolve_platform("dpv1")`` returns the
+    reconciled dpv1 platform."""
+    from hydra.utils import instantiate
+
+    result = _load_base_config((f"platform={name}",), config_dir=config_dir, version_base=version_base)
+    if "platform" not in result.cfg or result.cfg.platform is None:
+        raise KeyError(f"unknown platform {name!r}")
+    return instantiate(result.cfg.platform)
 
 
 def load_config(

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -4,6 +4,7 @@ defaults:
   - _self_
   - optional task: null
   - optional step: null
+  - optional platform: null
   - callable: callable
 
 context: {}

--- a/dau_build/config/platform/dpv1.yaml
+++ b/dau_build/config/platform/dpv1.yaml
@@ -1,0 +1,5 @@
+# @package platform
+
+# dpv1 (NiteFury XC7A200T) — points at the drift-free factory so the part
+# and 47-parameter XDMA personality stay sourced from dau_build.dpv1_shell.
+_target_: dau_build.platforms.dpv1_platform

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -12,10 +12,9 @@ The resource input to ``fits()`` is duck-typed (any object exposing
 so this public module never imports the private core, respecting the
 public/private wall.
 
-This is the schema (roadmap P0.1). Reconciling dpv1's authoritative values
-(the full XDMA personality map, constraint files) and resolving them
-through a hydra config group is P0.2 — ``dpv1_platform()`` here is a
-representative instance for the schema, not yet the build's source of truth.
+``dpv1_platform()`` is reconciled with the authoritative build constants
+(``DPV1_PART``, ``DPV1_XDMA_PERSONALITY``) and is resolvable through the
+``platform`` hydra config group (``resolve_platform("dpv1")``).
 """
 
 from __future__ import annotations
@@ -158,19 +157,39 @@ def fits(used: ResourceUse, platform: PlatformDefinition) -> FitReport:
     return FitReport(fits=all(value >= 0 for value in headroom.values()), headroom=headroom, utilization=utilization)
 
 
-def dpv1_platform() -> PlatformDefinition:
-    """Representative dpv1 (NiteFury XC7A200T) platform — the P0.1 schema
-    example. The XDMA personality map and constraint files are populated in
-    P0.2 from ``dau_build.dpv1_shell.DPV1_XDMA_PERSONALITY``; until then this
-    is a schema demonstration, not the authoritative build source.
+def _pcie_lanes_from_personality(personality: Mapping[str, str]) -> int:
+    """Derive the PCIe link width (an int) from the XDMA personality's
+    ``pl_link_cap_max_link_width`` (``"X4"`` → ``4``) so the lane count has
+    the same single source as the rest of the endpoint configuration."""
+    width = personality.get("pl_link_cap_max_link_width", "")
+    if not width.upper().startswith("X") or not width[1:].isdigit():
+        raise PlatformError(f"cannot parse pcie lane width from personality: {width!r}")
+    return int(width[1:])
 
-    Budget: XC7A200T-2FBG484 (134,600 LUT / 269,200 FF / 365 BRAM36 / 740
-    DSP48E1). Memory: 1 GiB DDR3-800 (~1.6 GB/s). Link: XDMA PCIe Gen2 x4."""
+
+def dpv1_platform() -> PlatformDefinition:
+    """The dpv1 (NiteFury XC7A200T) platform, reconciled with the
+    authoritative build constants: ``part`` and the XDMA personality map
+    (and the PCIe lane count derived from it) come from
+    ``dau_build.dpv1_shell`` — the personality stays defined once, so the
+    47-parameter map cannot drift from what the shell builds with.
+
+    Budget is the XC7A200T-2FBG484 datasheet capacity (134,600 LUT /
+    269,200 FF / 365 BRAM36 / 740 DSP48E1); memory is the board's 1 GiB
+    DDR3-800 (~1.6 GB/s) fronted by the vendored ``dpv1_mig.prj``. Shell
+    constraints are generated per build (``dpv1_constraints_xdc``), not
+    static platform files, so ``constraints`` is empty here."""
+    from dau_build.dpv1_shell import DPV1_PART, DPV1_XDMA_PERSONALITY
+
     return PlatformDefinition(
         name="dpv1",
-        part="xc7a200tfbg484-2",
+        part=DPV1_PART,
         budget=ResourceBudget(lut=134600, ff=269200, bram36=365, dsp=740),
-        host_link=HostLink(interface="pcie-xdma", pcie_lanes=4),
+        host_link=HostLink(
+            interface="pcie-xdma",
+            pcie_lanes=_pcie_lanes_from_personality(DPV1_XDMA_PERSONALITY),
+            xdma_personality=dict(DPV1_XDMA_PERSONALITY),
+        ),
         memory=PlatformMemory(kind="ddr3", size_bytes=1 << 30, mig_prj="dpv1_mig.prj", bandwidth_bytes_per_s=1_600_000_000),
         program_method="jtag",
     )

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -90,6 +90,33 @@ def test_fits_exactly_at_budget_is_ok() -> None:
     assert all(value == pytest.approx(1.0) for value in report.utilization.values())
 
 
+def test_dpv1_platform_reconciles_with_authoritative_shell_constants() -> None:
+    from dau_build.dpv1_shell import DPV1_PART, DPV1_XDMA_PERSONALITY
+
+    platform = dpv1_platform()
+    # part and the 47-parameter personality are sourced from the shell, not
+    # duplicated — the P0.2 gate: resolved values equal the build constants
+    assert platform.part == DPV1_PART
+    assert platform.host_link.xdma_personality == dict(DPV1_XDMA_PERSONALITY)
+    assert len(platform.host_link.xdma_personality) == 47
+    # lane count derives from the personality's link-width, not a literal
+    assert platform.host_link.pcie_lanes == 4
+    assert platform.memory.mig_prj == "dpv1_mig.prj"
+
+
+def test_platform_group_resolves_dpv1_through_hydra() -> None:
+    from dau_build.config import resolve_platform
+
+    assert resolve_platform("dpv1") == dpv1_platform()
+
+
+def test_resolve_platform_rejects_unknown() -> None:
+    from dau_build.config import resolve_platform
+
+    with pytest.raises(KeyError, match="unknown platform"):
+        resolve_platform("no-such-board")
+
+
 def _dpv1_with(**overrides: object) -> PlatformDefinition:
     base = dict(
         name="dpv1",


### PR DESCRIPTION
Roadmap P0.2 — dpv1 as the first registered platform.

- **Reconciliation (the P0.2 gate):** `dpv1_platform()` now sources `part` and the 47-parameter XDMA personality from `dau_build.dpv1_shell` (`DPV1_PART`, `DPV1_XDMA_PERSONALITY`), and derives `pcie_lanes` from the personality's `pl_link_cap_max_link_width` ("X4" → 4). The personality stays defined once — no 47-param duplication, so it cannot drift from what the shell builds with. Constraints are generated per build (`dpv1_constraints_xdc`), so the platform constraint list is empty.
- **Hydra config group:** `config/platform/dpv1.yaml` (`# @package platform`) points at the drift-free factory; `base.yaml` gains `optional platform: null`; `config.resolve_platform(name)` composes the group entry and instantiates a `PlatformDefinition`. User `--config-dir` overlays can add boards (the open-registration pattern).
- **Wall-clean, non-disruptive:** no dau-core import; the added `optional platform` default leaves task/step/callable resolution unchanged (full suite 206 green).

Tests assert resolved values equal the build constants (part, full personality, lane count, MIG prj) and that `resolve_platform("dpv1") == dpv1_platform()`, plus unknown-platform rejection.

Follow-up P0.3 (open-registration proof by test) and P0.6 (`platform/dpv2.yaml`) build directly on this.