### PR TITLE
Move the XDMA personality into config/platform/dpv1.yaml as the single source

### DIFF
--- a/dau_build/config/platform/dpv1.yaml
+++ b/dau_build/config/platform/dpv1.yaml
@@ -1,5 +1,78 @@
 # @package platform
 
-# dpv1 (NiteFury XC7A200T) — points at the drift-free factory so the part
-# and 47-parameter XDMA personality stay sourced from dau_build.dpv1_shell.
-_target_: dau_build.platforms.dpv1_platform
+# dpv1 (NiteFury XC7A200T) as data. The XDMA personality below is the
+# authoritative source: byte-for-byte the proven bring-up core's value_src=user
+# XCI parameters (all 47 — a hand-picked subset is memory-dead on hardware).
+# Every value is quoted so it survives ccflow's coerce_numbers_to_str intact
+# (e.g. "000" must not become "0"). Order is preserved to match the generated
+# Vivado CONFIG.* block byte-for-byte.
+_target_: dau_build.platforms.PlatformDefinition
+name: dpv1
+part: xc7a200tfbg484-2
+program_method: jtag
+budget:
+  _target_: dau_build.platforms.ResourceBudget
+  lut: 134600
+  ff: 269200
+  bram36: 365
+  dsp: 740
+memory:
+  _target_: dau_build.platforms.PlatformMemory
+  kind: ddr3
+  size_bytes: 1073741824
+  mig_prj: dpv1_mig.prj
+  bandwidth_bytes_per_s: 1600000000
+host_link:
+  _target_: dau_build.platforms.HostLink
+  interface: pcie-xdma
+  pcie_lanes: 4
+  xdma_personality:
+    _target_: dau_build.platforms.XdmaPersonality
+    params:
+      mode_selection: "Advanced"
+      pl_link_cap_max_link_width: "X4"
+      pl_link_cap_max_link_speed: "5.0_GT/s"
+      axi_data_width: "128_bit"
+      axisten_freq: "125"
+      xdma_axi_intf_mm: "AXI_Memory_Mapped"
+      xdma_rnum_chnl: "1"
+      xdma_wnum_chnl: "1"
+      xdma_sts_ports: "false"
+      axilite_master_en: "true"
+      axilite_master_size: "128"
+      axilite_master_scale: "Kilobytes"
+      axil_master_64bit_en: "true"
+      axil_master_prefetchable: "true"
+      xdma_pcie_64bit_en: "true"
+      xdma_pcie_prefetchable: "true"
+      plltype: "QPLL1"
+      cfg_mgmt_if: "false"
+      copy_pf0: "true"
+      runbit_fix: "false"
+      en_ext_ch_gt_drp: "false"
+      en_pcie_drp: "false"
+      en_transceiver_status_ports: "false"
+      enable_gen4: "false"
+      vendor_id: "10EE"
+      pf0_device_id: "7011"
+      pf0_Use_Class_Code_Lookup_Assistant: "false"
+      pf0_base_class_menu: "Device_was_built_before_Class_Code_definitions_were_finalized"
+      pf0_sub_class_interface_menu: "All_currently_implemented_devices_except_VGA-compatible_devices"
+      pf0_class_code: "120000"
+      pf0_class_code_base: "12"
+      pf0_class_code_sub: "00"
+      pf0_class_code_interface: "00"
+      pf0_subsystem_vendor_id: "0"
+      pf0_subsystem_id: "0"
+      pf0_msix_cap_table_bir: "BAR_3:2"
+      pf0_msix_cap_pba_bir: "BAR_3:2"
+      pf1_msix_cap_table_size: "000"
+      pf1_msix_cap_table_offset: "00000000"
+      pf1_msix_cap_pba_offset: "00000000"
+      PF0_DEVICE_ID_mqdma: "9024"
+      PF2_DEVICE_ID_mqdma: "9024"
+      PF3_DEVICE_ID_mqdma: "9024"
+      PF0_SRIOV_VF_DEVICE_ID: "0000"
+      PF1_SRIOV_VF_DEVICE_ID: "A134"
+      PF2_SRIOV_VF_DEVICE_ID: "A234"
+      PF3_SRIOV_VF_DEVICE_ID: "A334"

--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -18,6 +18,7 @@ XDMA). Hardware rules baked in (see dau-docs GUIDELINES):
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 DPV1_PART = "xc7a200tfbg484-2"
@@ -25,61 +26,15 @@ DPV1_PART = "xc7a200tfbg484-2"
 # lane index -> GTPE2 channel site (reversed lane order on the DAU platform variant 1 (dpv1))
 GT_LANE_SWIZZLE = ((3, "GTPE2_CHANNEL_X0Y7"), (0, "GTPE2_CHANNEL_X0Y6"), (2, "GTPE2_CHANNEL_X0Y5"), (1, "GTPE2_CHANNEL_X0Y4"))
 
