### PR TITLE
Retire ConfigOverrideModel and the override-dict merge

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
-
 from ccflow import BaseModel
 from pydantic import field_validator
 
@@ -62,38 +60,16 @@ class ResolvedBuildConfig(BaseModel):
         )
 
 
-def resolve_build_config(spec: DauBuildSpec, overrides: Mapping[str, str]) -> ResolvedBuildConfig:
+def resolve_build_config(spec: DauBuildSpec, *, backend_name: str | None = None) -> ResolvedBuildConfig:
+    """The build config as a view over the spec. Board, driver, operators,
+    and memory derive from the spec directly (Hydra field overrides on the
+    composed spec are how a user changes them — no bespoke override dict).
+    ``backend_name`` lets a task select the synthesis engine."""
     return ResolvedBuildConfig(
         spec=spec,
-        board=BoardConfig(
-            name=overrides.get("board.name", spec.platform),
-            platform=overrides.get("board.platform", spec.platform),
-            shell=overrides.get("board.shell", spec.shell),
-        ),
-        backend=BackendConfig(
-            name=overrides.get("backend.name", spec.backend),
-            invocation=overrides.get("backend.invocation", "dry-run"),
-        ),
-        driver=DriverConfig(
-            os=overrides.get("driver.os", "host"),
-            transport=overrides.get("driver.transport", "xdma"),
-        ),
-        operators=OperatorConfig(
-            set_name=overrides.get("operator.set", "spec"),
-            names=spec.operators,
-        ),
-        memory=MemoryConfig(
-            host_staging_bytes=_int_override(overrides, "memory.host_staging_bytes", 0),
-            device_staging_bytes=_int_override(overrides, "memory.device_staging_bytes", 0),
-        ),
+        board=BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
+        backend=BackendConfig(name=backend_name or spec.backend, invocation="dry-run"),
+        driver=DriverConfig(os="host", transport="xdma"),
+        operators=OperatorConfig(set_name="spec", names=spec.operators),
+        memory=MemoryConfig(),
     )
-
-
-def _int_override(overrides: Mapping[str, str], key: str, default: int) -> int:
-    raw = overrides.get(key)
-    if raw is None:
-        return default
-    try:
-        return int(raw, 0)
-    except ValueError as exc:
-        raise ValueError(f"override {key} must be an integer") from exc

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -42,11 +42,11 @@ def _build_spec_api():
     return build_spec
 
 
-def _resolve_build_config(spec, overrides):
+def _resolve_build_config(spec, *, backend_name=None):
     """Deferred for the same reason: build_config imports build_spec."""
     from dau_build.build_config import resolve_build_config
 
-    return resolve_build_config(spec, overrides)
+    return resolve_build_config(spec, backend_name=backend_name)
 
 
 class BuildStepError(ValueError):
