### PR TITLE
Add spec= Hydra config group; retire load_dau_build_spec and resolve_build_config

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -47,6 +47,22 @@ class ResolvedBuildConfig(BaseModel):
     operators: OperatorConfig
     memory: MemoryConfig
 
+    @classmethod
+    def from_spec(cls, spec: DauBuildSpec, *, backend_name: str | None = None) -> ResolvedBuildConfig:
+        """The build config as a view over the spec. Board, driver,
+        operators, and memory derive from the spec directly (Hydra field
+        overrides on the composed spec are how a user changes them — no
+        bespoke override dict). ``backend_name`` selects the synthesis
+        engine."""
+        return cls(
+            spec=spec,
+            board=BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
+            backend=BackendConfig(name=backend_name or spec.backend, invocation="dry-run"),
+            driver=DriverConfig(os="host", transport="xdma"),
+            operators=OperatorConfig(set_name="spec", names=spec.operators),
+            memory=MemoryConfig(),
+        )
+
     def to_text(self) -> str:
         return "\n".join(
             (
@@ -58,18 +74,3 @@ class ResolvedBuildConfig(BaseModel):
                 f"memory\thost_staging_bytes={self.memory.host_staging_bytes} device_staging_bytes={self.memory.device_staging_bytes}",
             )
         )
-
-
-def resolve_build_config(spec: DauBuildSpec, *, backend_name: str | None = None) -> ResolvedBuildConfig:
-    """The build config as a view over the spec. Board, driver, operators,
-    and memory derive from the spec directly (Hydra field overrides on the
-    composed spec are how a user changes them — no bespoke override dict).
-    ``backend_name`` lets a task select the synthesis engine."""
-    return ResolvedBuildConfig(
-        spec=spec,
-        board=BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
-        backend=BackendConfig(name=backend_name or spec.backend, invocation="dry-run"),
-        driver=DriverConfig(os="host", transport="xdma"),
-        operators=OperatorConfig(set_name="spec", names=spec.operators),
-        memory=MemoryConfig(),
-    )

--- a/dau_build/build_spec.py
+++ b/dau_build/build_spec.py
@@ -86,6 +86,13 @@ class BuildSpec(BaseModel):
     backend: str = "none"
     base_dir: Path = Path(".")
 
+    @classmethod
+    def from_file(cls, path: Path) -> BuildSpec:
+        """Parse a spec yaml file into a ``BuildSpec`` (sources resolve
+        against the file's directory). File input for the CLI/tests; the
+        Hydra ``spec=`` group composes a ``BuildSpec`` the same way."""
+        return build_spec_from_mapping(_load_yaml_mapping(path), base_dir=path.parent)
+
     def resolve(self) -> DauBuildSpec:
         if self.backend not in SUPPORTED_BACKENDS:
             raise DauBuildSpecError(f"unsupported backend: {self.backend}")
@@ -162,13 +169,6 @@ def build_spec_from_mapping(raw: dict[str, Any], *, base_dir: Path) -> BuildSpec
         backend=str(raw.get("backend", "none")),
         base_dir=base_dir,
     )
-
-
-def load_dau_build_spec(path: Path) -> DauBuildSpec:
-    """Back-compatible loader: parse the spec yaml into a ``BuildSpec`` and
-    resolve it. New code composes ``BuildSpec`` through the ``spec`` Hydra
-    config group instead of parsing a path."""
-    return build_spec_from_mapping(_load_yaml_mapping(path), base_dir=path.parent).resolve()
 
 
 def generate_dau_build_artifacts(spec: DauBuildSpec, *, output_root: Path) -> DauBuildArtifacts:
@@ -322,14 +322,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(arguments)
     try:
         if args.command == "build":
-            artifacts = write_dau_build_artifacts(load_dau_build_spec(args.spec), output_root=args.out)
+            artifacts = write_dau_build_artifacts(BuildSpec.from_file(args.spec).resolve(), output_root=args.out)
             print(f"dau-build-artifacts\tmanifest={artifacts.manifest_path} top_sv={artifacts.top_sv_path}")
             return 0
         if args.command == "inspect":
