### PR TITLE
Convert build_config models to ccflow.BaseModel

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -3,38 +3,43 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 
+from ccflow import BaseModel
+from pydantic import field_validator
+
 from dau_build.build_spec import DauBuildSpec
 
 
-@dataclass(frozen=True)
-class BoardConfig:
+class BoardConfig(BaseModel):
     name: str
     platform: str
     shell: str
 
 
-@dataclass(frozen=True)
-class BackendConfig:
+class BackendConfig(BaseModel):
     name: str
     invocation: str
 
 
-@dataclass(frozen=True)
-class DriverConfig:
+class DriverConfig(BaseModel):
     os: str
     transport: str
 
 
-@dataclass(frozen=True)
-class OperatorConfig:
+class OperatorConfig(BaseModel):
     set_name: str
     names: tuple[str, ...]
 
 
-@dataclass(frozen=True)
-class MemoryConfig:
-    host_staging_bytes: int
-    device_staging_bytes: int
+class MemoryConfig(BaseModel):
+    host_staging_bytes: int = 0
+    device_staging_bytes: int = 0
+
+    @field_validator("host_staging_bytes", "device_staging_bytes")
+    @classmethod
+    def _non_negative(cls, value: int, info) -> int:
+        if value < 0:
+            raise ValueError(f"{info.field_name} cannot be negative")
+        return value
 
 
 @dataclass(frozen=True)
@@ -91,9 +96,6 @@ def _int_override(overrides: Mapping[str, str], key: str, default: int) -> int:
     if raw is None:
         return default
     try:
-        value = int(raw, 0)
+        return int(raw, 0)
     except ValueError as exc:
         raise ValueError(f"override {key} must be an integer") from exc
-    if value < 0:
-        raise ValueError(f"override {key} cannot be negative")
-    return value

--- a/dau_build/tests/test_build_config.py
+++ b/dau_build/tests/test_build_config.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ccflow import BaseModel
+from pydantic import ValidationError
+
+from dau_build.build_config import (
+    BackendConfig,
+    BoardConfig,
+    MemoryConfig,
+    OperatorConfig,
+    ResolvedBuildConfig,
+    resolve_build_config,
+)
+from dau_build.build_spec import load_dau_build_spec
+
+_EXAMPLE_SPEC = Path(__file__).resolve().parents[2] / "examples" / "identity" / "dau-build.yaml"
+
+
+def test_config_models_are_pydantic() -> None:
+    for model in (BoardConfig, BackendConfig, MemoryConfig, OperatorConfig):
+        assert issubclass(model, BaseModel)
+
+
+def test_config_model_round_trips() -> None:
+    board = BoardConfig(name="b", platform="vivado-xdma", shell="xdma-ddr")
+    assert BoardConfig.model_validate(board.model_dump()) == board
+
+
+def test_memory_config_rejects_negative() -> None:
+    with pytest.raises(ValidationError, match="host_staging_bytes cannot be negative"):
+        MemoryConfig(host_staging_bytes=-1)
+    with pytest.raises(ValidationError, match="device_staging_bytes cannot be negative"):
+        MemoryConfig(device_staging_bytes=-1)
+    assert MemoryConfig().host_staging_bytes == 0  # defaults are valid
+
+
+@pytest.mark.skipif(not _EXAMPLE_SPEC.is_file(), reason="example spec not present")
+def test_resolve_build_config_builds_pydantic_models() -> None:
+    spec = load_dau_build_spec(_EXAMPLE_SPEC)
+    resolved = resolve_build_config(spec, {"memory.host_staging_bytes": "4096", "backend.name": "vivado"})
+    assert isinstance(resolved, ResolvedBuildConfig)
+    assert isinstance(resolved.board, BoardConfig) and isinstance(resolved.memory, MemoryConfig)
+    assert resolved.board.platform == spec.platform and resolved.board.shell == spec.shell
+    assert resolved.backend.name == "vivado"  # override wins over the spec default
+    assert resolved.memory.host_staging_bytes == 4096
+    assert resolved.operators.names == spec.operators
+    assert resolved.to_text().splitlines()[0] == "dau-build-resolved-config"
+
+
+@pytest.mark.skipif(not _EXAMPLE_SPEC.is_file(), reason="example spec not present")
+def test_resolve_build_config_rejects_bad_overrides() -> None:
+    spec = load_dau_build_spec(_EXAMPLE_SPEC)
+    with pytest.raises(ValueError, match="must be an integer"):
+        resolve_build_config(spec, {"memory.host_staging_bytes": "not-a-number"})
+    with pytest.raises(ValueError, match="cannot be negative"):
+        resolve_build_config(spec, {"memory.device_staging_bytes": "-8"})


### PR DESCRIPTION
PR3 of the config modernization. The build-config data models join the platform models and task tree as pydantic (`ccflow.BaseModel`), not frozen dataclasses.

- `BoardConfig`/`BackendConfig`/`DriverConfig`/`OperatorConfig`/`MemoryConfig` → `ccflow.BaseModel`. `MemoryConfig`'s non-negative rule is a field validator (raises `ValidationError`, a `ValueError` subclass, so existing `except ValueError` handlers still catch it); `_int_override` now only parses.
- `resolve_build_config` is unchanged in shape — it just builds pydantic models now (verified end-to-end against the example spec).
- **Scope boundary:** `ResolvedBuildConfig` stays a dataclass aggregate — it embeds the `DauBuildSpec` domain object and is a resolution *result*, not an externally-composed config, so pydantic-ifying it would need `arbitrary_types_allowed` for no gain. `DauBuildSpec` and the shell-request dataclasses are domain objects, likewise out of scope.
- Adds the first direct test coverage for `build_config` (pydantic behavior, validation, resolution, bad-override rejection).

Full suite 212 green.

On `board=`/`backend=`/`driver=` as selectable hydra *groups*: unlike the platform registry (where dpv1/dpv2 are genuinely distinct selectable boards), these are derived from the spec (`spec.platform`/`spec.backend`/`spec.operators`) with override support — turning them into independently-selected groups is an architectural change to the spec-driven resolution, proposed as a separate follow-up rather than folded in here.