### PR TITLE
Convert artifact_bundle and build_spec domain objects to ccflow.BaseModel

### DIFF
--- a/dau_build/artifact_bundle.py
+++ b/dau_build/artifact_bundle.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 from artlink import Artifact
+from ccflow import BaseModel
 
 from dau_build.packaging import ArtifactManifestError, artifact_modules, artifact_path, load_artifact_manifest
 
@@ -27,15 +27,13 @@ class ArtifactBundleError(ValueError):
     pass
 
 
-@dataclass(frozen=True)
-class ArtifactBundleEntry:
+class ArtifactBundleEntry(BaseModel):
     artifact: Artifact
     origin: str
     manifest_path: Path | None = None
 
 
-@dataclass(frozen=True)
-class ArtifactBundle:
+class ArtifactBundle(BaseModel):
     name: str
     entries: tuple[ArtifactBundleEntry, ...]
     manifest_paths: tuple[Path, ...] = ()

--- a/dau_build/build_spec.py
+++ b/dau_build/build_spec.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from ccflow import BaseModel
+from pydantic import Field
 
 from dau_build.artifact_bundle import ArtifactBundle, ArtifactBundleError, is_hdl_source_artifact, load_artifact_bundle, source_language_from_path
 from dau_build.packaging import Artifact, ArtifactManifest, ArtifactManifestError, artifact_modules, artifact_with_modules, load_artifact_manifest
@@ -30,8 +30,7 @@ class DauBuildSpecError(ValueError):
     pass
 
 
-@dataclass(frozen=True)
-class DauBuildSpec:
+class DauBuildSpec(BaseModel):
     name: str
     top_name: str
     platform: str
@@ -48,12 +47,11 @@ class DauBuildSpec:
     binary_assets: tuple[Path, ...] = ()
     artifact_manifests: tuple[Path, ...] = ()
     artifacts: tuple[Artifact, ...] = ()
-    artifact_bundle: ArtifactBundle = field(default_factory=lambda: ArtifactBundle(name="", entries=()), compare=False)
+    artifact_bundle: ArtifactBundle = Field(default_factory=lambda: ArtifactBundle(name="", entries=()))
     backend: str = "none"
 
 
-@dataclass(frozen=True)
-class DauBuildArtifacts:
+class DauBuildArtifacts(BaseModel):
     manifest_path: Path
     top_sv_path: Path
     artifact_manifest_path: Path

--- a/dau_build/tests/test_build_spec.py
+++ b/dau_build/tests/test_build_spec.py
@@ -1,4 +1,3 @@
-from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -96,9 +95,13 @@ def test_build_spec_resolve_equals_the_loader(tmp_path: Path) -> None:
 
 
 def test_load_dau_build_spec_records_declarative_hardware_contract(tmp_path: Path) -> None:
+    from dau_build.artifact_bundle import ArtifactBundle
+
     spec = load_dau_build_spec(_write_spec(tmp_path))
 
-    assert spec == DauBuildSpec(
+    # the artifact_bundle is derived from the sources; compare the declared
+    # identity fields by normalizing it out
+    assert spec.model_copy(update={"artifact_bundle": ArtifactBundle(name="", entries=())}) == DauBuildSpec(
         name="identity-pipeline",
         top_name="dau_identity_top",
         platform="vivado-xdma",
@@ -118,17 +121,17 @@ def test_load_dau_build_spec_records_declarative_hardware_contract(tmp_path: Pat
 
 
 def test_design_manifest_items_advertise_one_aggregation_unit(tmp_path: Path) -> None:
-    spec = replace(load_dau_build_spec(_write_spec(tmp_path)), operators=("int32-arrow-lite-aggregation",))
+    spec = load_dau_build_spec(_write_spec(tmp_path)).model_copy(update={"operators": ("int32-arrow-lite-aggregation",)})
 
     assert design_manifest_items(spec) == (
         ("design_name", "identity-pipeline"),
         ("units", "aggregation:1:min|max|sum|count:int32"),
     )
 
-    sum_only = replace(spec, operators=("sum_i64",))
+    sum_only = spec.model_copy(update={"operators": ("sum_i64",)})
     assert design_manifest_items(sum_only)[1] == ("units", "aggregation:1:sum:int32")
 
-    no_ops = replace(spec, operators=("identity",))
+    no_ops = spec.model_copy(update={"operators": ("identity",)})
     assert design_manifest_items(no_ops)[1] == ("units", "")
 
 


### PR DESCRIPTION
No-dataclasses sweep of dau-build (Config Rules): `ArtifactBundle`/`ArtifactBundleEntry` and `DauBuildSpec`/`DauBuildArtifacts` are now `ccflow.BaseModel`. artifact_bundle nests the already-pydantic artlink `Artifact`; `DauBuildSpec`'s derived `artifact_bundle` is a plain field (the old `compare=False` is handled by normalizing it in the one identity-equality test). Test `replace()` → `model_copy(update=...)`. Full suite 214 green.