### PR TITLE
Convert ResolvedBuildConfig to ccflow.BaseModel — no dataclasses left in dau-build

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
 
 from ccflow import BaseModel
 from pydantic import field_validator
@@ -42,8 +41,7 @@ class MemoryConfig(BaseModel):
         return value
 
 
-@dataclass(frozen=True)
-class ResolvedBuildConfig:
+class ResolvedBuildConfig(BaseModel):
     spec: DauBuildSpec
     board: BoardConfig
     backend: BackendConfig


### PR DESCRIPTION
Final model of the no-dataclasses sweep. `ResolvedBuildConfig` → `ccflow.BaseModel` (all its fields are already pydantic). `grep -rn '@dataclass' dau_build/ --include='*.py'` (excluding tests) is now empty. Full suite 214 green.