-            print(dau_build_spec_summary(load_dau_build_spec(args.spec)))
+            print(dau_build_spec_summary(BuildSpec.from_file(args.spec).resolve()))
             return 0
         if args.command == "validate" and args.spec is not None:
-            load_dau_build_spec(args.spec)
+            BuildSpec.from_file(args.spec).resolve()
             print(f"dau-build-spec-valid\tspec={args.spec}")
             return 0
         if args.command == "validate" and args.manifest is not None:

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -44,9 +44,9 @@ def _build_spec_api():
 
 def _resolve_build_config(spec, *, backend_name=None):
     """Deferred for the same reason: build_config imports build_spec."""
-    from dau_build.build_config import resolve_build_config
+    from dau_build.build_config import ResolvedBuildConfig
 
-    return resolve_build_config(spec, backend_name=backend_name)
+    return ResolvedBuildConfig.from_spec(spec, backend_name=backend_name)
 
 
 class BuildStepError(ValueError):
@@ -74,10 +74,27 @@ class BuildCallableModel(CallableModel):
 
 
 class SpecPathModel(BuildCallableModel):
-    spec_path: Path
+    # `spec` is composed by the Hydra `spec=` group (a BuildSpec); `spec_path`
+    # is file input for the CLI/tests. Typed Any, not BuildSpec, so importing
+    # build_steps stays light — build_spec pulls the SV-parser stack (F51).
+    spec: Any = None
+    spec_path: Path | None = None
 
     def load_spec(self):
-        return _build_spec_api().load_dau_build_spec(self.spec_path)
+        build_spec = self.spec
+        if build_spec is None:
+            if self.spec_path is None:
+                raise BuildStepError("a spec is required: pass spec=<name> or spec_path=<file>")
+            build_spec = _build_spec_api().BuildSpec.from_file(self.spec_path)
+        return build_spec.resolve()
+
+    @property
+    def spec_base_dir(self) -> Path:
+        return Path(self.spec.base_dir) if self.spec is not None else self.spec_path.parent
+
+    @property
+    def spec_label(self) -> str:
+        return self.spec.name if self.spec is not None else str(self.spec_path)
 
 
 class ModuleSelectionModel(SpecPathModel):
@@ -88,7 +105,7 @@ class ModuleSelectionModel(SpecPathModel):
         provided_modules = (spec.top_name, *spec.modules)
         if self.module not in provided_modules:
             expected = ", ".join(provided_modules)
-            raise BuildStepError(f"module {self.module!r} is not provided by spec {self.spec_path}; expected one of: {expected}")
+            raise BuildStepError(f"module {self.module!r} is not provided by spec {self.spec_label}; expected one of: {expected}")
         return spec
 
 
@@ -102,7 +119,7 @@ class ValidateStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         self.load_spec()
-        return BuildStepResult(step="validate", message=f"dau-build-spec-valid\tspec={self.spec_path}")
+        return BuildStepResult(step="validate", message=f"dau-build-spec-valid\tspec={self.spec_label}")
 
 
 class GenerateStep(SpecPathModel):
@@ -153,13 +170,13 @@ class SimulateStep(SpecPathModel):
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
         _resolve_build_config(spec)
-        _build_spec_api().generate_dau_build_artifacts(spec, output_root=self.output_root or self.spec_path.parent / ".dau-build-sim")
+        _build_spec_api().generate_dau_build_artifacts(spec, output_root=self.output_root or self.spec_base_dir / ".dau-build-sim")
         if self.simulate_engine == "verilator":
             return self._run_verilator(spec)
         return BuildStepResult(
             step="simulate",
             message=(
-                f"dau-build-simulate\tspec={self.spec_path} top={spec.top_name} modules={','.join(spec.modules)} "
+                f"dau-build-simulate\tspec={self.spec_label} top={spec.top_name} modules={','.join(spec.modules)} "
                 f"sources={len(spec.sources)} engine=svparser status=validated"
             ),
         )
@@ -194,7 +211,7 @@ class SimulateStep(SpecPathModel):
             expected_stdout = self.simulate_expect_stdout
             extra_sources = (testbench_path,)
 