-# XDMA personality: byte-for-byte the proven shell's PCIe-facing configuration.
-DPV1_XDMA_PERSONALITY = {
-    # every value_src=user parameter from the proven bring-up core's XCI
-    # (xdma 4.1, extracted 2026-07-09), applied verbatim: fresh 2025.x
-    # customizations with only the "obvious" subset were memory-dead on
-    # hardware (BARs enumerate, all reads 0xFFFFFFFF), so the personality is
-    # the complete user-set customization, not a hand-picked one.
-    "mode_selection": "Advanced",
-    "pl_link_cap_max_link_width": "X4",
-    "pl_link_cap_max_link_speed": "5.0_GT/s",
-    "axi_data_width": "128_bit",
-    "axisten_freq": "125",
-    "xdma_axi_intf_mm": "AXI_Memory_Mapped",
-    "xdma_rnum_chnl": "1",
-    "xdma_wnum_chnl": "1",
-    "xdma_sts_ports": "false",
-    "axilite_master_en": "true",
-    "axilite_master_size": "128",
-    "axilite_master_scale": "Kilobytes",
-    "axil_master_64bit_en": "true",
-    "axil_master_prefetchable": "true",
-    "xdma_pcie_64bit_en": "true",
-    "xdma_pcie_prefetchable": "true",
-    "plltype": "QPLL1",
-    "cfg_mgmt_if": "false",
-    "copy_pf0": "true",
-    "runbit_fix": "false",
-    "en_ext_ch_gt_drp": "false",
-    "en_pcie_drp": "false",
-    "en_transceiver_status_ports": "false",
-    "enable_gen4": "false",
-    "vendor_id": "10EE",
-    "pf0_device_id": "7011",
-    "pf0_Use_Class_Code_Lookup_Assistant": "false",
-    "pf0_base_class_menu": "Device_was_built_before_Class_Code_definitions_were_finalized",
-    "pf0_sub_class_interface_menu": "All_currently_implemented_devices_except_VGA-compatible_devices",
-    "pf0_class_code": "120000",
-    "pf0_class_code_base": "12",
-    "pf0_class_code_sub": "00",
-    "pf0_class_code_interface": "00",
-    "pf0_subsystem_vendor_id": "0",
-    "pf0_subsystem_id": "0",
-    "pf0_msix_cap_table_bir": "BAR_3:2",
-    "pf0_msix_cap_pba_bir": "BAR_3:2",
-    "pf1_msix_cap_table_size": "000",
-    "pf1_msix_cap_table_offset": "00000000",
-    "pf1_msix_cap_pba_offset": "00000000",
-    "PF0_DEVICE_ID_mqdma": "9024",
-    "PF2_DEVICE_ID_mqdma": "9024",
-    "PF3_DEVICE_ID_mqdma": "9024",
-    "PF0_SRIOV_VF_DEVICE_ID": "0000",
-    "PF1_SRIOV_VF_DEVICE_ID": "A134",
-    "PF2_SRIOV_VF_DEVICE_ID": "A234",
-    "PF3_SRIOV_VF_DEVICE_ID": "A334",
-}
+# The XDMA personality (the 47 value_src=user XCI parameters, applied
+# verbatim — a hand-picked subset is memory-dead on hardware) lives in
+# config/platform/dpv1.yaml, the single source. Resolve it once per process.
+@lru_cache(maxsize=1)
+def dpv1_xdma_personality():
+    """The dpv1 XDMA personality, resolved from the platform config."""
+    from dau_build.config import resolve_platform
+
+    return resolve_platform("dpv1").host_link.xdma_personality
 
 
 @dataclass(frozen=True)
@@ -211,7 +166,7 @@ set_property CFGBVS VCCO [current_design]
 def _project_preamble_tcl(request, *, banner: str) -> str:
     """Shared create_project/add_files/constraints/XDMA-BD preamble: every
     dpv1 shell starts from the same proven PCIe front end."""
