### PR TITLE
Wire composed board=/backend= groups into the task resolved config

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -48,16 +48,23 @@ class ResolvedBuildConfig(BaseModel):
     memory: MemoryConfig
 
     @classmethod
-    def from_spec(cls, spec: DauBuildSpec, *, backend_name: str | None = None) -> ResolvedBuildConfig:
+    def from_spec(
+        cls,
+        spec: DauBuildSpec,
+        *,
+        board: BoardConfig | None = None,
+        backend: BackendConfig | None = None,
+        backend_name: str | None = None,
+    ) -> ResolvedBuildConfig:
         """The build config as a view over the spec. Board, driver,
-        operators, and memory derive from the spec directly (Hydra field
-        overrides on the composed spec are how a user changes them — no
-        bespoke override dict). ``backend_name`` selects the synthesis
-        engine."""
+        operators, and memory derive from the spec directly. A composed
+        ``board=``/``backend=`` Hydra group wins over the spec-derived
+        default when provided; ``backend_name`` (e.g. a task's synthesis
+        engine) selects the backend when no ``backend=`` group is given."""
         return cls(
             spec=spec,
-            board=BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
-            backend=BackendConfig(name=backend_name or spec.backend, invocation="dry-run"),
+            board=board or BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
+            backend=backend or BackendConfig(name=backend_name or spec.backend, invocation="dry-run"),
             driver=DriverConfig(os="host", transport="xdma"),
             operators=OperatorConfig(set_name="spec", names=spec.operators),
             memory=MemoryConfig(),

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -42,11 +42,11 @@ def _build_spec_api():
     return build_spec
 
 
-def _resolve_build_config(spec, *, backend_name=None):
+def _resolve_build_config(spec, *, board=None, backend=None, backend_name=None):
     """Deferred for the same reason: build_config imports build_spec."""
     from dau_build.build_config import ResolvedBuildConfig
 
-    return ResolvedBuildConfig.from_spec(spec, backend_name=backend_name)
+    return ResolvedBuildConfig.from_spec(spec, board=board, backend=backend, backend_name=backend_name)
 
 
 class BuildStepError(ValueError):
@@ -75,10 +75,17 @@ class BuildCallableModel(CallableModel):
 
 class SpecPathModel(BuildCallableModel):
     # `spec` is composed by the Hydra `spec=` group (a BuildSpec); `spec_path`
-    # is file input for the CLI/tests. Typed Any, not BuildSpec, so importing
+    # is file input for the CLI/tests. `board`/`backend` are composed by the
+    # `board=`/`backend=` groups (BoardConfig/BackendConfig) and win over the
+    # spec-derived defaults. Typed Any, not the models, so importing
     # build_steps stays light — build_spec pulls the SV-parser stack (F51).
     spec: Any = None
     spec_path: Path | None = None
+    board: Any = None
+    backend: Any = None
+
+    def _resolved(self, spec, *, backend_name=None):
+        return _resolve_build_config(spec, board=self.board, backend=self.backend, backend_name=backend_name)
 
     def load_spec(self):
         build_spec = self.spec
@@ -146,7 +153,7 @@ class WriteStep(SpecPathModel):
 class ResolvedConfigStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        resolved = _resolve_build_config(self.load_spec())
+        resolved = self._resolved(self.load_spec())
         return BuildStepResult(step="resolved-config", message=resolved.to_text())
 
 
@@ -169,7 +176,7 @@ class SimulateStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
-        _resolve_build_config(spec)
+        self._resolved(spec)
         _build_spec_api().generate_dau_build_artifacts(spec, output_root=self.output_root or self.spec_base_dir / ".dau-build-sim")
         if self.simulate_engine == "verilator":
             return self._run_verilator(spec)
@@ -244,7 +251,7 @@ class SynthesisStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
-        resolved = _resolve_build_config(spec)
+        resolved = self._resolved(spec)
         artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
         return BuildStepResult(
             step="synthesis",
@@ -259,7 +266,7 @@ class ExplainStep(SpecPathModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec()
-        resolved = _resolve_build_config(spec)
+        resolved = self._resolved(spec)
         return BuildStepResult(
             step="explain",
             message="\n".join(
@@ -305,7 +312,7 @@ class SimulateTask(ModuleSelectionModel):
         spec = self.load_spec_and_validate_module()
         output_root = self.output_root or self.spec_base_dir / ".dau-build-sim"
         if self.simulator in {"svparser", "cocotb"}:
-            _resolve_build_config(spec)
+            self._resolved(spec)
             _build_spec_api().generate_dau_build_artifacts(spec, output_root=output_root)
             return BuildStepResult(
                 step="simulate",
@@ -372,7 +379,7 @@ class SynthesizeTask(ModuleSelectionModel):
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec_and_validate_module()
-        resolved = _resolve_build_config(spec, backend_name=self.engine)
+        resolved = self._resolved(spec, backend_name=self.engine)
         artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
         backend_artifacts = _write_vivado_backend_handoff(
             spec,

--- a/dau_build/config/step/steps/explain.yaml
+++ b/dau_build/config/step/steps/explain.yaml
@@ -3,3 +3,5 @@
 _target_: dau_build.build_steps.ExplainStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}

--- a/dau_build/config/step/steps/generate.yaml
+++ b/dau_build/config/step/steps/generate.yaml
@@ -3,4 +3,6 @@
 _target_: dau_build.build_steps.GenerateStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}
 output_root: ???

--- a/dau_build/config/step/steps/inspect.yaml
+++ b/dau_build/config/step/steps/inspect.yaml
@@ -3,3 +3,5 @@
 _target_: dau_build.build_steps.InspectStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}

--- a/dau_build/config/step/steps/resolved-config.yaml
+++ b/dau_build/config/step/steps/resolved-config.yaml
@@ -3,3 +3,5 @@
 _target_: dau_build.build_steps.ResolvedConfigStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}

--- a/dau_build/config/step/steps/simulate.yaml
+++ b/dau_build/config/step/steps/simulate.yaml
@@ -3,6 +3,8 @@
 _target_: dau_build.build_steps.SimulateStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}
 output_root: null
 simulate_engine: svparser
 simulate_profile: null

--- a/dau_build/config/step/steps/synthesis.yaml
+++ b/dau_build/config/step/steps/synthesis.yaml
@@ -3,4 +3,6 @@
 _target_: dau_build.build_steps.SynthesisStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}
 output_root: ???

--- a/dau_build/config/step/steps/validate.yaml
+++ b/dau_build/config/step/steps/validate.yaml
@@ -3,3 +3,5 @@
 _target_: dau_build.build_steps.ValidateStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}

--- a/dau_build/config/step/steps/write.yaml
+++ b/dau_build/config/step/steps/write.yaml
@@ -3,4 +3,6 @@
 _target_: dau_build.build_steps.WriteStep
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}
 output_root: ???

--- a/dau_build/config/task/tasks/build/synthesize.yaml
+++ b/dau_build/config/task/tasks/build/synthesize.yaml
@@ -3,6 +3,8 @@
 _target_: dau_build.build_steps.SynthesizeTask
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}
 module: ???
 engine: vivado
 output_root: ???

--- a/dau_build/config/task/tasks/sim/simulate.yaml
+++ b/dau_build/config/task/tasks/sim/simulate.yaml
@@ -3,6 +3,8 @@
 _target_: dau_build.build_steps.SimulateTask
 spec_path: null
 spec: ${oc.select:spec,null}
+board: ${oc.select:board,null}
+backend: ${oc.select:backend,null}
 module: ???
 simulator: svparser
 output_root: null

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -100,6 +100,8 @@ def test_public_override_dispatch_runs_packaged_task_configs(monkeypatch) -> Non
     assert captured["model_values"] == {
         "spec": None,
         "spec_path": "examples/identity/dau-build.yaml",
+        "board": None,
+        "backend": None,
         "module": "dau_identity_top",
         "simulator": "svparser",
         "output_root": None,
@@ -203,3 +205,24 @@ def test_dau_build_registers_a_hydra_searchpath_entry_point() -> None:
 
     registered = {ep.name: ep.value for ep in entry_points(group="hydra.lernaplugins")}
     assert registered.get("dau-build") == "pkg:dau_build.config"
+
+
+def test_board_and_backend_groups_override_spec_derived_resolved_config() -> None:
+    # board=/backend= compose into the task and win over the spec-derived view
+    spec = "examples/identity/dau-build.yaml"
+    base = ["step=steps/resolved-config", f"model.spec_path={spec}"]
+    derived = cfg_run(
+        base_load_config(root_config_dir=str(_CONFIG_DIR), root_config_name="base", overrides=base, basepath=str(_CONFIG_DIR), debug=False).cfg
+    )
+    composed = cfg_run(
+        base_load_config(
+            root_config_dir=str(_CONFIG_DIR),
+            root_config_name="base",
+            overrides=[*base, "board=boards/dau/dpv1", "backend=backends/vivado"],
+            basepath=str(_CONFIG_DIR),
+            debug=False,
+        ).cfg
+    )
+    assert "board\tname=vivado-xdma" in derived.message  # spec-derived: board name = platform
+    assert "board\tname=dpv1" in composed.message  # composed board wins
+    assert "backend\tname=vivado invocation=standard" in composed.message  # composed backend wins


### PR DESCRIPTION
Closes the dau-build follow-up from the nesting work: the `board=`/`backend=` Hydra groups now actually influence a build (they composed to models before, but tasks derived board/backend from the spec).

- `SpecPathModel` gains composed `board`/`backend` fields (typed `Any` to keep `build_steps` import light per F51 — `BoardConfig`/`BackendConfig` at runtime); the spec-based task/step yamls thread them via `${oc.select:board,null}` / `${oc.select:backend,null}`.
- `ResolvedBuildConfig.from_spec(spec, *, board=None, backend=None, backend_name=None)` prefers a composed group over the spec-derived default; `backend_name` (a task's synthesis `engine`) still selects the backend when no `backend=` group is given.
- **Verified**: `board=boards/dau/dpv1 backend=backends/vivado` → `board name=dpv1`, `backend invocation=standard`; without the groups the spec-derived view is byte-for-byte unchanged. Toolchain re-validated end-to-end (synthesize/resolved-config/hardware-plan/stage), full suite 217 green, check-dist clean.

Remaining follow-ups live in the private packages: the `dau`-side `design=designs/<cat>/<name>` tile group via its own search-path entry point, and threading `spec=` through `dau/dpv1.py`'s shell requests.