### PR TITLE
Wire docs into yardang

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Task and step names are path-style, mirroring the config tree (`task=tasks/sim/s
 
 ## Documentation
 
-Full documentation is in [docs/](docs/index.md):
+The documentation is organized into four sections:
 
 - **Tutorial** — [Build the identity example](docs/tutorial/first-build.md).
 - **How-to** — [Run a build end to end](docs/how-to/run-a-build.md) · [Program a bitstream on dpv1](docs/how-to/program-hardware.md) · [Extend dau-build](docs/how-to/extend-dau-build.md).

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -135,7 +135,7 @@ They are independent groups, composed together into a task's
 physical dpv1 definition can be reused regardless of which backend produced a
 bitstream.
 
-## Backends: Vivado today, others later {#backends}
+## Backends: Vivado today, others later
 
 **Only the Vivado backend is real today.** Understanding the current shape makes
 clear what adding another backend involves.
@@ -161,5 +161,5 @@ say, a yosys/nextpnr flow is a second *implementation*: a backend module
 paralleling `vivado_backend.py`, a widened `engine` literal with real dispatch,
 and its task configs. There is no yosys, nextpnr, or other backend scaffolding in
 the tree today — not a stub, not a config file. That is a deliberate honesty about
-the current state, not an oversight. [Extending dau-build](../how-to/extend-dau-build.md#add-a-synthesis-backend)
+the current state, not an oversight. [Extending dau-build](../how-to/extend-dau-build.md)
 walks through exactly what a new backend requires.

--- a/docs/how-to/extend-dau-build.md
+++ b/docs/how-to/extend-dau-build.md
@@ -7,8 +7,9 @@ This guide shows the three things you are most likely to add: a new task from
 your own package, a new board or platform, and a new synthesis backend.
 
 For the concepts behind the search path and the config groups, see
-[the architecture explanation](../explanation/architecture.md). For an ad-hoc
-overlay without packaging, jump to [the last section](#try-it-without-packaging).
+[the architecture explanation](../explanation/architecture.md). To test an
+overlay without packaging, see **Try it without packaging** at the end of this
+guide.
 
 ## Register your config tree on the search path
 
@@ -91,12 +92,12 @@ add `mypkg/config/platform/platforms/<vendor>/<board>.yaml` targeting
 `dau_build.platforms.PlatformDefinition`. Select them with
 `board=boards/<vendor>/<board>` and `platform=platforms/<vendor>/<board>`.
 
-## Add a synthesis backend {#add-a-synthesis-backend}
+## Add a synthesis backend
 
 Adding a *real* backend (for example a yosys/nextpnr flow) is more than a config
 file, because today `BackendConfig` is only a label and synthesis codegen is
 hard-wired to Vivado. Read
-[the backend section of the architecture explanation](../explanation/architecture.md#backends)
+[the backend section of the architecture explanation](../explanation/architecture.md)
 first — it describes exactly what is a label and what is wired.
 
 A new backend requires four things:
@@ -134,7 +135,7 @@ A new backend requires four things:
 Everything except step 3 composes purely from your package via the search path.
 Until a backend implements steps 2–4, selecting its label runs no real codegen.
 
-## Try it without packaging {#try-it-without-packaging}
+## Try it without packaging
 
 To test a config overlay before packaging it, point the argparse CLI at a
 directory with `--config-dir`:

--- a/docs/how-to/program-hardware.md
+++ b/docs/how-to/program-hardware.md
@@ -14,7 +14,7 @@ host. Run these on the machine physically attached to the board.
 The named plans are `local-build-and-program`, `build-and-program`,
 `validate-bitstream`, `recovery`, `flash`, `thunderbolt-hold`, and
 `thunderbolt-release`. Full field lists are in the
-[task catalog](../reference/tasks-and-steps.md#tasks).
+[task catalog](../reference/tasks-and-steps.md).
 
 > **Programming can wedge the PCIe link.** Removing and reprogramming an endpoint
 > while the host holds it can hang a rescan hard enough to need a power cycle. On

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -71,7 +71,7 @@ Validates a spec (`--spec`) or a generated artifact bundle (`--manifest`). `--sp
 dau-build-steps step=<path> [field=value ...]
 ```
 
-Dispatches a low-level step (see [steps](tasks-and-steps.md#steps)). Fields carry no `model.` prefix. Steps are development/plumbing operations; user-facing workflows use tasks.
+Dispatches a low-level step (see [steps](tasks-and-steps.md)). Fields carry no `model.` prefix. Steps are development/plumbing operations; user-facing workflows use tasks.
 
 ## `dau-build-cfg`
 

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -59,7 +59,7 @@ tasks/stage/stage-vivado-project
 tasks/validate/validate-vivado-artifacts
 ```
 
-Fields per task are in the [task and step catalog](tasks-and-steps.md#tasks).
+Fields per task are in the [task and step catalog](tasks-and-steps.md).
 
 ## `step`
 
@@ -76,7 +76,7 @@ steps/validate
 steps/write
 ```
 
-Fields per step are in the [task and step catalog](tasks-and-steps.md#steps).
+Fields per step are in the [task and step catalog](tasks-and-steps.md).
 
 ## `spec`
 
@@ -111,7 +111,7 @@ shell: xdma-ddr
 
 `BackendConfig` fields: `name` (str), `invocation` (str). Vivado is the only
 backend with a real implementation. See
-[the architecture explanation](../explanation/architecture.md#backends) for
+[the architecture explanation](../explanation/architecture.md) for
 current-vs-future backend support.
 
 ## `platform`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,14 @@ section-order = [
 title = "dau-build"
 root = "README.md"
 pages = [
+    "docs/tutorial/first-build.md",
+    "docs/how-to/run-a-build.md",
+    "docs/how-to/program-hardware.md",
+    "docs/how-to/extend-dau-build.md",
+    "docs/reference/commands.md",
+    "docs/reference/config-groups.md",
+    "docs/reference/tasks-and-steps.md",
+    "docs/explanation/architecture.md",
 ]
 use-autoapi = false
 


### PR DESCRIPTION
## What

Populates `[tool.yardang]` `pages` in `pyproject.toml` with the `docs/` Diátaxis tree so the documentation site builds. README remains the site root/index.

## Anchor fixes

While wiring the build, fixed anchors that only worked under GitHub auto-slugging:

- Removed `{#id}` heading attributes. GitHub renders them as literal text and yardang (MyST with `heading_anchors` off) does not recognize them.
- Pointed cross-document links at the page instead of a `#section` fragment, which MyST cannot resolve without heading anchors.
- Reworked the README doc-map intro, which linked to a `docs/index.md` that `.gitignore` excludes from the repo (a latent broken link from the prior docs PR).

## Verification

- `yardang build` succeeds with zero warnings.
- `README.md` passes `mdformat --check` (CI `lint-docs`).
- All relative doc links resolve.