-    xdma_config = " \\\n".join(f"    CONFIG.{key} {{{value}}}" for key, value in DPV1_XDMA_PERSONALITY.items())
+    xdma_config = dpv1_xdma_personality().to_tcl_config()
     generated_paths = tuple(request.output_root / name for name, _ in request.generated_sources)
     sources = " \\\n".join(f'    "{path.as_posix()}"' for path in (*request.hdl_sources, *generated_paths))
     sv_typing = "\n".join(

--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -26,6 +26,7 @@ DPV1_PART = "xc7a200tfbg484-2"
 # lane index -> GTPE2 channel site (reversed lane order on the DAU platform variant 1 (dpv1))
 GT_LANE_SWIZZLE = ((3, "GTPE2_CHANNEL_X0Y7"), (0, "GTPE2_CHANNEL_X0Y6"), (2, "GTPE2_CHANNEL_X0Y5"), (1, "GTPE2_CHANNEL_X0Y4"))
 
+
 # The XDMA personality (the 47 value_src=user XCI parameters, applied
 # verbatim — a hand-picked subset is memory-dead on hardware) lives in
 # config/platform/dpv1.yaml, the single source. Resolve it once per process.

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -175,24 +175,10 @@ def fits(used: ResourceUse, platform: PlatformDefinition) -> FitReport:
 
 
 def dpv1_platform() -> PlatformDefinition:
-    """The dpv1 (NiteFury XC7A200T) platform, reconciled with the
-    authoritative build constants: ``part`` and the XDMA personality (and
-    the PCIe lane count derived from it) come from ``dau_build.dpv1_shell``
-    — the personality stays defined once, so the 47-parameter map cannot
-    drift from what the shell builds with.
+    """The dpv1 (NiteFury XC7A200T) platform, resolved from its config
+    (``config/platform/dpv1.yaml``) — the single source for the part,
+    budget, memory, and the 47-parameter XDMA personality the shell builds
+    with. A convenience wrapper over ``resolve_platform("dpv1")``."""
+    from dau_build.config import resolve_platform
 
-    Budget is the XC7A200T-2FBG484 datasheet capacity (134,600 LUT /
-    269,200 FF / 365 BRAM36 / 740 DSP48E1); memory is the board's 1 GiB
-    DDR3-800 (~1.6 GB/s) fronted by the vendored ``dpv1_mig.prj``. Shell
-    constraints are generated per build, so ``constraints`` is empty."""
-    from dau_build.dpv1_shell import DPV1_PART, DPV1_XDMA_PERSONALITY
-
-    personality = XdmaPersonality(params=dict(DPV1_XDMA_PERSONALITY))
-    return PlatformDefinition(
-        name="dpv1",
-        part=DPV1_PART,
-        budget=ResourceBudget(lut=134600, ff=269200, bram36=365, dsp=740),
-        host_link=HostLink(interface="pcie-xdma", pcie_lanes=personality.link_width(), xdma_personality=personality),
-        memory=PlatformMemory(kind="ddr3", size_bytes=1 << 30, mig_prj="dpv1_mig.prj", bandwidth_bytes_per_s=1_600_000_000),
-        program_method="jtag",
-    )
+    return resolve_platform("dpv1")

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 
 from dau_build.dpv1_shell import (
-    DPV1_XDMA_PERSONALITY,
     GT_LANE_SWIZZLE,
     MmDdrJobShellRequest,
     MmJobShellRequest,
     dpv1_constraints_xdc,
     dpv1_ddr_constraints_xdc,
+    dpv1_xdma_personality,
     gt_lane_swizzle_hook_tcl,
     mm_ddr_job_shell_project_tcl,
     mm_job_shell_project_tcl,
@@ -32,18 +32,18 @@ def _request(tmp_path: Path) -> MmJobShellRequest:
 
 def test_personality_mirrors_the_proven_shell() -> None:
     # the hardware rules: 64-bit prefetchable BARs, 128K KB-scale AXI-Lite, QPLL1
-    assert DPV1_XDMA_PERSONALITY["axil_master_64bit_en"] == "true"
-    assert DPV1_XDMA_PERSONALITY["axil_master_prefetchable"] == "true"
-    assert DPV1_XDMA_PERSONALITY["xdma_pcie_prefetchable"] == "true"
-    assert DPV1_XDMA_PERSONALITY["axilite_master_scale"] == "Kilobytes"
-    assert DPV1_XDMA_PERSONALITY["axilite_master_size"] == "128"
-    assert DPV1_XDMA_PERSONALITY["plltype"] == "QPLL1"
-    assert DPV1_XDMA_PERSONALITY["pf0_device_id"] == "7011"
+    assert dpv1_xdma_personality().params["axil_master_64bit_en"] == "true"
+    assert dpv1_xdma_personality().params["axil_master_prefetchable"] == "true"
+    assert dpv1_xdma_personality().params["xdma_pcie_prefetchable"] == "true"
+    assert dpv1_xdma_personality().params["axilite_master_scale"] == "Kilobytes"
+    assert dpv1_xdma_personality().params["axilite_master_size"] == "128"
+    assert dpv1_xdma_personality().params["plltype"] == "QPLL1"
+    assert dpv1_xdma_personality().params["pf0_device_id"] == "7011"
 
 
 def test_project_tcl_embeds_personality_staging_and_hook(tmp_path: Path) -> None:
     text = mm_job_shell_project_tcl(_request(tmp_path))
-    for key, value in DPV1_XDMA_PERSONALITY.items():
+    for key, value in dpv1_xdma_personality().params.items():
         assert f"CONFIG.{key} {{{value}}}" in text
     # staging layout from the register contract
     assert "-offset 0x00000000 -range 0x00020000" in text  # input BRAM
@@ -87,7 +87,7 @@ def _ddr_request(tmp_path: Path) -> MmDdrJobShellRequest:
 
 def test_ddr_project_tcl_embeds_mig_and_shared_memory_path(tmp_path: Path) -> None:
     text = mm_ddr_job_shell_project_tcl(_ddr_request(tmp_path))
-    for key, value in DPV1_XDMA_PERSONALITY.items():
+    for key, value in dpv1_xdma_personality().params.items():
         assert f"CONFIG.{key} {{{value}}}" in text
     # the memory controller comes from the vendored proven configuration
     assert "xilinx.com:ip:mig_7series" in text

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -94,23 +94,22 @@ def test_fits_exactly_at_budget_is_ok() -> None:
     assert all(value == pytest.approx(1.0) for value in report.utilization.values())
 
 
-def test_dpv1_platform_reconciles_with_authoritative_shell_constants() -> None:
-    from dau_build.dpv1_shell import DPV1_PART, DPV1_XDMA_PERSONALITY
+def test_dpv1_platform_is_the_single_source_for_the_shell() -> None:
+    from dau_build.dpv1_shell import DPV1_PART, dpv1_xdma_personality
 
     platform = dpv1_platform()
-    # part and the 47-parameter personality are sourced from the shell, not
-    # duplicated — the resolved values equal the build constants
-    assert platform.part == DPV1_PART
-    assert platform.host_link.xdma_personality.params == dict(DPV1_XDMA_PERSONALITY)
     assert len(platform.host_link.xdma_personality.params) == 47
-    # lane count derives from the personality's link-width, not a literal
-    assert platform.host_link.pcie_lanes == 4
+    # part stays a shell constant (request default); the config must not drift
+    assert platform.part == DPV1_PART
+    # lane count is consistent with the personality's link width
+    assert platform.host_link.pcie_lanes == platform.host_link.xdma_personality.link_width() == 4
     assert platform.memory.mig_prj == "dpv1_mig.prj"
-    # the emitted CONFIG block matches the shell's own inline emission
-    from dau_build.dpv1_shell import DPV1_XDMA_PERSONALITY as personality_map
-
-    expected = " \\\n".join(f"    CONFIG.{key} {{{value}}}" for key, value in personality_map.items())
-    assert platform.host_link.xdma_personality.to_tcl_config() == expected
+    # the shell's personality accessor resolves the same config
+    assert dpv1_xdma_personality() == platform.host_link.xdma_personality
+    # coerce-sensitive values survive yaml load intact
+    params = platform.host_link.xdma_personality.params
+    assert params["pf1_msix_cap_table_size"] == "000"
+    assert params["pf1_msix_cap_table_offset"] == "00000000"
 
 
 def test_platform_group_resolves_dpv1_through_hydra() -> None:


### PR DESCRIPTION
PR2 of the config modernization. The 47-parameter XDMA personality is now config data, not a Python constant.

- **Single source:** the 47 `value_src=user` XCI params live in `config/platform/dpv1.yaml` under `host_link.xdma_personality.params`. `DPV1_XDMA_PERSONALITY` is retired.
- **Threaded through the shell:** `dpv1_shell` resolves them via `dpv1_xdma_personality()` (`lru_cache`d, `resolve_platform` imported lazily so `import dau_build.dpv1_shell` stays light — no eager hydra) and emits the `CONFIG.*` block through `XdmaPersonality.to_tcl_config()`.
- **Provably behavior-preserving:** the generated project Tcl is byte-identical to the pinned goldens (`test_project_tcl_matches_pre_fragment_goldens` green). Hardware isn't re-touched until a rebuild+flash.
- **coerce-safe:** every value is quoted in the yaml so ccflow's `coerce_numbers_to_str` leaves it intact (`"000"` stays `"000"`, not `"0"`), and order matches the emission — both asserted by test.
- `dpv1_platform()` is now `resolve_platform("dpv1")`. `DPV1_PART` stays a constant (request default) with the config pinned to it.

Full suite 207 green, wall-clean. PR3 sweeps `build_config.py`'s config dataclasses next.