-        work_dir = self.output_root or self.spec_path.parent / ".dau-build-sim" / "verilator"
+        work_dir = self.output_root or self.spec_base_dir / ".dau-build-sim" / "verilator"
         extra_args = tuple(shlex.split(self.simulate_extra_args))
         all_sources = _unique_paths((*spec.sources, *extra_sources))
         try:
@@ -215,7 +232,7 @@ class SimulateStep(SpecPathModel):
         return BuildStepResult(
             step="simulate",
             message=(
-                f"dau-build-simulate\tspec={self.spec_path} top={spec.top_name} modules={','.join(spec.modules)} sources={len(spec.sources)} "
+                f"dau-build-simulate\tspec={self.spec_label} top={spec.top_name} modules={','.join(spec.modules)} sources={len(spec.sources)} "
                 f"engine=verilator {mode_segment}testbench_top={top_module} work_dir={work_dir} status=passed"
             ),
         )
@@ -248,7 +265,7 @@ class ExplainStep(SpecPathModel):
             message="\n".join(
                 (
                     "dau-build-explain",
-                    f"spec\tpath={self.spec_path} name={spec.name} top={spec.top_name}",
+                    f"spec\tpath={self.spec_label} name={spec.name} top={spec.top_name}",
                     f"board\tname={resolved.board.name} platform={resolved.board.platform} shell={resolved.board.shell}",
                     "actions\tvalidate=local simulate=local synthesis=local-handoff artifacts=generate-or-write",
                 )
@@ -278,23 +295,25 @@ class SimulateTask(ModuleSelectionModel):
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        if self.simulator in ("verilator", "cocotb") and self.profile and self.spec_path is None:
+        no_spec = self.spec is None and self.spec_path is None
+        if self.simulator in ("verilator", "cocotb") and self.profile and no_spec:
             return self._run_registered_profile()
-        if self.spec_path is None or not self.module:
-            raise BuildStepError("task=simulate requires spec_path and module (or simulator=verilator profile=<name> for a registered profile)")
+        if no_spec or not self.module:
+            raise BuildStepError(
+                "task=simulate requires a spec (spec=<name> or spec_path=<file>) and module (or simulator=verilator profile=<name> for a registered profile)"
+            )
         spec = self.load_spec_and_validate_module()
-        output_root = self.output_root or self.spec_path.parent / ".dau-build-sim"
+        output_root = self.output_root or self.spec_base_dir / ".dau-build-sim"
         if self.simulator in {"svparser", "cocotb"}:
             _resolve_build_config(spec)
             _build_spec_api().generate_dau_build_artifacts(spec, output_root=output_root)
             return BuildStepResult(
                 step="simulate",
-                message=f"dau-build-simulate\ttask=simulate simulator={self.simulator} module={self.module} spec={self.spec_path} status=validated",
+                message=f"dau-build-simulate\ttask=simulate simulator={self.simulator} module={self.module} spec={self.spec_label} status=validated",
             )
-        step_data: dict[str, str] = {}
+        step_data: dict[str, Any] = {"spec": self.spec} if self.spec is not None else {"spec_path": str(self.spec_path)}
         step_data.update(
             {
-                "spec_path": str(self.spec_path),
                 "output_root": str(output_root),
                 "simulate.engine": "verilator",
                 "simulate.verilator": self.verilator,
@@ -367,7 +386,7 @@ class SynthesizeTask(ModuleSelectionModel):
         return BuildStepResult(
             step="synthesize",
             message=(
-                f"dau-build-synthesize\ttask=synthesize engine={self.engine} module={self.module} spec={self.spec_path} "
+                f"dau-build-synthesize\ttask=synthesize engine={self.engine} module={self.module} spec={self.spec_label} "
                 f"output_root={self.output_root} manifest={artifacts.manifest_path} top_sv={artifacts.top_sv_path} "
                 f"backend_manifest={backend_artifacts.manifest_path} command_plan={backend_artifacts.command_plan_path} status=handoff-written"
             ),

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -5,6 +5,7 @@ defaults:
   - optional task: null
   - optional step: null
   - optional platform: null
+  - optional spec: null
   - callable: callable
 
 context: {}

--- a/dau_build/config/spec/identity.yaml
+++ b/dau_build/config/spec/identity.yaml
@@ -1,0 +1,19 @@
+# @package spec
+
+# The identity example as a Hydra-composed BuildSpec: dau-build task=inspect
+# spec=identity (run from the dau-build repo root so base_dir resolves).
+_target_: dau_build.build_spec.BuildSpec
+name: identity-pipeline
+top_name: dau_identity_top
+platform: vivado-xdma
+shell: xdma-ddr
+artifact_stem: dau-identity
+register_map_version: "0.1"
+stream_protocol_version: "0.1"
+clock: clk
+reset: reset
+operators: [identity]
+modules: [identity]
+artifact_manifests: [package.artifacts.yaml]
+backend: vivado
+base_dir: examples/identity

--- a/dau_build/config/step/explain.yaml
+++ b/dau_build/config/step/explain.yaml
@@ -1,4 +1,5 @@
 # @package model
 
 _target_: dau_build.build_steps.ExplainStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}

--- a/dau_build/config/step/generate.yaml
+++ b/dau_build/config/step/generate.yaml
@@ -1,5 +1,6 @@
 # @package model
 
 _target_: dau_build.build_steps.GenerateStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}
 output_root: ???

--- a/dau_build/config/step/inspect.yaml
+++ b/dau_build/config/step/inspect.yaml
@@ -1,4 +1,5 @@
 # @package model
 
 _target_: dau_build.build_steps.InspectStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}

--- a/dau_build/config/step/resolved-config.yaml
+++ b/dau_build/config/step/resolved-config.yaml
@@ -1,4 +1,5 @@
 # @package model
 
 _target_: dau_build.build_steps.ResolvedConfigStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}

