### PR TITLE
Restructure documentation using Diataxis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,133 +9,31 @@ Build tools for dau
 
 ## Overview
 
-`dau-build` consumes declarative YAML build specs and YAML artifact bundles. Artifact bundles are provided by `artlink` and use the `artlink.manifest/v0` schema: they can carry HDL/SystemVerilog sources, Python reference sources, constraints, bitstreams, and other metadata/binary assets. HDL module ownership is expressed with `provides: {kind: hdl-module, name: ...}` capabilities. The reusable bundle layer validates required roles, source languages, duplicate module providers, missing files, and HDL availability before a build spec reaches backend tooling.
+`dau-build` turns declarative FPGA build specs into concrete artifacts: generated SystemVerilog, `artlink.manifest/v0` artifact bundles, backend handoff manifests, Vivado Tcl, and ordered hardware command plans. Every operation is a typed `ccflow.CallableModel` composed from a Hydra config tree in `dau_build/config`, so the whole pipeline composes, inspects, and tests on a development machine, with the privileged steps (Vivado, JTAG, PCIe) gated behind an explicit `execute=true`.
 
-Use `dau-build inspect --spec <spec.yaml>` to see the resolved package inputs. When a spec references `artifact_manifests`, inspect prints each source, metadata file, and binary asset with its originating manifest so backend handoff issues can be debugged before invoking a toolchain.
+Vivado is the only synthesis backend today; the config plumbing is backend-agnostic so others (e.g. yosys/nextpnr) can be added later.
 
-The checked-in identity example shows the current portable handoff shape:
+## Quickstart
+
+Build the checked-in identity example — no board or vendor tools required:
 
 ```bash
-dau-build inspect --spec examples/identity/dau-build.yaml
-dau-build build --spec examples/identity/dau-build.yaml --out outputs/identity
+dau-build inspect  --spec examples/identity/dau-build.yaml
+dau-build build    --spec examples/identity/dau-build.yaml --out outputs/identity
 dau-build validate --manifest outputs/identity/dau-identity.manifest --root outputs/identity
+dau-build task=tasks/sim/simulate module=dau_identity_top spec_path=examples/identity/dau-build.yaml
 ```
 
-The public callable task surface is available directly through `dau-build`. It accepts Hydra-style `key=value` overrides and dispatches typed `ccflow.CallableModel` requests for simulation, synthesis handoff, flash planning, and smoke-test planning:
+Task and step names are path-style, mirroring the config tree (`task=tasks/sim/simulate`, `step=steps/inspect`).
 
-```bash
-dau-build task=simulate simulator=cocotb module=dau_identity_top spec_path=examples/identity/dau-build.yaml
-dau-build task=simulate simulator=verilator module=dau_int32_aggregation_tile spec_path=examples/identity/dau-build.yaml profile=dau-int32-aggregation-tile output_root=outputs/sim
-dau-build task=synthesize engine=vivado module=dau_identity_top spec_path=examples/identity/dau-build.yaml output_root=outputs/identity
-dau-build task=build-vivado-artifacts work_root=outputs/identity/vivado artifact_stem=dau-identity execute=true
-dau-build task=flash manifest_path=outputs/identity/vivado/dau-identity.manifest
-dau-build task=smoke-test test=aggregation manifest_path=outputs/identity/vivado/dau-identity.manifest
-dau-build task=flash tool=openFPGAloader bitstream=outputs/vivado/project.runs/impl_1/Top_wrapper.bit
-dau-build task=smoke-test test=identity
-```
+## Documentation
 
-The `simulate` task validates the selected module against the DAU build spec for `simulator=cocotb` and `simulator=svparser`. Pass `simulator=verilator` with either a named DAU-owned `profile` or raw `testbench_path=...` and `top_module=...`, plus an optional `expect_stdout=...` marker, to compile and run a Verilator testbench through the generic `dau-sim` Verilator adapter. Simulation profiles are carried as `artlink.manifest/v0` metadata artifacts with role `simulation-profile`; pass `profile_manifest=...` or `simulate.profile_manifest=...` to add project-local profile manifests.
+Full documentation is in [docs/](docs/index.md):
 
