### PR TITLE
Remove the build/inspect/validate file subcommands

### DIFF
--- a/dau_build/build_spec.py
+++ b/dau_build/build_spec.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 from pathlib import Path
 from typing import Any
 
@@ -289,57 +288,23 @@ def dau_artifact_manifest(spec: DauBuildSpec, *, design: Design, top_sv_path: Pa
 
 
 def main(argv: list[str] | None = None) -> int:
+    """``dau-build``: dispatch a task through the registry from the flat
+    ``task=<path> field=value`` surface (see docs/reference/commands.md)."""
     import sys
 
+    from dau_build.build_steps import BuildStepError, execute_override_request
+
     arguments = sys.argv[1:] if argv is None else argv
-    if arguments and _looks_like_override_request(arguments[0]):
-        from dau_build.build_steps import BuildStepError, execute_override_request
-
-        try:
-            result = execute_override_request(arguments)
-        except (BuildStepError, DauBuildSpecError) as exc:
-            print(f"error: {exc}", file=sys.stderr)
-            return 1
-        print(result.message)
-        return 0
-
-    parser = argparse.ArgumentParser(description="Build DAU hardware artifacts from a declarative build spec")
-    subparsers = parser.add_subparsers(dest="command", required=True)
-
-    build_parser = subparsers.add_parser("build", help="Generate DAU top-level SystemVerilog and manifest artifacts")
-    build_parser.add_argument("--spec", required=True, type=Path, help="Path to a DAU build YAML spec")
-    build_parser.add_argument("--out", required=True, type=Path, help="Output directory for generated artifacts")
-
-    inspect_parser = subparsers.add_parser("inspect", help="Print the resolved DAU build spec summary")
-    inspect_parser.add_argument("--spec", required=True, type=Path, help="Path to a DAU build YAML spec")
-
-    validate_parser = subparsers.add_parser("validate", help="Validate a DAU build spec or generated artifact bundle")
-    validate_target = validate_parser.add_mutually_exclusive_group(required=True)
-    validate_target.add_argument("--spec", type=Path, help="Path to a DAU build YAML spec")
-    validate_target.add_argument("--manifest", type=Path, help="Path to a generated DAU artifact manifest")
-    validate_parser.add_argument("--root", type=Path, help="Artifact bundle root; defaults to the manifest parent")
-
-    args = parser.parse_args(arguments)
-    _warn_deprecated_subcommand(args.command)
+    if not arguments or not _looks_like_override_request(arguments[0]):
+        print("usage: dau-build task=<path> [field=value ...]  (see docs/reference/commands.md)", file=sys.stderr)
+        return 2
     try:
-        if args.command == "build":
-            artifacts = write_dau_build_artifacts(BuildSpec.from_file(args.spec).resolve(), output_root=args.out)
-            print(f"dau-build-artifacts\tmanifest={artifacts.manifest_path} top_sv={artifacts.top_sv_path}")
-            return 0
-        if args.command == "inspect":
-            print(dau_build_spec_summary(BuildSpec.from_file(args.spec).resolve()))
-            return 0
-        if args.command == "validate" and args.spec is not None:
-            BuildSpec.from_file(args.spec).resolve()
-            print(f"dau-build-spec-valid\tspec={args.spec}")
-            return 0
-        if args.command == "validate" and args.manifest is not None:
-            top_sv_path = validate_dau_build_artifact_bundle(args.manifest, root=args.root)
-            print(f"dau-build-artifacts-valid\tmanifest={args.manifest} top_sv={top_sv_path}")
-            return 0
-    except DauBuildSpecError as exc:
-        parser.exit(1, f"error: {exc}\n")
-    return 1
+        result = execute_override_request(arguments)
+    except (BuildStepError, DauBuildSpecError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print(result.message)
+    return 0
 
 
 def main_callable_steps(argv: list[str] | None = None) -> int:
@@ -355,21 +320,6 @@ def main_callable_steps(argv: list[str] | None = None) -> int:
         return 1
     print(result.message)
     return 0
-
-
-_SUBCOMMAND_TASK_EQUIVALENT = {
-    "build": "task=tasks/spec/build",
-    "inspect": "task=tasks/spec/inspect",
-    "validate": "task=tasks/spec/validate",
-}
-
-
-def _warn_deprecated_subcommand(command: str) -> None:
-    import sys
-
-    task = _SUBCOMMAND_TASK_EQUIVALENT.get(command)
-    if task is not None:
-        print(f"warning: 'dau-build {command}' is deprecated; use 'dau-build {task} ...' (see docs/reference/commands.md)", file=sys.stderr)
 
 
 def _looks_like_override_request(argument: str) -> bool:

--- a/dau_build/tests/test_build_spec.py
+++ b/dau_build/tests/test_build_spec.py
@@ -223,7 +223,7 @@ def test_generate_dau_build_artifacts_emits_stream_job_top_boundary_for_stream_m
 def test_cli_build_emits_dau_native_artifact_bundle(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = main(["build", "--spec", str(spec_path), "--out", str(tmp_path / "out")])
+    exit_code = main(["task=tasks/spec/build", f"spec_path={spec_path}", f"output_root={tmp_path / 'out'}"])
 
     assert exit_code == 0
     assert (tmp_path / "out" / "generated" / "dau_identity_top.sv").is_file()
@@ -285,7 +285,7 @@ def test_generate_dau_build_artifacts_rejects_unknown_requested_module(tmp_path:
 def test_cli_inspect_reports_spec_without_generating_outputs(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = _main_exit_code(["inspect", "--spec", str(spec_path)])
+    exit_code = _main_exit_code(["task=tasks/spec/inspect", f"spec_path={spec_path}"])
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [
@@ -297,9 +297,11 @@ def test_cli_inspect_reports_spec_without_generating_outputs(tmp_path: Path, cap
 def test_cli_validate_accepts_spec_and_artifact_bundle(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    spec_exit_code = _main_exit_code(["validate", "--spec", str(spec_path)])
-    build_exit_code = main(["build", "--spec", str(spec_path), "--out", str(tmp_path / "out")])
-    bundle_exit_code = _main_exit_code(["validate", "--manifest", str(tmp_path / "out" / "dau-identity.manifest"), "--root", str(tmp_path / "out")])
+    spec_exit_code = _main_exit_code(["task=tasks/spec/validate", f"spec_path={spec_path}"])
+    build_exit_code = main(["task=tasks/spec/build", f"spec_path={spec_path}", f"output_root={tmp_path / 'out'}"])
+    bundle_exit_code = _main_exit_code(
+        ["task=tasks/spec/validate", f"manifest_path={tmp_path / 'out' / 'dau-identity.manifest'}", f"root={tmp_path / 'out'}"]
+    )
 
     assert spec_exit_code == 0
     assert build_exit_code == 0
@@ -515,7 +517,7 @@ def test_cli_inspect_reports_manifest_input_origins(tmp_path: Path, capsys) -> N
         encoding="utf-8",
     )
 
-    exit_code = _main_exit_code(["inspect", "--spec", str(spec_path)])
+    exit_code = _main_exit_code(["task=tasks/spec/inspect", f"spec_path={spec_path}"])
 
     assert exit_code == 0
     origin = package_manifest_path.resolve().as_posix()

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -7,7 +7,7 @@ the tree they expose.
 
 | Command                 | Entry point                                | Argument style                                 | Purpose                                            |
 | ----------------------- | ------------------------------------------ | ---------------------------------------------- | -------------------------------------------------- |
-| `dau-build`             | `dau_build.build_spec:main`                | subcommands, or flat `task=<path> field=value` | Spec operations and flat task dispatch             |
+| `dau-build`             | `dau_build.build_spec:main`                | flat `task=<path> field=value`                 | Flat task dispatch                                 |
 | `dau-build-steps`       | `dau_build.build_spec:main_callable_steps` | flat `step=<path> field=value`                 | Low-level step dispatch                            |
 | `dau-build-cfg`         | `dau_build.cli:main`                       | `[--config-dir DIR] task=<path> model.<f>=v`   | Compose and run a task through the registry        |
 | `dau-build-cfg-explain` | `dau_build.cli:explain`                    | same as `dau-build-cfg`                        | Print the resolved config; do not run              |
@@ -20,59 +20,16 @@ The full set of task and step names and their fields is in the [task and step ca
 ## `dau-build`
 
 ```text
-dau-build <subcommand> [options]
 dau-build task=<path> [field=value ...]
 ```
 
-If the first argument contains `=`, the command dispatches a flat task request through the registry (equivalent to `dau-build-cfg` without the `model.` prefix). Otherwise it runs one of three subcommands that operate directly on a build spec file.
-
-> **Deprecated.** The `build`, `inspect`, and `validate` subcommands are superseded by the `tasks/spec/*` tasks and print a deprecation warning. Use the task form instead:
->
-> | Subcommand                                 | Task equivalent                                             |
-> | ------------------------------------------ | ----------------------------------------------------------- |
-> | `dau-build inspect --spec X`               | `dau-build task=tasks/spec/inspect spec_path=X`             |
-> | `dau-build build --spec X --out D`         | `dau-build task=tasks/spec/build spec_path=X output_root=D` |
-> | `dau-build validate --spec X`              | `dau-build task=tasks/spec/validate spec_path=X`            |
-> | `dau-build validate --manifest M --root D` | `dau-build task=tasks/spec/validate manifest_path=M root=D` |
-
-### `build`
+Dispatches a task through the registry from the flat surface — equivalent to `dau-build-cfg` without the `model.` prefix on field overrides. Exits non-zero with a usage message if the first argument is not a `key=value` override. For example, the spec operations (inspect, build, and validate a spec or generated bundle):
 
 ```text
-dau-build build --spec <spec.yaml> --out <dir>
+dau-build task=tasks/spec/inspect  spec_path=examples/identity/dau-build.yaml
+dau-build task=tasks/spec/build     spec_path=examples/identity/dau-build.yaml output_root=outputs/identity
+dau-build task=tasks/spec/validate  manifest_path=outputs/identity/dau-identity.manifest root=outputs/identity
 ```
-
-Resolves the spec and writes the generated top-level SystemVerilog, DAU manifest, and `artlink.manifest/v0` artifact bundle under `--out`. Prints `dau-build-artifacts\tmanifest=<path> top_sv=<path>`.
-
-| Option   | Required | Description                     |
-| -------- | -------- | ------------------------------- |
-| `--spec` | yes      | Path to a DAU build YAML spec.  |
-| `--out`  | yes      | Output directory for artifacts. |
-
-### `inspect`
-
-```text
-dau-build inspect --spec <spec.yaml>
-```
-
-Prints the resolved build-spec summary, including each source, metadata file, and binary asset with its originating manifest.
-
-| Option   | Required | Description                    |
-| -------- | -------- | ------------------------------ |
-| `--spec` | yes      | Path to a DAU build YAML spec. |
-
-### `validate`
-
-```text
-dau-build validate (--spec <spec.yaml> | --manifest <manifest> [--root <dir>])
-```
-
-Validates a spec (`--spec`) or a generated artifact bundle (`--manifest`). `--spec` and `--manifest` are mutually exclusive and one is required.
-
-| Option       | Required   | Description                                                  |
-| ------------ | ---------- | ------------------------------------------------------------ |
-| `--spec`     | one of two | Validate a build spec.                                       |
-| `--manifest` | one of two | Validate a generated artifact manifest.                      |
-| `--root`     | no         | Artifact bundle root; defaults to the manifest's parent dir. |
 
 ## `dau-build-steps`
 


### PR DESCRIPTION
## What

Removes the `dau-build build|inspect|validate --flags` argparse subcommands (and the deprecation warning from #94). `dau-build` is now purely the flat task dispatcher:

```
dau-build task=<path> field=value ...
```

The `tasks/spec/inspect`, `tasks/spec/build`, and `tasks/spec/validate` tasks added in #94 fully replace them, so per the plan we drop the old surface outright rather than carry a deprecation shim.

## Breaking change

This removes CLI entry points, so it is a breaking change — covered by the next minor release. Scripts using `dau-build inspect --spec X` etc. must switch to `dau-build task=tasks/spec/inspect spec_path=X` (mapping in docs/reference/commands.md history).

## Changes

- `build_spec.py`: `main()` is now just the task dispatcher; removed the subparsers, the deprecation helper, and the unused `argparse` import.
- Reference docs: dropped the subcommand sections and the deprecation table; the `dau-build` entry documents the flat task surface.
- The `test_cli_*` tests now drive the same operations through the task form (emitted messages are unchanged).

## Verification

- Full suite: 218 passed. ruff clean. yardang build zero warnings; README passes mdformat + codespell.