--- a/dau_build/config/step/simulate.yaml
+++ b/dau_build/config/step/simulate.yaml
@@ -1,7 +1,8 @@
 # @package model
 
 _target_: dau_build.build_steps.SimulateStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}
 output_root: null
 simulate_engine: svparser
 simulate_profile: null

--- a/dau_build/config/step/synthesis.yaml
+++ b/dau_build/config/step/synthesis.yaml
@@ -1,5 +1,6 @@
 # @package model
 
 _target_: dau_build.build_steps.SynthesisStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}
 output_root: ???

--- a/dau_build/config/step/validate.yaml
+++ b/dau_build/config/step/validate.yaml
@@ -1,4 +1,5 @@
 # @package model
 
 _target_: dau_build.build_steps.ValidateStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}

--- a/dau_build/config/step/write.yaml
+++ b/dau_build/config/step/write.yaml
@@ -1,5 +1,6 @@
 # @package model
 
 _target_: dau_build.build_steps.WriteStep
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}
 output_root: ???

--- a/dau_build/config/task/simulate.yaml
+++ b/dau_build/config/task/simulate.yaml
@@ -1,7 +1,8 @@
 # @package model
 
 _target_: dau_build.build_steps.SimulateTask
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}
 module: ???
 simulator: svparser
 output_root: null

--- a/dau_build/config/task/synthesize.yaml
+++ b/dau_build/config/task/synthesize.yaml
@@ -1,7 +1,8 @@
 # @package model
 
 _target_: dau_build.build_steps.SynthesizeTask
-spec_path: ???
+spec_path: null
+spec: ${oc.select:spec,null}
 module: ???
 engine: vivado
 output_root: ???

--- a/dau_build/tests/test_build_config.py
+++ b/dau_build/tests/test_build_config.py
@@ -12,9 +12,8 @@ from dau_build.build_config import (
     MemoryConfig,
     OperatorConfig,
     ResolvedBuildConfig,
-    resolve_build_config,
 )
-from dau_build.build_spec import load_dau_build_spec
+from dau_build.build_spec import BuildSpec
 
 _EXAMPLE_SPEC = Path(__file__).resolve().parents[2] / "examples" / "identity" / "dau-build.yaml"
 
@@ -39,8 +38,8 @@ def test_memory_config_rejects_negative() -> None:
 
 @pytest.mark.skipif(not _EXAMPLE_SPEC.is_file(), reason="example spec not present")
 def test_resolve_build_config_is_a_view_over_the_spec() -> None:
