### PR TITLE
Register config on the Hydra search path; add nested board/backend/design groups

### DIFF
--- a/dau_build/cli.py
+++ b/dau_build/cli.py
@@ -63,5 +63,30 @@ def explain(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _hydra_run(cfg):
+    from ccflow.utils.hydra import cfg_run
+
+    outcome = cfg_run(cfg)
+    if isinstance(outcome, BuildStepResult):
+        print(outcome.message)
+    elif outcome is not None:
+        print(outcome)
+    return outcome
+
+
+def run(argv: list[str] | None = None):
+    """The single ccflow-etl-style CLI: a Hydra app over ``dau_build/config``
+    with the search path active, so packaged and search-path-registered
+    config groups compose uniformly:
+
+        dau-build-run task=tasks/... board=boards/dau/dpv1 backend=backends/vivado
+
+    Search-path packages (their own ``hydra.lernaplugins`` entry point) add
+    boards/backends/designs/tasks without editing dau-build."""
+    import hydra
+
+    return hydra.main(config_path="config", config_name="base", version_base=None)(_hydra_run)()
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/dau_build/config/backend/backends/none.yaml
+++ b/dau_build/config/backend/backends/none.yaml
@@ -1,0 +1,6 @@
+# @package backend
+
+# backend=backends/none (dry-run, no vendor toolchain)
+_target_: dau_build.build_config.BackendConfig
+name: none
+invocation: dry-run

--- a/dau_build/config/backend/backends/vivado.yaml
+++ b/dau_build/config/backend/backends/vivado.yaml
@@ -1,0 +1,6 @@
+# @package backend
+
+# backend=backends/vivado
+_target_: dau_build.build_config.BackendConfig
+name: vivado
+invocation: standard

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -5,7 +5,10 @@ defaults:
   - optional task: null
   - optional step: null
   - optional platform: null
+  - optional board: null
+  - optional backend: null
   - optional spec: null
+  - optional design: null
   - callable: callable
 
 context: {}

--- a/dau_build/config/board/boards/dau/dpv1.yaml
+++ b/dau_build/config/board/boards/dau/dpv1.yaml
@@ -1,0 +1,8 @@
+# @package board
+
+# board=boards/dau/dpv1 — the dpv1 board's build-config view. Boards live
+# under boards/<vendor>/<board>; drop your own via a search-path package.
+_target_: dau_build.build_config.BoardConfig
+name: dpv1
+platform: vivado-xdma
+shell: xdma-ddr

--- a/dau_build/config/design/designs/README.md
+++ b/dau_build/config/design/designs/README.md
@@ -1,0 +1,9 @@
+# design config group
+
+`design=designs/<category>/<name>` selects a design — an assortment of tiles
+to synthesize (e.g. `designs/custom/aggregator_heavy`). The tile-composition
+models are private (dau/dau-core own `ScanCompositionSpec`); dau (private)
+registers its own `design/` configs on the search path via its own
+`hydra.lernaplugins` entry point, extending this generic build framework
+without dau-build depending on the private core. This directory is the
+public scaffold for that extension point.

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -371,7 +371,10 @@ def test_package_scripts_stay_on_hydra_style_dau_build_entrypoints() -> None:
         "dau-build-steps": "dau_build.build_spec:main_callable_steps",
         "dau-build-cfg": "dau_build.cli:main",
         "dau-build-cfg-explain": "dau_build.cli:explain",
+        "dau-build-run": "dau_build.cli:run",
     }
+    # the config tree is registered on the Hydra search path for extension
+    assert pyproject["project"]["entry-points"]["hydra.lernaplugins"]["dau-build"] == "pkg:dau_build.config"
 
 
 def _write_spec(tmp_path: Path) -> Path:

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -178,3 +178,27 @@ def _write_spec(tmp_path: Path) -> Path:
         encoding="utf-8",
     )
     return spec_path
+
+
+def test_nested_board_and_backend_config_groups_compose() -> None:
+    # path-style group selection: board=boards/dau/dpv1 backend=backends/vivado
+    from hydra import compose, initialize_config_module
+    from hydra.utils import instantiate
+
+    from dau_build.build_config import BackendConfig, BoardConfig
+
+    with initialize_config_module(config_module="dau_build.config", version_base=None):
+        cfg = compose(config_name="base", overrides=["board=boards/dau/dpv1", "backend=backends/vivado"])
+    board = instantiate(cfg.board)
+    backend = instantiate(cfg.backend)
+    assert isinstance(board, BoardConfig) and board.name == "dpv1" and board.platform == "vivado-xdma"
+    assert isinstance(backend, BackendConfig) and backend.name == "vivado"
+
+
+def test_dau_build_registers_a_hydra_searchpath_entry_point() -> None:
+    # the config tree is on the Hydra search path (lerna bridge) so packages
+    # and users can extend it; dau-build must register itself
+    from importlib.metadata import entry_points
+
+    registered = {ep.name: ep.value for ep in entry_points(group="hydra.lernaplugins")}
+    assert registered.get("dau-build") == "pkg:dau_build.config"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,15 @@ dau-build = "dau_build.build_spec:main"
 dau-build-steps = "dau_build.build_spec:main_callable_steps"
 dau-build-cfg = "dau_build.cli:main"
 dau-build-cfg-explain = "dau_build.cli:explain"
+dau-build-run = "dau_build.cli:run"
+
+# Register dau-build's config tree on the Hydra search path (via the lerna
+# bridge). Its config groups become discoverable to the CLI and to any other
+# package/user that composes with the search path — the extension mechanism:
+# a package registers its own `pkg:<name>.config` to add boards, backends,
+# designs, or tasks without touching dau-build.
+[project.entry-points."hydra.lernaplugins"]
+dau-build = "pkg:dau_build.config"
 
 [project.urls]
 Repository = "https://github.com/dau-dev/dau-build"


### PR DESCRIPTION
First step toward the ccflow-etl config-group pattern — dau-build's config becomes discoverable and user-extensible (the `calendar=/calendars/exchange/NYSE` idea, applied to boards/backends/designs/tasks).

- **SearchPathPlugin entry point**: `[project.entry-points."hydra.lernaplugins"] dau-build = "pkg:dau_build.config"` puts the config tree on the Hydra search path (via the lerna bridge). Any package or user registers its own `pkg:<name>.config` to add config groups **without editing dau-build** — the same mechanism ccflow-etl/finance-etl use.
- **Nested path-style groups**: `board=boards/dau/dpv1` and `backend=backends/vivado` (+ `backends/none`) compose `BoardConfig`/`BackendConfig`. `design/designs/` is the public scaffold for `design=designs/<cat>/<name>` tile assortments — the private `dau` package will register its own `design/` configs (which need `ScanCompositionSpec`, private) via its own search-path entry point, so the public framework never depends on the private core.
- **Single Hydra CLI**: `dau-build-run` (`dau_build.cli:run`) is a `hydra.main` app over the config tree with the search path active — the ccflow-etl-style front door alongside the existing `dau-build-cfg`.

Tests: nested `board=`/`backend=` compose to their models; the entry point is registered. New config dirs ship in the sdist. Full suite 216 green.

**Follow-ups** (noted in the roadmap): nest the existing `platform`/`spec`/`task`/`step` groups to the same path style; wire composed `board=`/`backend=` into the task's resolved config (they currently derive from the spec); the `dau`-side `design=` tile-composition group.