@@ -64,11 +64,6 @@ BuildCallableModelType = TypeVar("BuildCallableModelType", bound="BuildCallableM
 class BuildCallableModel(CallableModel):
     _STRINGIFY_SEPARATOR: ClassVar[str] = ","
 
-    def override_mapping(self) -> dict[str, str]:
-        raw = self.model_dump(mode="python", by_alias=True, exclude_none=True, exclude={"meta", "type_"})
-        raw.pop("_target_", None)
-        return {key: self._stringify_override_value(value) for key, value in raw.items()}
-
     @classmethod
     def _stringify_override_value(cls, value) -> str:
         if isinstance(value, Path):
@@ -78,39 +73,7 @@ class BuildCallableModel(CallableModel):
         return str(value)
 
 
-class ConfigOverrideModel(BuildCallableModel):
-    board_name: str | None = Field(default=None, alias="board.name")
-    board_platform: str | None = Field(default=None, alias="board.platform")
-    board_shell: str | None = Field(default=None, alias="board.shell")
-    backend_name: str | None = Field(default=None, alias="backend.name")
-    backend_invocation: str | None = Field(default=None, alias="backend.invocation")
-    driver_os: str | None = Field(default=None, alias="driver.os")
-    driver_transport: str | None = Field(default=None, alias="driver.transport")
-    operator_set: str | None = Field(default=None, alias="operator.set")
-    memory_host_staging_bytes: int | None = Field(default=None, alias="memory.host_staging_bytes")
-    memory_device_staging_bytes: int | None = Field(default=None, alias="memory.device_staging_bytes")
-
-    def config_overrides(self) -> dict[str, str]:
-        return {
-            key: value
-            for key, value in self.override_mapping().items()
-            if key
-            in {
-                "board.name",
-                "board.platform",
-                "board.shell",
-                "backend.name",
-                "backend.invocation",
-                "driver.os",
-                "driver.transport",
-                "operator.set",
-                "memory.host_staging_bytes",
-                "memory.device_staging_bytes",
-            }
-        }
-
-
-class SpecPathModel(ConfigOverrideModel):
+class SpecPathModel(BuildCallableModel):
     spec_path: Path
 
     def load_spec(self):
@@ -166,7 +129,7 @@ class WriteStep(SpecPathModel):
 class ResolvedConfigStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        resolved = _resolve_build_config(self.load_spec(), self.override_mapping())
+        resolved = _resolve_build_config(self.load_spec())
         return BuildStepResult(step="resolved-config", message=resolved.to_text())
 
 
@@ -189,7 +152,7 @@ class SimulateStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
-        _resolve_build_config(spec, self.override_mapping())
+        _resolve_build_config(spec)
         _build_spec_api().generate_dau_build_artifacts(spec, output_root=self.output_root or self.spec_path.parent / ".dau-build-sim")
         if self.simulate_engine == "verilator":
             return self._run_verilator(spec)
@@ -264,7 +227,7 @@ class SynthesisStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
-        resolved = _resolve_build_config(spec, self.override_mapping())
+        resolved = _resolve_build_config(spec)
         artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
         return BuildStepResult(
             step="synthesis",
@@ -279,7 +242,7 @@ class ExplainStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
-        resolved = _resolve_build_config(spec, self.override_mapping())
+        resolved = _resolve_build_config(spec)
         return BuildStepResult(
             step="explain",
             message="\n".join(
@@ -322,13 +285,13 @@ class SimulateTask(ModuleSelectionModel):
         spec = self.load_spec_and_validate_module()
         output_root = self.output_root or self.spec_path.parent / ".dau-build-sim"
         if self.simulator in {"svparser", "cocotb"}:
-            _resolve_build_config(spec, self.override_mapping())
+            _resolve_build_config(spec)
             _build_spec_api().generate_dau_build_artifacts(spec, output_root=output_root)
             return BuildStepResult(
                 step="simulate",
                 message=f"dau-build-simulate\ttask=simulate simulator={self.simulator} module={self.module} spec={self.spec_path} status=validated",
             )
-        step_data = self.config_overrides()
+        step_data: dict[str, str] = {}
         step_data.update(
             {
                 "spec_path": str(self.spec_path),
@@ -390,9 +353,7 @@ class SynthesizeTask(ModuleSelectionModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec_and_validate_module()
-        task_overrides = self.override_mapping()
-        task_overrides["backend.name"] = self.engine
-        resolved = _resolve_build_config(spec, task_overrides)
+        resolved = _resolve_build_config(spec, backend_name=self.engine)
         artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
         backend_artifacts = _write_vivado_backend_handoff(
             spec,

--- a/dau_build/tests/test_build_config.py
+++ b/dau_build/tests/test_build_config.py
@@ -38,22 +38,15 @@ def test_memory_config_rejects_negative() -> None:
 
 
 @pytest.mark.skipif(not _EXAMPLE_SPEC.is_file(), reason="example spec not present")
-def test_resolve_build_config_builds_pydantic_models() -> None:
+def test_resolve_build_config_is_a_view_over_the_spec() -> None:
     spec = load_dau_build_spec(_EXAMPLE_SPEC)
-    resolved = resolve_build_config(spec, {"memory.host_staging_bytes": "4096", "backend.name": "vivado"})
+    resolved = resolve_build_config(spec)
     assert isinstance(resolved, ResolvedBuildConfig)
     assert isinstance(resolved.board, BoardConfig) and isinstance(resolved.memory, MemoryConfig)
+    # board/operators/backend derive from the spec (no bespoke override dict)
     assert resolved.board.platform == spec.platform and resolved.board.shell == spec.shell
-    assert resolved.backend.name == "vivado"  # override wins over the spec default
-    assert resolved.memory.host_staging_bytes == 4096
+    assert resolved.backend.name == spec.backend
     assert resolved.operators.names == spec.operators
     assert resolved.to_text().splitlines()[0] == "dau-build-resolved-config"
-
-
-@pytest.mark.skipif(not _EXAMPLE_SPEC.is_file(), reason="example spec not present")
-def test_resolve_build_config_rejects_bad_overrides() -> None:
-    spec = load_dau_build_spec(_EXAMPLE_SPEC)
-    with pytest.raises(ValueError, match="must be an integer"):
-        resolve_build_config(spec, {"memory.host_staging_bytes": "not-a-number"})
-    with pytest.raises(ValueError, match="cannot be negative"):
-        resolve_build_config(spec, {"memory.device_staging_bytes": "-8"})
+    # a task may select the synthesis engine
+    assert resolve_build_config(spec, backend_name="vivado").backend.name == "vivado"

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -104,27 +104,19 @@ def test_execute_write_step_persists_artifacts(tmp_path: Path) -> None:
 def test_resolved_config_step_reports_typed_board_driver_operator_and_memory_models(tmp_path: Path) -> None:
     spec_path = _write_spec(tmp_path)
 
-    result = execute_override_step(
-        (
-            "step=resolved-config",
-            f"spec_path={spec_path}",
-            "board.name=lab-fpga",
-            "driver.os=linux",
-            "operator.set=int32-aggregation",
-            "memory.host_staging_bytes=4096",
-        )
-    )
+    # the resolved config is a view over the spec — no bespoke override dict
+    result = execute_override_step(("step=resolved-config", f"spec_path={spec_path}"))
 
     assert result == BuildStepResult(
         step="resolved-config",
         message="\n".join(
             (
                 "dau-build-resolved-config",
-                "board\tname=lab-fpga platform=vivado-xdma shell=xdma-ddr",
+                "board\tname=vivado-xdma platform=vivado-xdma shell=xdma-ddr",
                 "backend\tname=none invocation=dry-run",
-                "driver\tos=linux transport=xdma",
-                "operators\tset=int32-aggregation names=identity",
-                "memory\thost_staging_bytes=4096 device_staging_bytes=0",
+                "driver\tos=host transport=xdma",
+                "operators\tset=spec names=identity",
+                "memory\thost_staging_bytes=0 device_staging_bytes=0",
             )
         ),
     )
@@ -219,12 +211,12 @@ def test_synthesis_step_writes_local_artifacts_for_backend_handoff(tmp_path: Pat
 def test_explain_step_describes_resolved_plan(tmp_path: Path) -> None:
     spec_path = _write_spec(tmp_path)
 
-    result = execute_override_step(("step=explain", f"spec_path={spec_path}", "board.name=lab-fpga"))
+    result = execute_override_step(("step=explain", f"spec_path={spec_path}"))
 
     assert result.message.splitlines() == [
         "dau-build-explain",
         f"spec\tpath={spec_path} name=identity-pipeline top=dau_identity_top",
-        "board\tname=lab-fpga platform=vivado-xdma shell=xdma-ddr",
+        "board\tname=vivado-xdma platform=vivado-xdma shell=xdma-ddr",
         "actions\tvalidate=local simulate=local synthesis=local-handoff artifacts=generate-or-write",
     ]
 

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -83,16 +83,6 @@ def test_public_override_dispatch_runs_packaged_task_configs(monkeypatch) -> Non
     assert captured["request_kind"] == "task"
     assert captured["request_name"] == "simulate"
     assert captured["model_values"] == {
-        "board_name": None,
-        "board_platform": None,
-        "board_shell": None,
-        "backend_name": None,
-        "backend_invocation": None,
-        "driver_os": None,
-        "driver_transport": None,
-        "operator_set": None,
-        "memory_host_staging_bytes": None,
-        "memory_device_staging_bytes": None,
         "spec_path": "examples/identity/dau-build.yaml",
         "module": "dau_identity_top",
         "simulator": "svparser",


### PR DESCRIPTION
Kills the most egregious hand-rolled-config anti-pattern (GUIDELINES Config Rules): `ConfigOverrideModel`'s `board.name`/`backend.name`/`driver.os`/`memory.*` aliased fields were pydantic reimplementing Hydra group composition, stringified into an override dict and merged by `resolve_build_config`.

- `resolve_build_config(spec, *, backend_name=None)` is now a **view over the spec**: board/driver/operators/memory derive from the spec directly; `backend_name` is the one real override (SynthesizeTask's engine). `_int_override` and the override-dict param are gone.
- `ConfigOverrideModel` + `override_mapping`/`config_overrides` deleted; `SpecPathModel` extends `BuildCallableModel` directly. Users change these via Hydra field overrides on the composed spec, not a bespoke dict.
- Tests updated to the spec-derived behavior (the override-mechanism tests exercised the retired path).

Full suite 213 green; byte-identity goldens unchanged. Next: `spec_path` → `spec=` Hydra group, retiring `load_dau_build_spec`'s path use.