-    spec = load_dau_build_spec(_EXAMPLE_SPEC)
-    resolved = resolve_build_config(spec)
+    spec = BuildSpec.from_file(_EXAMPLE_SPEC).resolve()
+    resolved = ResolvedBuildConfig.from_spec(spec)
     assert isinstance(resolved, ResolvedBuildConfig)
     assert isinstance(resolved.board, BoardConfig) and isinstance(resolved.memory, MemoryConfig)
     # board/operators/backend derive from the spec (no bespoke override dict)
@@ -49,4 +48,4 @@ def test_resolve_build_config_is_a_view_over_the_spec() -> None:
     assert resolved.operators.names == spec.operators
     assert resolved.to_text().splitlines()[0] == "dau-build-resolved-config"
     # a task may select the synthesis engine
-    assert resolve_build_config(spec, backend_name="vivado").backend.name == "vivado"
+    assert ResolvedBuildConfig.from_spec(spec, backend_name="vivado").backend.name == "vivado"

--- a/dau_build/tests/test_build_spec.py
+++ b/dau_build/tests/test_build_spec.py
@@ -8,7 +8,6 @@ from dau_build.build_spec import (
     build_spec_from_mapping,
     design_manifest_items,
     generate_dau_build_artifacts,
-    load_dau_build_spec,
     main,
     write_dau_build_artifacts,
 )
@@ -91,13 +90,13 @@ def test_build_spec_resolve_equals_the_loader(tmp_path: Path) -> None:
 
     composed = build_spec_from_mapping(_load_yaml_mapping(spec_path), base_dir=spec_path.parent)
     assert isinstance(composed, BuildSpec)
-    assert composed.resolve() == load_dau_build_spec(spec_path)
+    assert composed.resolve() == BuildSpec.from_file(spec_path).resolve()
 
 
 def test_load_dau_build_spec_records_declarative_hardware_contract(tmp_path: Path) -> None:
     from dau_build.artifact_bundle import ArtifactBundle
 
-    spec = load_dau_build_spec(_write_spec(tmp_path))
+    spec = BuildSpec.from_file(_write_spec(tmp_path)).resolve()
 
     # the artifact_bundle is derived from the sources; compare the declared
     # identity fields by normalizing it out