-The packaged Hydra/ccflow configs live in `dau_build/config`, following the `ccflow-etl` model:
-
-- `base.yaml` selects `task=...` or `step=...`, sets `callable: /model`, and configures ccflow's graph evaluator.
-- `task/*.yaml` constructs the public task `ccflow.CallableModel`s.
-- `step/*.yaml` constructs the lower-level step `ccflow.CallableModel`s.
-- `callable/callable.yaml` is the small ccflow registry pointer.
-
-Select tasks directly with overrides such as `task=simulate`, `task=synthesize`, or `step=validate`, then override the task fields. The public `dau-build task=...` and `dau-build-steps step=...` dispatchers compose these packaged configs before running the selected `ccflow.CallableModel`. Composite tasks such as `task=build-vivado-artifacts` expose dependencies through `Flow.deps`, so ccflow's `GraphEvaluator` owns the ordering while `MemoryCacheEvaluator` avoids duplicate in-process execution. These configs only instantiate the classes registered in `TASK_MODEL_TYPES` and `STEP_MODEL_TYPES`; artifact/profile data stays in `dau_build/profiles` as artlink manifests rather than being duplicated into task configs.
-
-The `synthesize` task writes the local DAU generated top, DAU manifest, `artlink.manifest/v0` artifact bundle, and `vivado/<artifact-stem>.manifest` backend handoff. The backend manifest records the selected module, generated top, HDL source set, command plan, expected bitstream path, register/status contract, staging buffers, and operator metadata. It still does not invoke Vivado directly. Run `task=build-vivado-artifacts execute=true` on the Vivado host to move the backend manifest from `build_status=planned` to `build_status=built` after the bitstream, resource report, timing report, and Vivado log exist. `task=flash` and `task=smoke-test` require `build_status=built` when they consume a manifest; they currently produce safe plans and validation output rather than touching hardware by default.
-
-For lower-level development, `dau-build-steps step=...` exposes artifact operations such as `inspect`, `validate`, `generate`, `write`, `resolved-config`, and `explain`. Those operations are also `ccflow.CallableModel`s; user-facing workflows should use `dau-build task=...`.
-
-The packaged DAU Verilator profile manifest is `dau_build/profiles/dau-core-verilator-profiles.artifacts.yaml`. It references packaged HDL benches from `dau_build/profiles/sv` while keeping the workflow as a typed `ccflow.CallableModel` request.
-
-Currently available packaged DAU Verilator profiles are:
-
-- `dau-int32-aggregation-tile`
-- `dau-int32-arrow-lite-stream-aggregation`
-- `dau-int32-stream-aggregation`
-
-`examples/identity/package.artifacts.yaml` is the reusable input package. `examples/identity/generated/dau-identity.artifacts.yaml` is a portable example of the generated artifact bundle; its paths are relative to the example directory rather than to a developer workstation.
-
-## Vivado Command Plans
-
-`dau-build task=stage-*` owns generated Vivado artifact staging, while `dau-build task=hardware-plan` owns live hardware-session command sequences. By default these tasks print plans without executing privileged commands; pass `execute=true` when running directly on the hardware host. Use `work_root=...` as a generated work directory and `source_shell_root=...` as the read-only shell seed when staging needs the current Vivado shell.
-
-Useful plans:
-
-```bash
-dau-build task=stage-shell \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado
-dau-build task=hardware-plan plan=local-build-and-program \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  dau_utils_root=/path/to/dau-utils
-dau-build task=hardware-plan plan=validate-bitstream \
-  work_root=outputs/vivado \
-  bitstream=/path/to/Top_wrapper.bit \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  dau_utils_root=/path/to/dau-utils
-dau-build task=stage-vivado-overlay \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado \
-  dau_core_root=/path/to/dau-core \
-  dau_artifact_bundle=outputs/dau-identity/dau-identity.artifacts.yaml \
-  artifact_stem=dau-vivado \
-  backend_platform=vivado-xdma \
-  backend_shell=xdma-shell \
-  operator=identity
-dau-build task=stage-vivado-project \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  dau_utils_root=/path/to/dau-utils \
-  artifact_stem=dau-vivado
-dau-build task=build-vivado-artifacts \
-  work_root=outputs/vivado \
-  artifact_stem=dau-vivado \
-  execute=true
-dau-build task=validate-vivado-artifacts \
-  work_root=outputs/vivado \
-  project_manifest_path=dau-vivado.project
-dau-build task=hardware-plan plan=flash \
-  work_root=outputs/vivado \
-  dau_utils_root=/path/to/dau-utils
-dau-build task=hardware-plan plan=recovery work_root=outputs/vivado
-```
-
-## Hardware Host Workflow
-
-Treat Vivado-capable machines as normal Linux hardware hosts. From your development machine, SSH to the host, rsync the package checkouts or generated artifacts you need, install the DAU packages with pip on that host, and run the same local CLIs there. The `dau-build` CLI roadmap is focused on typed build/config steps, not host orchestration wrappers.
-
-```bash
-ssh root@primary-linux-host "mkdir -p /srv/dau"
-rsync -a --delete /path/to/dau-core/ root@primary-linux-host:/srv/dau/dau-core/
-rsync -a --delete /path/to/dau-driver/ root@primary-linux-host:/srv/dau/dau-driver/
-rsync -a --delete /path/to/dau-build/ root@primary-linux-host:/srv/dau/dau-build/
-ssh root@primary-linux-host "cd /srv/dau/dau-build && python -m pip install -e ../dau-core -e ../dau-driver -e ."
-ssh root@primary-linux-host "cd /srv/dau/dau-build && dau-build inspect --spec examples/identity/dau-build.yaml"
-```
-
-The shell staging path is `stage-shell`. It copies a read-only Vivado shell seed into a generated work directory with `rsync --delete --delete-excluded`, excluding Vivado run/cache/log outputs. This lets `dau-build` mutate and build `outputs/vivado` while keeping the seed checkout as evidence/fixtures rather than the normal build workspace.
-
-The hardware-session path that does not invoke Vivado is `validate-bitstream`. It detects the JTAG chain, removes any stale endpoint, programs the selected volatile bitstream, performs the ordered bridge/global PCIe rescan, retries the endpoint check with additional ordered rescans when needed, runs the dependency-free hardware identity smoke through `dau-driver`, and releases runtime PM. The XDMA kernel module must already be loaded; for the Vivado shell checkout that module lives under `sw/xdma/xdma.ko` in either the read-only seed or generated work directory.
-
-The backend dry-run path is `stage-vivado-overlay`. It can first stage the shell seed into the generated work directory, then writes the generated overlay Tcl, guarded build Tcl, structured backend manifest preview, and Vivado command plan there without invoking Vivado or touching hardware. The manifest is produced from a typed backend request that records the platform, shell, artifact stem, register map version, stream protocol version, operator set, DAU HDL root, final manifest/plan/bitstream paths, resource/timing report paths, Vivado log path, and Vivado command settings. Use `task=validate-vivado-artifacts` immediately after staging to check that the manifest, overlay Tcl, build Tcl, command plan, and planned output paths agree without requiring Xilinx tools. The `task=build-vivado-artifacts` workflow runs only the generated overlay/build Vivado command and then validates the artifact bundle; it does not program JTAG, rescan PCIe, or run smoke tests. After the generated build Tcl runs, it appends `build_status=built` and the bitstream/report/log paths; validation then requires those files to exist.
-
-For DAU-native backend handoff, pass `dau_artifact_bundle=...` to `task=stage-vivado-overlay` or `task=stage-vivado-project`. The Vivado backend loads and validates the YAML bundle, records the generated top and HDL source set in the backend manifest, and adds those HDL sources to the generated overlay Tcl before the shell-specific bridge is applied. This is the first handoff step from DAU build artifacts into the Vivado/XDMA adapter.
-
-For a local wrapper that already runs `vivado -mode batch -source`, pass `vivado_invocation=source-only` so generated command plans invoke the wrapper with only a Tcl source path. If that wrapper launches Vivado in a container that mounts the current directory, also pass `vivado_mount_root=/path/to/dau`; the backend will emit small driver Tcl files, launch the wrapper from the mounted root, and render DAU HDL and bundle source paths relative to the generated work directory.
-
-The structured project dry-run path is `task=stage-vivado-project`. It stages the read-only shell seed into the generated work directory, writes `<artifact-stem>.project` to record the shell seed, work directory, DAU checkout roots, XDMA module path, backend artifacts, Vivado settings, and the high-level stage/build/validate commands, then writes the same backend overlay/build/manifest/plan artifacts as `task=stage-vivado-overlay`. The generated stage/build/validate commands point at `task=stage-vivado-overlay`, `task=build-vivado-artifacts`, and `task=validate-vivado-artifacts`. Pass `project_manifest_path=<artifact-stem>.project` to validation to include the project manifest schema, backend cross-references, and generated command contracts in the no-Xilinx check.
-
-The `local-build-and-program` plan uses the explicitly named `dau_build.vivado_backend` module. That backend stages a generated `scripts/dau_overlay.tcl` in the generated Vivado work directory, imports the DAU identity register HDL and AXI-Lite wrapper from `dau-core`, replaces the scratch AXI GPIO identity endpoint, maps the DAU window at `xdma_0/M_AXI_LITE + 0x1000`, regenerates and pins `Top_wrapper` in the generated work directory, resets the DAU module-ref out-of-context synthesis run, writes `dau-vivado.manifest`, then runs a generated `scripts/dau_build.tcl` that keeps the existing synthesis/implementation flow while guarding stale hard-coded XDMA lane cell paths from the shell seed. Treat this as the current Vivado backend for bring-up, not the final structured DAU build generator.
+- **Tutorial** — [Build the identity example](docs/tutorial/first-build.md).
+- **How-to** — [Run a build end to end](docs/how-to/run-a-build.md) · [Program a bitstream on dpv1](docs/how-to/program-hardware.md) · [Extend dau-build](docs/how-to/extend-dau-build.md).
+- **Reference** — [Commands](docs/reference/commands.md) · [Config groups](docs/reference/config-groups.md) · [Task and step catalog](docs/reference/tasks-and-steps.md).
+- **Explanation** — [Architecture](docs/explanation/architecture.md): how Hydra composition, ccflow evaluation, and the search-path extension model work, and the current state of backend support.
 
 > [!NOTE]
 > This library was generated using [copier](https://copier.readthedocs.io/en/stable/) from the [Base Python Project Template repository](https://github.com/python-project-templates/base).

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -1,0 +1,165 @@
+# Architecture: how dau-build composes work from Hydra config
+
+This page explains *why* dau-build is built the way it is — declarative specs,
+typed `ccflow` models, and a Hydra config tree — and what that structure buys
+you. It is background reading. For the commands themselves, see the
+[command reference](../reference/commands.md); for step-by-step goals, the
+[how-to guides](../how-to/run-a-build.md).
+
+## The shape of the tool
+
+dau-build turns a declarative description of an FPGA build into concrete
+artifacts: generated SystemVerilog, artifact bundles, backend handoff manifests,
+Tcl scripts, and command plans. Everything the tool does is expressed as a typed
+`ccflow.CallableModel` — a `SimulateTask`, a `SynthesizeTask`, a
+`BuildVivadoArtifactsTask`, and so on — and every one of those models is *built
+from configuration*, not hand-constructed in Python.
+
+That configuration is a Hydra config tree under `dau_build/config`. Running the
+tool is therefore always the same two-phase act: **compose** a config from
+groups and overrides, then **instantiate and run** the model it describes. The
+CLIs are thin front-ends over that one idea.
+
+The reason for this design is that an FPGA build has many axes that vary
+independently — which task, which board, which backend, which spec — and those
+axes are reused across dozens of operations. Encoding each axis as a Hydra config
+group lets any combination compose without a bespoke argument parser per command,
+and lets a downstream package add new options without editing dau-build.
+
+## Config groups are directories
+
+Each subdirectory of `dau_build/config` is a Hydra config group: `task`, `step`,
+`spec`, `board`, `backend`, `platform`, `design`, `callable`. Selecting an option
+is an override `<group>=<option>`, where the option is the file's path relative to
+the group directory. A file at `config/task/tasks/sim/simulate.yaml` is selected
+as `task=tasks/sim/simulate`. The names are path-style because the groups nest;
+short aliases are deliberately not supported, so a name always says where its
+file lives.
+
+Each option file opens with a `# @package <key>` directive that decides where its
+content lands in the composed config. Tasks and steps declare `# @package model`,
+so a selected task *becomes* the `model` that gets run. Boards, backends, specs,
+and platforms declare their own singular key. The base config
+`config/base.yaml` lists every group as `optional … null`, so nothing is selected
+until you override it, and a run picks exactly one of `task=` or `step=` to fill
+`model`. See the [config group reference](../reference/config-groups.md) for the
+full list.
+
+Because groups are just directories and options are just files, the config tree
+*is* the catalog. Adding a task is adding a file; the name→class registry is
+derived by globbing the tree (`_model_types_from_config_group`), so there is no
+second place to register it.
+
+## Why there are two override syntaxes
+
+Two families of CLI exist because two audiences want different things.
+
+The flat CLIs (`dau-build`, `dau-build-steps`) take `task=<path> field=value` with
+no prefix — the terse form for driving a single task from a shell or a Makefile.
+The Hydra CLIs (`dau-build-cfg`, `dau-build-cfg-explain`, `dau-build-run`) take
+`task=<path> model.<field>=value` and also accept group selections like
+`spec=specs/identity board=boards/dau/dpv1 backend=backends/vivado`. The `model.`
+prefix is not decoration: on these CLIs the task is composed *into* the `model`
+key, so its fields are addressed under `model.`. Both families converge on the
+same registry execution — the flat form is sugar over the composed form.
+
+`dau-build-run` is the fullest expression of the idea: a Hydra `hydra.main`
+application, so it inherits Hydra's own conventions (`+group=option` to add a
+group, `-m` multirun) and, crucially, the active search path.
+
+## ccflow owns ordering and caching
+
+A composed `model` is run by ccflow, not by dau-build directly. The `callable`
+group wires a `MultiEvaluator` of a `GraphEvaluator` and a `MemoryCacheEvaluator`.
+Composite tasks declare their prerequisites through `Flow.deps`, and the
+`GraphEvaluator` walks that dependency graph so the pieces run in the right order;
+the `MemoryCacheEvaluator` prevents a shared dependency from executing twice in a
+single process. This is why, for example, `build-vivado-artifacts` can depend on
+staging and validation without dau-build hand-coding the sequence — the ordering
+lives in the model graph, and the evaluator owns it.
+
+## The search path makes the tree extensible
+
+dau-build registers its own config tree on the Hydra search path through a
+`hydra.lernaplugins` entry point (`pkg:dau_build.config`). Any installed package
+can do the same for its own `pkg:<name>.config`, and its groups then compose
+uniformly alongside the packaged ones — new boards, backends, designs, or tasks
+without touching dau-build.
+
+The mechanism is honored by the lerna search-path bridge (`lerna` on PyPI); the
+entry point is inert without it, so a package that relies on cross-package
+composition depends on `lerna` directly. The private `dau` package is the working
+example: it registers `pkg:dau.config`, which adds `task=dpv1-shell`, and with
+`dau` installed `dau-build-run task=dpv1-shell` resolves that task with no
+`--config-dir` overlay. dau-build never imports `dau` — extension flows one way,
+through the search path, which keeps the public tool free of private
+dependencies. See [Extending dau-build](../how-to/extend-dau-build.md) for how to
+do this yourself.
+
+## Plans first, execution on the host
+
+Most build and hardware tasks default to `execute: false` and emit *plans*:
+generated Tcl, backend manifests at `build_status=planned`, staged work
+directories, and ordered command sequences — all without invoking a vendor
+toolchain or touching hardware. Passing `execute=true` runs the privileged action.
+
+This separation is deliberate. It lets the whole pipeline be composed, inspected,
+validated, and tested on a developer machine with no Xilinx tools and no board
+attached, and confines the privileged, irreversible steps (running Vivado,
+programming JTAG, rescanning PCIe) to an explicit opt-in on the machine that
+actually has the hardware. The validators (`validate-vivado-artifacts`) check that
+a plan is internally consistent — manifest, Tcl, command plan, and output paths
+all agree — before anyone spends an hour of synthesis on it.
+
+## Board, platform, and backend are three separate things
+
+These three groups are easy to conflate; they answer different questions.
+
+- **`platform`** (`PlatformDefinition`) is the hardware board as data: the part
+  number, the resource budget, the memory, and the host link — including the
+  full XDMA personality. For dpv1 the personality is the 47 proven bring-up XCI
+  parameters, quoted verbatim and order-preserved so the generated Vivado
+  `CONFIG.*` block is byte-for-byte identical to the known-good core. A hand-picked
+  subset of those parameters leaves the device memory-dead on hardware, which is
+  why the definition insists on carrying all of them exactly. `fits()` checks a
+  design's resource use against this budget.
+- **`board`** (`BoardConfig`) is a small build-config view — `name`, `platform`,
+  `shell` — where `platform` and `shell` here are backend *labels* (e.g.
+  `vivado-xdma`, `xdma-ddr`) threaded into Vivado manifests, not the hardware
+  `PlatformDefinition`.
+- **`backend`** (`BackendConfig`) is the synthesis toolchain, as a label.
+
+They are independent groups, composed together into a task's
+`ResolvedBuildConfig` only where a task needs them. Keeping the hardware truth
+(`platform`) separate from the backend labels (`board`, `backend`) means the same
+physical dpv1 definition can be reused regardless of which backend produced a
+bitstream.
+
+## Backends: Vivado today, others later {#backends}
+
+**Only the Vivado backend is real today.** Understanding the current shape makes
+clear what adding another backend involves.
+
+`BackendConfig` has two fields, `name` and `invocation`, and it is a *label*, not
+a driver. `invocation` (`standard` vs `dry-run`) is surfaced in the resolved
+config as metadata and is not branched on. The `backends/none` option is that
+label with no toolchain behind it — a dry-run. So selecting `backend=backends/...`
+changes what the resolved config *reports*, not what codegen runs.
+
+What actually runs codegen is the synthesis engine. `SynthesizeTask.engine` is a
+`Literal["vivado"]` — it accepts nothing else — and the task unconditionally
+writes the Vivado backend handoff. The real backend implementation lives in
+`vivado_backend.py`, which generates text artifacts (overlay Tcl, build Tcl, a
+key=value manifest, a command plan) and never spawns Vivado itself; that happens
+in the `execute=true` build tasks and in `hardware_plan.py`. There is no dispatch
+table keyed on backend name — the wiring from `engine="vivado"` to the Vivado
+generator is direct.
+
+So the config-group plumbing, the open registry, the `_target_` indirection, and
+the search-path extension are all backend-agnostic and ready; what is missing for,
+say, a yosys/nextpnr flow is a second *implementation*: a backend module
+paralleling `vivado_backend.py`, a widened `engine` literal with real dispatch,
+and its task configs. There is no yosys, nextpnr, or other backend scaffolding in
+the tree today — not a stub, not a config file. That is a deliberate honesty about
+the current state, not an oversight. [Extending dau-build](../how-to/extend-dau-build.md#add-a-synthesis-backend)
+walks through exactly what a new backend requires.

--- a/docs/how-to/extend-dau-build.md
+++ b/docs/how-to/extend-dau-build.md
@@ -1,0 +1,148 @@
+# How to extend dau-build
+
+dau-build is designed to be extended without editing it. Its config tree is on
+the Hydra search path, so an installed package can add its own tasks, steps,
+boards, backends, or platforms, and they compose alongside the packaged ones.
+This guide shows the three things you are most likely to add: a new task from
+your own package, a new board or platform, and a new synthesis backend.
+
+For the concepts behind the search path and the config groups, see
+[the architecture explanation](../explanation/architecture.md). For an ad-hoc
+overlay without packaging, jump to [the last section](#try-it-without-packaging).
+
+## Register your config tree on the search path
+
+The one-time setup: give your package a `config` directory laid out like
+dau-build's (config groups as subdirectories), make it importable, and register
+it on the Hydra search path.
+
+1. Put a Hydra config tree in your package, e.g. `mypkg/config/`, with an
+   `__init__.py` so `mypkg.config` is an importable package (Hydra resolves the
+   `pkg:` search-path entry by importing it).
+
+1. Add the entry point and depend on the search-path bridge in your
+   `pyproject.toml`:
+
+   ```toml
+   dependencies = ["dau-build", "lerna>=2.0.4"]
+
+   [project.entry-points."hydra.lernaplugins"]
+   mypkg = "pkg:mypkg.config"
+   ```
+
+   `lerna` is what honors the `hydra.lernaplugins` entry point; without it the
+   entry point is inert.
+
+Your groups now compose through dau-build's Hydra CLIs. dau-build never imports
+your package — extension flows one way, so your private code can depend on
+dau-build while dau-build stays free of it.
+
+## Add a task
+
+A task is a config file plus the `ccflow.CallableModel` it targets.
+
+1. Write the model as a `ccflow.CallableModel` in your package (e.g.
+   `mypkg.tasks.MyTask`).
+
+1. Add `mypkg/config/task/tasks/<category>/<name>.yaml`:
+
+   ```yaml
+   # @package model
+
+   _target_: mypkg.tasks.MyTask
+   some_field: ???
+   other_field: default
+   ```
+
+   The `# @package model` directive makes the selected task *become* the `model`
+   that runs. dau-build derives its name→class registry by globbing the config
+   tree, so there is nothing else to register — the `_target_` may point at any
+   importable module.
+
+1. Run it through dau-build's Hydra CLI:
+
+   ```bash
+   dau-build-run task=tasks/<category>/<name> model.some_field=value
+   ```
+
+The private `dau` package does exactly this to add `task=dpv1-shell`: with `dau`
+installed, `dau-build-run task=dpv1-shell model.shell=... model.output_root=...`
+resolves a task defined entirely in `dau`, with no `--config-dir` overlay.
+
+## Add a board or platform
+
+Boards and platforms reuse dau-build's existing models, so they are pure config —
+no new Python.
+
+For a board's build-config view, add
+`mypkg/config/board/boards/<vendor>/<board>.yaml`:
+
+```yaml
+# @package board
+
+_target_: dau_build.build_config.BoardConfig
+name: myboard
+platform: my-xdma
+shell: my-shell
+```
+
+For the hardware platform definition (part, resource budget, memory, host link),
+add `mypkg/config/platform/platforms/<vendor>/<board>.yaml` targeting
+`dau_build.platforms.PlatformDefinition`. Select them with
+`board=boards/<vendor>/<board>` and `platform=platforms/<vendor>/<board>`.
+
+## Add a synthesis backend {#add-a-synthesis-backend}
+
+Adding a *real* backend (for example a yosys/nextpnr flow) is more than a config
+file, because today `BackendConfig` is only a label and synthesis codegen is
+hard-wired to Vivado. Read
+[the backend section of the architecture explanation](../explanation/architecture.md#backends)
+first — it describes exactly what is a label and what is wired.
+
+A new backend requires four things:
+
+1. **A backend label**, so it is selectable. Add
+   `<pkg>/config/backend/backends/yosys.yaml` reusing the existing model:
+
+   ```yaml
+   # @package backend
+
+   _target_: dau_build.build_config.BackendConfig
+   name: yosys
+   invocation: standard
+   ```
+
+   By itself this only changes the reported metadata in the resolved config.
+
+1. **A backend module** that generates the flow's artifacts, paralleling
+   `dau_build/vivado_backend.py`: its own request/artifact `ccflow.BaseModel`s
+   and `generate_*`/`validate_*` entry points, emitting whatever scripts and
+   manifests the yosys/nextpnr flow needs, with a backend identity string
+   analogous to `dau_build.vivado_backend.vivado_overlay`.
+
+1. **Real engine dispatch.** `SynthesizeTask.engine` is currently
+   `Literal["vivado"]` and the task calls the Vivado handoff unconditionally.
+   Widen the literal to include your engine and replace that unconditional call
+   with a branch on `engine`. This is the change that must land *in dau-build*
+   (or in a fork), since the dispatch lives there — the other pieces can live in
+   your package.
+
+1. **Build and validate tasks**, paralleling `build-vivado-artifacts.yaml` and
+   `validate-vivado-artifacts.yaml`, each targeting a new build-step
+   `ccflow.CallableModel` for your backend.
+
+Everything except step 3 composes purely from your package via the search path.
+Until a backend implements steps 2–4, selecting its label runs no real codegen.
+
+## Try it without packaging {#try-it-without-packaging}
+
+To test a config overlay before packaging it, point the argparse CLI at a
+directory with `--config-dir`:
+
+```bash
+dau-build-cfg --config-dir ./my-configs task=tasks/<category>/<name> model.some_field=value
+```
+
+The overlay's groups merge into the tree for that run, and its `_target_` models
+can come from any importable package. This is the quickest way to iterate on a new
+task config before wiring up the entry point.

--- a/docs/how-to/program-hardware.md
+++ b/docs/how-to/program-hardware.md
@@ -1,0 +1,118 @@
+# How to program a bitstream on dpv1
+
+This guide programs and validates a bitstream on a dpv1 board (a NiteFury
+XC7A200T reached over a PCIe/Thunderbolt link) using the `hardware-plan` task. It
+covers the three situations you hit most: programming a fresh build, validating
+an already-built bitstream, and recovering a device that a bad image has wedged.
+
+`hardware-plan` composes an ordered sequence of hardware-session steps — JTAG
+detect, endpoint remove, program, PCIe rescan, endpoint check, driver smoke — and
+runs them in the order the board actually needs. Like the build tasks it is
+plan-first: without `execute=true` it prints the plan; with it, it runs on the
+host. Run these on the machine physically attached to the board.
+
+The named plans are `local-build-and-program`, `build-and-program`,
+`validate-bitstream`, `recovery`, `flash`, `thunderbolt-hold`, and
+`thunderbolt-release`. Full field lists are in the
+[task catalog](../reference/tasks-and-steps.md#tasks).
+
+> **Programming can wedge the PCIe link.** Removing and reprogramming an endpoint
+> while the host holds it can hang a rescan hard enough to need a power cycle. On
+> a host where that is a risk, arm a watchdog / auto-reboot before you run any
+> `execute=true` plan, so a wedge recovers itself.
+
+## Preview a plan before running it
+
+Always look at the sequence first. Omit `execute=true` and the task prints the
+ordered steps without touching the board:
+
+```bash
+dau-build task=tasks/hardware/hardware-plan \
+  plan=local-build-and-program \
+  source_shell_root=/path/to/vivado-shell-seed \
+  work_root=outputs/vivado \
+  dau_core_root=/path/to/dau-core \
+  dau_driver_root=/path/to/dau-driver \
+  dau_utils_root=/path/to/dau-utils
+```
+
+Read the printed steps. When they look right, re-run the same command with
+`execute=true` appended.
+
+## Program a fresh build
+
+`local-build-and-program` stages the shell, runs the Vivado overlay build, then
+programs and verifies the device. Add `execute=true` to run it on the host:
+
+```bash
+dau-build task=tasks/hardware/hardware-plan \
+  plan=local-build-and-program \
+  source_shell_root=/path/to/vivado-shell-seed \
+  work_root=outputs/vivado \
+  dau_core_root=/path/to/dau-core \
+  dau_driver_root=/path/to/dau-driver \
+  dau_utils_root=/path/to/dau-utils \
+  execute=true
+```
+
+The plan holds runtime power management, writes the overlay/build Tcl, runs the
+Vivado build, detects the JTAG chain, removes the stale endpoint, programs the
+volatile bitstream, performs the ordered bridge-then-global PCIe rescan, retries
+the endpoint check, runs the dependency-free driver smoke (which asserts the DAU
+magic register and prints `DAU_SMOKE_OK`), and finally releases power management.
+If any step fails, the release step still runs.
+
+If you already have a bitstream and only want to program it, use
+`build-and-program` with `bitstream=<path>` instead — it skips staging and the
+Vivado build.
+
+## Validate an already-built bitstream
+
+To program a specific bitstream and run the full endpoint-and-smoke check without
+building anything, use `validate-bitstream`:
+
+```bash
+dau-build task=tasks/hardware/hardware-plan \
+  plan=validate-bitstream \
+  work_root=outputs/vivado \
+  bitstream=/path/to/Top_wrapper.bit \
+  dau_core_root=/path/to/dau-core \
+  dau_driver_root=/path/to/dau-driver \
+  dau_utils_root=/path/to/dau-utils \
+  execute=true
+```
+
+The XDMA kernel module must already be loaded; for a Vivado shell checkout it
+lives at `sw/xdma/xdma.ko` in the seed or work directory.
+
+## Recover a wedged device
+
+If a bad image has left the endpoint dead, do **not** rescan first — a rescan
+against a resident dead image is what hangs. The `recovery` plan does the steps in
+the safe order: hold power management, remove the endpoint via sysfs, program a
+known-good volatile bitstream, then rescan and re-check:
+
+```bash
+dau-build task=tasks/hardware/hardware-plan \
+  plan=recovery \
+  work_root=outputs/vivado \
+  execute=true
+```
+
+This recovers the link without a reboot in most cases. If the endpoint still does
+not reappear, the device needs a power cycle.
+
+## Flash and smoke-test from a manifest
+
+To flash and to run a smoke test against a `built` shell-build manifest, use the
+`flash` and `smoke-test` tasks (these consume the manifest and verify the
+bitstream digest before touching the board):
+
+```bash
+dau-build task=tasks/flash/flash manifest_path=outputs/vivado/shell-build.artifacts.yaml
+dau-build task=tasks/flash/smoke-test test=identity
+```
+
+Both require `build_status=built` when given a manifest, and both emit a safe plan
+unless run against real hardware. The smoke `test` is one of `identity`,
+`dma-loopback`, or `aggregation`.

--- a/docs/how-to/run-a-build.md
+++ b/docs/how-to/run-a-build.md
@@ -1,0 +1,98 @@
+# How to run a build end to end
+
+This guide takes a design from a build spec to a validated, ready-to-run Vivado
+build. It follows the plan-first flow: everything up to the actual synthesis is
+composed and checked on your development machine, and only the `execute=true`
+step needs a Vivado host.
+
+The stages are **synthesize → stage → build → validate**, then hand off to
+[programming the board](program-hardware.md). Vivado is the only backend today,
+so every backend-specific command below is a `vivado` command.
+
+Field lists for each task are in the [task catalog](../reference/tasks-and-steps.md).
+To see the full resolved config for any command before running it, prefix it with
+`dau-build-cfg-explain`.
+
+## Synthesize the handoff
+
+Generate the DAU top, artifact bundle, and the `vivado/<stem>.manifest` backend
+handoff. This writes a manifest at `build_status=planned` and does **not** invoke
+Vivado:
+
+```bash
+dau-build-cfg task=tasks/build/synthesize \
+  spec=specs/identity \
+  model.module=dau_identity_top \
+  model.output_root=outputs/identity
+```
+
+If you keep your spec in a file rather than a config group, drop `spec=` and pass
+`model.spec_path=<file>` instead. To attach a specific board and backend to the
+resolved config, add `board=boards/dau/dpv1 backend=backends/vivado`.
+
+## Stage the Vivado work directory
+
+Staging copies a read-only Vivado shell seed into a writable work directory and
+writes the overlay Tcl, guarded build Tcl, backend manifest, and command plan —
+still without running Vivado.
+
+For a full project dry-run that also records checkout roots and the
+stage/build/validate command contract, use `stage-vivado-project`:
+
+```bash
+dau-build task=tasks/stage/stage-vivado-project \
+  source_shell_root=/path/to/vivado-shell-seed \
+  work_root=outputs/vivado \
+  dau_core_root=/path/to/dau-core \
+  dau_driver_root=/path/to/dau-driver \
+  artifact_stem=dau-vivado
+```
+
+If you only need the overlay artifacts, use `tasks/stage/stage-vivado-overlay`
+instead (it requires `work_root` and `dau_core_root`). To fold a DAU artifact
+bundle into the overlay, add `dau_artifact_bundle=<bundle.yaml>`. If your Vivado
+runs through a wrapper that only accepts a Tcl source path, add
+`vivado_invocation=source-only`, and if that wrapper mounts the current directory
+in a container, also add `vivado_mount_root=/path/to/dau`.
+
+## Validate before you synthesize
+
+Check that the staged plan is internally consistent — manifest, overlay Tcl,
+build Tcl, command plan, and planned output paths all agree — without needing
+Xilinx tools:
+
+```bash
+dau-build task=tasks/validate/validate-vivado-artifacts \
+  work_root=outputs/vivado \
+  project_manifest_path=dau-vivado.project
+```
+
+Do this on your development machine before moving to the Vivado host. A failure
+here is cheap; a failure an hour into synthesis is not.
+
+## Build on the Vivado host
+
+On the machine with Vivado, run the generated overlay/build command and let it
+validate the artifact bundle. This is the step that spends real synthesis time,
+so it is gated behind `execute=true`:
+
+```bash
+dau-build task=tasks/build/build-vivado-artifacts \
+  work_root=outputs/vivado \
+  artifact_stem=dau-vivado \
+  execute=true
+```
+
+Once the bitstream, resource report, timing report, and Vivado log exist, this
+moves the backend manifest from `build_status=planned` to `built`. Downstream
+flashing and smoke-testing require `built`.
+
+Treat the Vivado machine as an ordinary Linux host: SSH in, `rsync` the checkouts
+or generated work directory you need, `pip install` the DAU packages there, and
+run the same CLIs. dau-build does not wrap host orchestration.
+
+## Next
+
+With a `built` bitstream, continue to
+[Program a bitstream on dpv1](program-hardware.md) to program and validate it on
+hardware.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,0 +1,107 @@
+# Command reference
+
+`dau-build` installs five console scripts. All of them ultimately run typed
+`ccflow.CallableModel`s composed from the Hydra config tree in
+`dau_build/config`. They differ in how arguments are parsed and which surface of
+the tree they expose.
+
+| Command                 | Entry point                                | Argument style                                 | Purpose                                            |
+| ----------------------- | ------------------------------------------ | ---------------------------------------------- | -------------------------------------------------- |
+| `dau-build`             | `dau_build.build_spec:main`                | subcommands, or flat `task=<path> field=value` | Spec operations and flat task dispatch             |
+| `dau-build-steps`       | `dau_build.build_spec:main_callable_steps` | flat `step=<path> field=value`                 | Low-level step dispatch                            |
+| `dau-build-cfg`         | `dau_build.cli:main`                       | `[--config-dir DIR] task=<path> model.<f>=v`   | Compose and run a task through the registry        |
+| `dau-build-cfg-explain` | `dau_build.cli:explain`                    | same as `dau-build-cfg`                        | Print the resolved config; do not run              |
+| `dau-build-run`         | `dau_build.cli:run`                        | Hydra app: `task=<path> group=opt model.<f>=v` | Hydra `hydra.main` app with the search path active |
+
+Task and step names are **path-style**, mirroring the config tree: `task=tasks/sim/simulate`, `step=steps/inspect`. Short names (`task=simulate`) are not accepted. Field overrides carry a `model.` prefix on the Hydra CLIs (`dau-build-cfg`, `dau-build-cfg-explain`, `dau-build-run`) and no prefix on the flat CLIs (`dau-build`, `dau-build-steps`).
+
+The full set of task and step names and their fields is in the [task and step catalog](tasks-and-steps.md). The config groups selectable with `spec=`, `board=`, `backend=`, `platform=` are in the [config group reference](config-groups.md).
+
+## `dau-build`
+
+```text
+dau-build <subcommand> [options]
+dau-build task=<path> [field=value ...]
+```
+
+If the first argument contains `=`, the command dispatches a flat task request through the registry (equivalent to `dau-build-cfg` without the `model.` prefix). Otherwise it runs one of three subcommands that operate directly on a build spec file.
+
+### `build`
+
+```text
+dau-build build --spec <spec.yaml> --out <dir>
+```
+
+Resolves the spec and writes the generated top-level SystemVerilog, DAU manifest, and `artlink.manifest/v0` artifact bundle under `--out`. Prints `dau-build-artifacts\tmanifest=<path> top_sv=<path>`.
+
+| Option   | Required | Description                     |
+| -------- | -------- | ------------------------------- |
+| `--spec` | yes      | Path to a DAU build YAML spec.  |
+| `--out`  | yes      | Output directory for artifacts. |
+
+### `inspect`
+
+```text
+dau-build inspect --spec <spec.yaml>
+```
+
+Prints the resolved build-spec summary, including each source, metadata file, and binary asset with its originating manifest.
+
+| Option   | Required | Description                    |
+| -------- | -------- | ------------------------------ |
+| `--spec` | yes      | Path to a DAU build YAML spec. |
+
+### `validate`
+
+```text
+dau-build validate (--spec <spec.yaml> | --manifest <manifest> [--root <dir>])
+```
+
+Validates a spec (`--spec`) or a generated artifact bundle (`--manifest`). `--spec` and `--manifest` are mutually exclusive and one is required.
+
+| Option       | Required   | Description                                                  |
+| ------------ | ---------- | ------------------------------------------------------------ |
+| `--spec`     | one of two | Validate a build spec.                                       |
+| `--manifest` | one of two | Validate a generated artifact manifest.                      |
+| `--root`     | no         | Artifact bundle root; defaults to the manifest's parent dir. |
+
+## `dau-build-steps`
+
+```text
+dau-build-steps step=<path> [field=value ...]
+```
+
+Dispatches a low-level step (see [steps](tasks-and-steps.md#steps)). Fields carry no `model.` prefix. Steps are development/plumbing operations; user-facing workflows use tasks.
+
+## `dau-build-cfg`
+
+```text
+dau-build-cfg [--config-dir DIR] task=<path> [group=option ...] [model.<field>=value ...]
+```
+
+Composes the base config with the given overrides and runs the selected model through ccflow. Prints the model's result message.
+
+| Option         | Description                                                                                                   |
+| -------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--config-dir` | A user config overlay directory. Its groups are merged into the tree (open registration).                     |
+| overrides      | Hydra overrides: group selections (`task=`, `spec=`, `board=`, `backend=`) and field sets (`model.<field>=`). |
+
+Raises an error if no `task=`/`step=` is selected (nothing populates `model`).
+
+## `dau-build-cfg-explain`
+
+```text
+dau-build-cfg-explain [--config-dir DIR] task=<path> [group=option ...] [model.<field>=value ...]
+```
+
+Takes the same arguments as `dau-build-cfg` but prints the fully resolved config as YAML and does not run anything. Use it to inspect what a set of overrides composes to.
+
+## `dau-build-run`
+
+```text
+dau-build-run task=<path> [group=option ...] [model.<field>=value ...]
+```
+
+A Hydra `hydra.main` application over `dau_build/config` (config name `base`). The Hydra search path is active, so config groups registered by other installed packages compose uniformly alongside the packaged ones. Standard Hydra CLI conventions apply: use `+group=option` to add a group not present in the defaults, and `-m` for multirun.
+
+This is the recommended entry point for cross-package composition. For example, with the private `dau` package installed, `dau-build-run task=dpv1-shell` resolves a task defined in `dau`'s config tree with no `--config-dir` overlay. See [Extending dau-build](../how-to/extend-dau-build.md).

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -1,0 +1,142 @@
+# Config group reference
+
+The packaged Hydra config tree lives in `dau_build/config`. Each subdirectory is
+a Hydra **config group**; selecting an option from a group is a CLI override of
+the form `<group>=<option-path>`. Options are addressed by their path relative to
+the group directory, so a file at `config/task/tasks/sim/simulate.yaml` is
+selected with `task=tasks/sim/simulate`.
+
+The base config `config/base.yaml` declares the groups and their defaults:
+
+```yaml
+defaults:
+  - _self_
+  - optional task: null
+  - optional step: null
+  - optional platform: null
+  - optional board: null
+  - optional backend: null
+  - optional spec: null
+  - optional design: null
+  - callable: callable
+```
+
+Every group except `callable` is `optional … null`: nothing is selected unless
+overridden. A run selects exactly one of `task=` or `step=` to populate `model`,
+optionally augmented by `spec=`, `board=`, `backend=`, and `platform=`.
+
+Each option file begins with a `# @package <key>` directive that places its
+content under that top-level key. Tasks and steps use `# @package model`; the
+other groups use their singular key (`# @package board`, etc.).
+
+| Group      | `@package` key | Instantiated model                       | Selects                                                          |
+| ---------- | -------------- | ---------------------------------------- | ---------------------------------------------------------------- |
+| `task`     | `model`        | a `…Task` `ccflow.CallableModel`         | The unit of work to run.                                         |
+| `step`     | `model`        | a `…Step` `ccflow.CallableModel`         | A lower-level plumbing operation.                                |
+| `spec`     | `spec`         | `dau_build.build_spec.BuildSpec`         | A composed build spec (Hydra-native alternative to `spec_path`). |
+| `board`    | `board`        | `dau_build.build_config.BoardConfig`     | A board's build-config view.                                     |
+| `backend`  | `backend`      | `dau_build.build_config.BackendConfig`   | The synthesis backend.                                           |
+| `platform` | `platform`     | `dau_build.platforms.PlatformDefinition` | The full physical platform definition.                           |
+| `design`   | `design`       | (none packaged)                          | Reserved; registered by extension packages.                      |
+| `callable` | —              | ccflow registry pointer                  | Fixed evaluator wiring; not normally overridden.                 |
+
+## `task`
+
+Packaged options (`task=<path>`):
+
+```text
+tasks/build/build-shell-project
+tasks/build/build-vivado-artifacts
+tasks/build/overlay-build
+tasks/build/synthesize
+tasks/flash/flash
+tasks/flash/smoke-test
+tasks/hardware/hardware-plan
+tasks/sim/simulate
+tasks/stage/stage-shell
+tasks/stage/stage-vivado-overlay
+tasks/stage/stage-vivado-project
+tasks/validate/validate-vivado-artifacts
+```
+
+Fields per task are in the [task and step catalog](tasks-and-steps.md#tasks).
+
+## `step`
+
+Packaged options (`step=<path>`):
+
+```text
+steps/explain
+steps/generate
+steps/inspect
+steps/resolved-config
+steps/simulate
+steps/synthesis
+steps/validate
+steps/write
+```
+
+Fields per step are in the [task and step catalog](tasks-and-steps.md#steps).
+
+## `spec`
+
+`spec=specs/identity` composes `dau_build.build_spec.BuildSpec` into the `spec`
+key. Tasks and steps read it via `spec: ${oc.select:spec,null}`, so a composed
+`spec=` is an alternative to passing `model.spec_path=<file>`. The packaged
+`specs/identity` option carries `base_dir: examples/identity`, so it resolves
+only when run from the dau-build repository root.
+
+## `board`
+
+`board=boards/dau/dpv1` composes `BoardConfig` into the `board` key. Options live
+under `boards/<vendor>/<board>`. The packaged `boards/dau/dpv1` option:
+
+```yaml
+_target_: dau_build.build_config.BoardConfig
+name: dpv1
+platform: vivado-xdma
+shell: xdma-ddr
+```
+
+`BoardConfig` fields: `name` (str), `platform` (str), `shell` (str).
+
+## `backend`
+
+`backend=backends/vivado` composes `BackendConfig` into the `backend` key.
+
+| Option            | `name`   | `invocation` | Description                    |
+| ----------------- | -------- | ------------ | ------------------------------ |
+| `backends/vivado` | `vivado` | `standard`   | The Vivado/XDMA backend.       |
+| `backends/none`   | `none`   | `dry-run`    | No vendor toolchain (dry-run). |
+
+`BackendConfig` fields: `name` (str), `invocation` (str). Vivado is the only
+backend with a real implementation. See
+[the architecture explanation](../explanation/architecture.md#backends) for
+current-vs-future backend support.
+
+## `platform`
+
+`platform=platforms/dau/dpv1` composes `dau_build.platforms.PlatformDefinition`
+into the `platform` key. Options live under `platforms/<vendor>/<board>`. The
+packaged `platforms/dau/dpv1` option is the authoritative dpv1 definition: part
+number, program method, `ResourceBudget`, `PlatformMemory`, and a `HostLink`
+whose `XdmaPersonality.params` are the 47 proven bring-up XCI parameters,
+quoted verbatim and order-preserved so the generated Vivado `CONFIG.*` block is
+byte-for-byte identical to the known-good core.
+
+`PlatformDefinition` is composed of `ResourceBudget` (`lut`, `ff`, `bram36`,
+`dsp`), `PlatformMemory` (`kind`, `size_bytes`, `mig_prj`,
+`bandwidth_bytes_per_s`), and `HostLink` (`interface`, `pcie_lanes`,
+`xdma_personality`).
+
+## `design`
+
+Declared in the defaults (`optional design: null`) but no option is packaged in
+`dau-build`. It is the reserved group for higher-level design/tile compositions
+registered by extension packages on the search path.
+
+## `callable`
+
+`callable/callable.yaml` is a fixed ccflow registry pointer wiring the evaluator
+(`GraphEvaluator` + `MemoryCacheEvaluator` via `MultiEvaluator`). It is selected
+by default and is not normally overridden.

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -1,0 +1,118 @@
+# Task and step catalog
+
+Tasks and steps are `ccflow.CallableModel`s selected from the `task` and `step`
+config groups. This page lists each one, its `_target_` model, its required
+fields (those set to `???` in the config, which must be supplied as overrides),
+and its default execution mode.
+
+The complete field set with defaults for any task or step is self-describing:
+
+```text
+dau-build-cfg-explain task=<path>
+dau-build-cfg-explain step=<path>
+```
+
+Fields marked **required** have no default and must be overridden. On the Hydra
+CLIs (`dau-build-cfg`, `dau-build-run`) fields carry a `model.` prefix; on the
+flat CLIs (`dau-build`, `dau-build-steps`) they do not.
+
+Tasks whose default is **plan** carry `execute: false` and produce plans,
+manifests, and staged files without invoking a vendor toolchain or touching
+hardware. Pass `execute=true` to run the privileged action. Tasks marked **run**
+always execute their (non-privileged) operation.
+
+## Tasks
+
+### `tasks/sim/simulate` — `SimulateTask`
+
+Validates or simulates a module against the build spec. Required: `module`.
+Default `simulator: svparser` (validation only); `simulator=cocotb` runs a cocotb
+bench; `simulator=verilator` compiles and runs a Verilator testbench via a named
+`profile` or explicit `testbench_path`/`top_module`. Mode: **run**.
+
+### `tasks/build/synthesize` — `SynthesizeTask`
+
+Writes the generated DAU top, DAU manifest, `artlink.manifest/v0` bundle, and the
+`vivado/<artifact-stem>.manifest` backend handoff at `build_status=planned`. Does
+not invoke Vivado. Required: `module`, `output_root`. Default `engine: vivado`.
+Mode: **run** (produces a planned manifest).
+
+### `tasks/build/build-shell-project` — `BuildShellProjectTask`
+
+Builds a standalone shell project from a generated Tcl script. Required:
+`output_root`. Default `script: build_mm_job.tcl`. Mode: **plan**.
+
+### `tasks/build/build-vivado-artifacts` — `BuildVivadoArtifactsTask`
+
+Runs the generated overlay/build Vivado command, then validates the artifact
+bundle. Moves the backend manifest from `planned` to `built` once the bitstream,
+resource report, timing report, and Vivado log exist. Required: `work_root`.
+Default `artifact_stem: dau-vivado`. Mode: **plan** (pass `execute=true` on the
+Vivado host).
+
+### `tasks/build/overlay-build` — `VivadoOverlayBuildTask`
+
+Runs only the generated overlay/build Vivado command (no JTAG, PCIe rescan, or
+smoke test). Required: `work_root`. Default `backend: vivado`. Mode: **plan**.
+
+### `tasks/stage/stage-shell` — `ShellStageTask`
+
+Copies a read-only Vivado shell seed into a generated work directory with
+`rsync --delete --delete-excluded`, excluding Vivado run/cache/log outputs.
+Required: `work_root`, `source_shell_root`. Mode: **plan**.
+
+### `tasks/stage/stage-vivado-overlay` — `VivadoOverlayStageTask`
+
+Writes the generated overlay Tcl, guarded build Tcl, backend manifest preview,
+and Vivado command plan without invoking Vivado. Pass `dau_artifact_bundle=` to
+fold a DAU artifact bundle into the overlay. Required: `work_root`,
+`dau_core_root`. Mode: **plan**.
+
+### `tasks/stage/stage-vivado-project` — `VivadoProjectStageTask`
+
+Stages the shell seed and writes `<artifact-stem>.project` recording the shell
+seed, work directory, DAU checkout roots, XDMA module path, backend artifacts,
+and stage/build/validate commands, plus the same overlay artifacts as
+`stage-vivado-overlay`. Required: `work_root`, `source_shell_root`,
+`dau_core_root`, `dau_driver_root`. Mode: **plan**.
+
+### `tasks/validate/validate-vivado-artifacts` — `ValidateVivadoArtifactsTask`
+
+Checks that the manifest, overlay Tcl, build Tcl, command plan, and planned
+output paths agree, without requiring Xilinx tools. Pass
+`project_manifest_path=<artifact-stem>.project` to include the project manifest.
+Required: `work_root`. Mode: **plan**.
+
+### `tasks/hardware/hardware-plan` — `HardwarePlanTask`
+
+Produces a live hardware-session command sequence for a named `plan` (e.g.
+`local-build-and-program`, `validate-bitstream`, `flash`, `recovery`). Required:
+`plan`, `work_root`. Mode: **plan** (pass `execute=true` on the hardware host).
+
+### `tasks/flash/flash` — `FlashTask`
+
+Produces a flashing plan for a bitstream. Requires `build_status=built` when it
+consumes a `manifest_path`. Default `tool: openFPGAloader`, `mode: volatile`.
+Mode: **run** (produces a plan).
+
+### `tasks/flash/smoke-test` — `SmokeTestTask`
+
+Produces a smoke-test plan/validation. Requires `build_status=built` when it
+consumes a `manifest_path`. Required: `test`. Mode: **run** (produces a plan).
+
+## Steps
+
+Steps are lower-level operations over the spec and artifact bundle. All read the
+spec via `spec_path` or a composed `spec=` group, and accept optional `board=`
+and `backend=` groups.
+
+| Step                    | Model                | Required      | Description                                                    |
+| ----------------------- | -------------------- | ------------- | -------------------------------------------------------------- |
+| `steps/inspect`         | `InspectStep`        | —             | Print the resolved spec summary.                               |
+| `steps/validate`        | `ValidateStep`       | —             | Validate the spec / bundle.                                    |
+| `steps/explain`         | `ExplainStep`        | —             | Explain the resolved inputs.                                   |
+| `steps/resolved-config` | `ResolvedConfigStep` | —             | Print the resolved build config (spec + board + backend view). |
+| `steps/generate`        | `GenerateStep`       | `output_root` | Generate the DAU top and artifacts.                            |
+| `steps/write`           | `WriteStep`          | `output_root` | Write the artifact bundle.                                     |
+| `steps/synthesis`       | `SynthesisStep`      | `output_root` | Produce the synthesis handoff.                                 |
+| `steps/simulate`        | `SimulateStep`       | —             | Run a simulation (fields prefixed `simulate_*`).               |

--- a/docs/tutorial/first-build.md
+++ b/docs/tutorial/first-build.md
@@ -1,0 +1,112 @@
+# Build the identity example
+
+In this tutorial we will take a checked-in example design through dau-build:
+inspect it, generate its artifacts, validate the result, and run a simulation
+check — all on your machine, with no FPGA and no Xilinx tools installed. By the
+end you will have run every stage of the plan-first build flow and seen what each
+one produces.
+
+Work from the root of a `dau-build` checkout. Every command here uses the
+`examples/identity` design that ships with the package.
+
+## Step 1 — Inspect the spec
+
+First, look at what the example declares. Run:
+
+```bash
+dau-build inspect --spec examples/identity/dau-build.yaml
+```
+
+You should see a summary line followed by the resolved inputs:
+
+```text
+dau-build-spec	name=identity-pipeline platform=vivado-xdma shell=xdma-ddr modules=identity sources=1 clock=clk reset=reset backend=vivado
+manifest	index=0 path=.../examples/identity/package.artifacts.yaml
+source	index=0 path=.../examples/identity/rtl/identity.sv role=hdl-source language=systemverilog origin=...
+source	index=1 path=.../examples/identity/python/model.py role=python-source language=python origin=...
+metadata	index=0 path=.../examples/identity/constraints/identity.xdc role=constraints format=xdc origin=...
+binary	index=0 path=.../examples/identity/bitstreams/seed.bit role=bitstream format=xilinx-bitstream origin=...
+```
+
+Notice that each source, constraint, and binary is listed with its role and the
+artifact bundle it came from. This is the resolved view dau-build hands to a
+backend — nothing has been generated yet.
+
+## Step 2 — Generate the artifacts
+
+Now generate the build outputs into a fresh directory:
+
+```bash
+dau-build build --spec examples/identity/dau-build.yaml --out outputs/identity
+```
+
+The command prints the two headline artifacts it wrote:
+
+```text
+dau-build-artifacts	manifest=outputs/identity/dau-identity.manifest top_sv=outputs/identity/generated/dau_identity_top.sv
+```
+
+Look at what landed in the output directory:
+
+```bash
+ls outputs/identity
+```
+
+```text
+dau-identity.artifacts.yaml   dau-identity.manifest   generated
+```
+
+You have generated the top-level SystemVerilog (`generated/dau_identity_top.sv`),
+the DAU manifest, and an `artlink.manifest/v0` artifact bundle. These are the
+portable inputs a synthesis backend consumes.
+
+## Step 3 — Validate the bundle
+
+Check that the generated bundle is internally consistent — that every file the
+manifest references exists and every required role is present:
+
+```bash
+dau-build validate --manifest outputs/identity/dau-identity.manifest --root outputs/identity
+```
+
+```text
+dau-build-artifacts-valid	manifest=outputs/identity/dau-identity.manifest top_sv=outputs/identity/generated/dau_identity_top.sv
+```
+
+The `-valid` prefix confirms the bundle passed. If a referenced file were missing,
+validation would fail here rather than deep inside a Vivado run later.
+
+## Step 4 — Run a simulation check
+
+Finally, validate the generated top against the spec through the simulation task.
+The default simulator, `svparser`, parses and checks the module without needing
+any external simulator:
+
+```bash
+dau-build task=tasks/sim/simulate module=dau_identity_top spec_path=examples/identity/dau-build.yaml
+```
+
+```text
+dau-build-simulate	task=simulate simulator=svparser module=dau_identity_top spec=examples/identity/dau-build.yaml status=validated
+```
+
+`status=validated` means the module checked out against the build spec. This is
+your first task run — `task=tasks/sim/simulate` selected the simulate task from
+the config tree, and the `module=` and `spec_path=` overrides supplied its fields.
+
+## What you have done
+
+You have run the identity design through the full plan-first flow: **inspect →
+build → validate → simulate**, and seen the artifacts each stage produces — all
+without a board or a vendor toolchain. Every dau-build task and step works this
+same way: select it from the config tree and override its fields.
+
+From here:
+
+- To drive a real synthesis-and-program sequence, see
+  [Run a build end to end](../how-to/run-a-build.md) and
+  [Program a bitstream on dpv1](../how-to/program-hardware.md).
+- To understand how the config composition works underneath these commands, read
+  [the architecture explanation](../explanation/architecture.md).
+- For the full set of commands, tasks, and config groups, see the
+  [reference](../reference/commands.md).


### PR DESCRIPTION
## What

Restructures the dau-build documentation using [Diátaxis](https://diataxis.fr). The monolithic README (which had drifted into a blend of overview, how-to, reference, and explanation with stale command syntax) is split into a `docs/` tree with one section per mode, and the README is slimmed to an overview plus a doc map.

```
docs/
  index.md                       landing page
  tutorial/first-build.md        the identity example, no hardware required
  how-to/run-a-build.md          synthesize → stage → build → validate
  how-to/program-hardware.md     program / validate / recover a bitstream on dpv1
  how-to/extend-dau-build.md     add tasks, boards, or a backend via the search path
  reference/commands.md          the five console scripts
  reference/config-groups.md     task/step/spec/board/backend/platform groups
  reference/tasks-and-steps.md   every task and step, its model, required fields
  explanation/architecture.md    Hydra composition, ccflow, search path, backends
```

## Why

The old README mixed all four documentation modes on one page and its command examples predated the path-style config nesting. This makes the material findable by intent and corrects the accuracy problems.

## Accuracy corrections

- **Command syntax**: task/step names are now path-style (`task=tasks/sim/simulate`, not `task=simulate`), and field overrides carry a `model.` prefix on the Hydra CLIs (`dau-build-cfg`, `dau-build-run`) but not on the flat CLIs (`dau-build`, `dau-build-steps`). The old short-name examples no longer run.
- **Backend status**: states plainly that Vivado is the only real backend, that `BackendConfig` is a label rather than a driver, and that `SynthesizeTask.engine` is hard-wired to `vivado`. The extension guide describes exactly what a second backend (e.g. yosys/nextpnr) requires.
- **Hydra machinery**: the architecture explanation covers config groups as directories, `# @package`, the two override syntaxes, ccflow's `GraphEvaluator`/`MemoryCacheEvaluator`, the `hydra.lernaplugins` + `lerna` search-path extension model, and the plan-vs-execute split.

## Verification

- Tutorial commands were run against the checked-in identity example; the expected outputs in the tutorial are real.
- All relative doc links resolve.
- `README.md` passes `mdformat --check` and `codespell` (the CI `lint-docs` target); all docs are mdformat-clean.
- Public/private wall respected: no host names or private workload-shell internals; the dpv1 board/platform and `hardware-plan` flow are already public in this repo.
