### PR TITLE
Convert dpv1_shell requests and hardware_plan models to ccflow.BaseModel

### DIFF
--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -17,9 +17,10 @@ XDMA). Hardware rules baked in (see dau-docs GUIDELINES):
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
+
+from ccflow import BaseModel
 
 DPV1_PART = "xc7a200tfbg484-2"
 
@@ -38,8 +39,7 @@ def dpv1_xdma_personality():
     return resolve_platform("dpv1").host_link.xdma_personality
 
 
-@dataclass(frozen=True)
-class MmJobShellRequest:
+class MmJobShellRequest(BaseModel):
     """Inputs for generating the MM job shell project. The caller supplies
     the generated binding sources as (filename, text) pairs — dau-build is
     generic platform integration and generates the *project*, never the
@@ -59,8 +59,7 @@ class MmJobShellRequest:
     jobs: int = 12
 
 
-@dataclass(frozen=True)
-class MmDdrJobShellRequest:
+class MmDdrJobShellRequest(BaseModel):
     """Inputs for generating the DDR-staged MM job shell project: the MM
     job shell with the block RAM staging replaced by the memory controller
     (MIG, configured from a caller-supplied .prj) shared between the XDMA

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -5,8 +5,9 @@ import base64
 import shlex
 import subprocess
 from collections.abc import Sequence
-from dataclasses import dataclass
 from pathlib import Path
+
+from ccflow import BaseModel
 
 from dau_build.vivado_backend import (
     VivadoBackendArtifactValidation,
@@ -51,18 +52,19 @@ SHELL_STAGE_EXCLUDES = (
 )
 
 
-@dataclass(frozen=True)
-class ToolStep:
+class ToolStep(BaseModel):
     name: str
     argv: tuple[str, ...]
+
+    def __init__(self, name: str, argv: tuple[str, ...] = ()) -> None:
+        super().__init__(name=name, argv=argv)
 
     @property
     def command_line(self) -> str:
         return shlex.join(self.argv)
 
 
-@dataclass(frozen=True)
-class HardwareToolchainConfig:
+class HardwareToolchainConfig(BaseModel):
     work_root: Path
     bitstream_path: Path | None = None
     vivado_executable: str = "vivado"
@@ -90,6 +92,12 @@ class HardwareToolchainConfig:
     @property
     def lspci_slot(self) -> str:
         return self.endpoint_bdf.removeprefix("0000:")
+
+
+# resolve forward-ref annotations (this module uses `from __future__ import
+# annotations`, so pydantic needs the models rebuilt against module globals)
+ToolStep.model_rebuild()
+HardwareToolchainConfig.model_rebuild()
 
 
 def build_and_program_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, ...]:


### PR DESCRIPTION
No-dataclasses sweep: `MmJobShellRequest`/`MmDdrJobShellRequest` and `ToolStep`/`HardwareToolchainConfig` → `ccflow.BaseModel`. `ToolStep` keeps a positional `__init__` (constructed positionally across the plan builders); models are `model_rebuild()`-ed to resolve forward-ref annotations under `from __future__ import annotations`. Byte-identity Tcl goldens unchanged; full suite 214 green.