@@ -121,7 +120,7 @@ def test_load_dau_build_spec_records_declarative_hardware_contract(tmp_path: Pat
 
 
 def test_design_manifest_items_advertise_one_aggregation_unit(tmp_path: Path) -> None:
-    spec = load_dau_build_spec(_write_spec(tmp_path)).model_copy(update={"operators": ("int32-arrow-lite-aggregation",)})
+    spec = BuildSpec.from_file(_write_spec(tmp_path)).resolve().model_copy(update={"operators": ("int32-arrow-lite-aggregation",)})
 
     assert design_manifest_items(spec) == (
         ("design_name", "identity-pipeline"),
@@ -136,7 +135,7 @@ def test_design_manifest_items_advertise_one_aggregation_unit(tmp_path: Path) ->
 
 
 def test_generate_dau_build_artifacts_loads_sv_and_emits_top_and_manifest(tmp_path: Path) -> None:
-    spec = load_dau_build_spec(_write_spec(tmp_path))
+    spec = BuildSpec.from_file(_write_spec(tmp_path)).resolve()
     artifacts = generate_dau_build_artifacts(spec, output_root=tmp_path / "out")
 
     assert artifacts.top_sv_path == tmp_path / "out" / "generated" / "dau_identity_top.sv"
@@ -165,7 +164,7 @@ def test_generate_dau_build_artifacts_loads_sv_and_emits_top_and_manifest(tmp_pa
 
 
 def test_write_dau_build_artifacts_persists_bundle_without_toolchain_invocation(tmp_path: Path) -> None:
-    spec = load_dau_build_spec(_write_spec(tmp_path))
+    spec = BuildSpec.from_file(_write_spec(tmp_path)).resolve()
     artifacts = write_dau_build_artifacts(spec, output_root=tmp_path / "out")
 
     assert artifacts.top_sv_path.read_text(encoding="utf-8") == artifacts.top_sv_text
@@ -201,7 +200,7 @@ def test_generate_dau_build_artifacts_emits_stream_job_top_boundary_for_stream_m
         encoding="utf-8",
     )
 
-    artifacts = generate_dau_build_artifacts(load_dau_build_spec(spec_path), output_root=tmp_path / "out")
+    artifacts = generate_dau_build_artifacts(BuildSpec.from_file(spec_path).resolve(), output_root=tmp_path / "out")
     top = artifacts.top_sv_text
 
     assert "input wire logic register_read_enable" in top
@@ -240,7 +239,7 @@ def test_load_dau_build_spec_rejects_missing_source_file(tmp_path: Path) -> None
     spec_path.write_text(spec_path.read_text(encoding="utf-8").replace("ff.sv", "missing.sv"), encoding="utf-8")
 
     with pytest.raises(Exception) as exc_info:
-        load_dau_build_spec(spec_path)
+        BuildSpec.from_file(spec_path).resolve()
 
     assert exc_info.type.__name__ == "DauBuildSpecError"
     assert "missing source file" in str(exc_info.value)
@@ -251,7 +250,7 @@ def test_load_dau_build_spec_rejects_empty_modules(tmp_path: Path) -> None:
     spec_path.write_text(spec_path.read_text(encoding="utf-8").replace("modules:\n  - ff\n  - decoder", "modules: []"), encoding="utf-8")
 
     with pytest.raises(Exception) as exc_info:
-        load_dau_build_spec(spec_path)
+        BuildSpec.from_file(spec_path).resolve()
 
     assert exc_info.type.__name__ == "DauBuildSpecError"
     assert "modules must contain at least one entry" in str(exc_info.value)
@@ -262,7 +261,7 @@ def test_load_dau_build_spec_rejects_unsupported_backend(tmp_path: Path) -> None
     spec_path.write_text(spec_path.read_text(encoding="utf-8").replace("backend: vivado", "backend: quartus"), encoding="utf-8")
 
     with pytest.raises(Exception) as exc_info:
-        load_dau_build_spec(spec_path)
+        BuildSpec.from_file(spec_path).resolve()
 
     assert exc_info.type.__name__ == "DauBuildSpecError"
     assert "unsupported backend" in str(exc_info.value)
@@ -274,7 +273,7 @@ def test_generate_dau_build_artifacts_rejects_unknown_requested_module(tmp_path:
         spec_path.read_text(encoding="utf-8").replace("modules:\n  - ff\n  - decoder", "modules:\n  - missing_module"),
         encoding="utf-8",
     )
-    spec = load_dau_build_spec(spec_path)
+    spec = BuildSpec.from_file(spec_path).resolve()
 
     with pytest.raises(Exception) as exc_info:
         generate_dau_build_artifacts(spec, output_root=tmp_path / "out")
@@ -379,7 +378,7 @@ def test_build_spec_consumes_yaml_artifact_manifest_inputs(tmp_path: Path) -> No
         encoding="utf-8",
     )
 
-    spec = load_dau_build_spec(spec_path)
+    spec = BuildSpec.from_file(spec_path).resolve()
     artifacts = write_dau_build_artifacts(spec, output_root=tmp_path / "out")
     artifact_manifest = load_artifact_manifest(artifacts.artifact_manifest_path, validate_paths=True, root=tmp_path / "out")
 
@@ -445,7 +444,7 @@ def test_build_spec_reports_manifest_inputs_without_hdl(tmp_path: Path) -> None:
     )
 
     with pytest.raises(Exception) as exc_info:
-        load_dau_build_spec(spec_path)
+        BuildSpec.from_file(spec_path).resolve()
 
     assert exc_info.type.__name__ == "DauBuildSpecError"
     assert "artifact manifest input(s) do not provide HDL source artifacts" in str(exc_info.value)

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -239,7 +239,7 @@ def test_public_build_docs_and_tests_do_not_name_internal_hardware_hosts() -> No
 
 
 def test_execute_step_validates_required_overrides(tmp_path: Path) -> None:
-    with pytest.raises(BuildStepError, match="missing required override"):
+    with pytest.raises(BuildStepError, match="a spec is required"):
         execute_override_step(("step=inspect",))
 
 

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -13,6 +13,21 @@ _CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
 _SV_DIR = (Path(__file__).parent / ".." / "sv").resolve()
 
 
+def test_spec_hydra_group_composes_a_buildspec() -> None:
+    # the packaged `spec=identity` group composes a BuildSpec into model.spec
+    # — the Hydra-native replacement for a hand-passed spec_path
+    result = base_load_config(
+        root_config_dir=str(_CONFIG_DIR),
+        root_config_name="base",
+        overrides=["step=inspect", "spec=identity"],
+        basepath=str(_CONFIG_DIR),
+        debug=False,
+    )
+    output = cfg_run(result.cfg)
+    assert output.step == "inspect"
+    assert "name=identity-pipeline" in output.message
+
+
 def test_packaged_task_and_step_config_targets_follow_callable_registries() -> None:
     assert _config_group_names("task") == tuple(sorted(TASK_MODEL_TYPES))
     assert _config_group_names("step") == tuple(sorted(STEP_MODEL_TYPES))
@@ -83,6 +98,7 @@ def test_public_override_dispatch_runs_packaged_task_configs(monkeypatch) -> Non
     assert captured["request_kind"] == "task"
     assert captured["request_name"] == "simulate"
     assert captured["model_values"] == {
+        "spec": None,
         "spec_path": "examples/identity/dau-build.yaml",
         "module": "dau_identity_top",
         "simulator": "svparser",

--- a/dau_build/tests/test_examples.py
+++ b/dau_build/tests/test_examples.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from dau_build.build_spec import generate_dau_build_artifacts, load_dau_build_spec
+from dau_build.build_spec import BuildSpec, generate_dau_build_artifacts
 from dau_build.packaging import artifact_modules, load_artifact_manifest
 
 _EXAMPLE_DIR = Path(__file__).parents[2] / "examples" / "identity"
 
 
 def test_identity_example_build_spec_loads_and_generates_artifacts(tmp_path: Path) -> None:
-    spec = load_dau_build_spec(_EXAMPLE_DIR / "dau-build.yaml")
+    spec = BuildSpec.from_file(_EXAMPLE_DIR / "dau-build.yaml").resolve()
     artifacts = generate_dau_build_artifacts(spec, output_root=tmp_path / "out")
 
     assert spec.name == "identity-pipeline"

--- a/dau_build/tests/test_simulate_profile_task.py
+++ b/dau_build/tests/test_simulate_profile_task.py
@@ -24,7 +24,7 @@ def test_profile_only_simulate_runs(tmp_path):
 
 
 def test_simulate_without_spec_or_profile_fails_typed(tmp_path):
-    with pytest.raises(BuildStepError, match="requires spec_path and module"):
+    with pytest.raises(BuildStepError, match="requires a spec"):
         execute_override_task(["task=simulate", "simulator=verilator"])
 
 


### PR DESCRIPTION
Completes the config-composition phase — configuration composes through Hydra, not hand-assembled in Python ([GUIDELINES] Config Rules, `ccflow-etl` exemplar).

- **New `spec=` Hydra config group**: `config/spec/identity.yaml` (`# @package spec`) composes a `BuildSpec` into the task/step models via `spec: ${oc.select:spec,null}`; `base.yaml` gains `optional spec: null`. **`dau-build step=inspect spec=identity` works** — pinned by test.
- **`load_dau_build_spec` deleted** → `BuildSpec.from_file(path)` classmethod (file input for CLI/tests; the `spec=` group composes the same `BuildSpec`; `base_dir` resolves sources).
- **`resolve_build_config` free function deleted** → `ResolvedBuildConfig.from_spec` classmethod.
- Tasks accept a composed `spec` (typed `Any` to keep `build_steps` import light per F51 — it's a `BuildSpec` at runtime) or `spec_path` file input; `spec_base_dir`/`spec_label` handle both.

**Verification:** `grep` confirms zero `@dataclass` and no `resolve_build_config`/`load_dau_build_spec`/`ConfigOverrideModel` anywhere in dau-build source. Full suite 214 green; byte-identity Tcl/artifact goldens unchanged.