### PR TITLE
Add a yosys synthesis backend

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,16 @@ jobs:
     - name: Install dependencies
       run: make develop
 
+    - name: Install synthesis tools (yosys + yosys-slang)
+      run: |
+        gh release download v0.0.13 --repo dau-dev/tools --pattern 'yosys_*.deb' --pattern 'yosys-slang_*.deb' --dir /tmp/tools
+        sudo apt-get update
+        sudo apt-get install -y /tmp/tools/yosys_*.deb /tmp/tools/yosys-slang_*.deb
+        yosys --version
+        yosys -m slang -p 'help read_slang' >/dev/null && echo "yosys-slang plugin OK"
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Lint
       run: make lint
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Build tools for dau
 
 `dau-build` turns declarative FPGA build specs into concrete artifacts: generated SystemVerilog, `artlink.manifest/v0` artifact bundles, backend handoff manifests, Vivado Tcl, and ordered hardware command plans. Every operation is a typed `ccflow.CallableModel` composed from a Hydra config tree in `dau_build/config`, so the whole pipeline composes, inspects, and tests on a development machine, with the privileged steps (Vivado, JTAG, PCIe) gated behind an explicit `execute=true`.
 
-Vivado is the only synthesis backend today; the config plumbing is backend-agnostic so others (e.g. yosys/nextpnr) can be added later.
+Two synthesis engines are supported: Vivado (the FPGA bitstream flow) and yosys (open-source synthesis that runs in CI). The config plumbing is backend-agnostic, so more can be added.
 
 ## Quickstart
 

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -403,14 +403,19 @@ class SimulateTask(ModuleSelectionModel):
 
 
 class SynthesizeTask(ModuleSelectionModel):
-    engine: Literal["vivado"]
+    engine: Literal["vivado", "yosys"]
     output_root: Path
+    # yosys-only: the SystemVerilog frontend and executable
+    frontend: Literal["verilog", "slang"] = "verilog"
+    yosys: str = "yosys"
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         spec = self.load_spec_and_validate_module()
         resolved = self._resolved(spec, backend_name=self.engine)
         artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
+        if self.engine == "yosys":
+            return self._synthesize_with_yosys(spec, artifacts)
         backend_artifacts = _write_vivado_backend_handoff(
             spec,
             selected_module=self.module,
@@ -426,6 +431,33 @@ class SynthesizeTask(ModuleSelectionModel):
                 f"dau-build-synthesize\ttask=synthesize engine={self.engine} module={self.module} spec={self.spec_label} "
                 f"output_root={self.output_root} manifest={artifacts.manifest_path} top_sv={artifacts.top_sv_path} "
                 f"backend_manifest={backend_artifacts.manifest_path} command_plan={backend_artifacts.command_plan_path} status=handoff-written"
+            ),
+        )
+
+    def _synthesize_with_yosys(self, spec, artifacts) -> BuildStepResult:
+        # yosys is runnable (unlike the Vivado plan), so this actually
+        # elaborates and synthesizes the generated top — a real check
+        from dau_build.yosys_backend import YosysBackendError, YosysBackendRequest, run_yosys_synthesis
+
+        request = YosysBackendRequest(
+            top_module=spec.top_name,
+            sources=(artifacts.top_sv_path, *spec.sources),
+            output_root=self.output_root,
+            frontend=self.frontend,
+            yosys=self.yosys,
+        )
+        try:
+            result = run_yosys_synthesis(request)
+        except YosysBackendError as exc:
+            raise BuildStepError(str(exc)) from exc
+        if not result.passed:
+            raise BuildStepError(f"yosys synthesis failed for {spec.top_name} (frontend={self.frontend}); see {result.log_path}")
+        return BuildStepResult(
+            step="synthesize",
+            message=(
+                f"dau-build-synthesize\ttask=synthesize engine=yosys frontend={self.frontend} module={self.module} "
+                f"spec={self.spec_label} top={spec.top_name} output_root={self.output_root} "
+                f"script={result.script_path} cells={result.cell_count} status=synthesized"
             ),
         )
 

--- a/dau_build/config/backend/backends/yosys.yaml
+++ b/dau_build/config/backend/backends/yosys.yaml
@@ -1,0 +1,6 @@
+# @package backend
+
+# backend=backends/yosys (open-source synthesis; runnable in CI)
+_target_: dau_build.build_config.BackendConfig
+name: yosys
+invocation: standard

--- a/dau_build/config/task/tasks/build/synthesize.yaml
+++ b/dau_build/config/task/tasks/build/synthesize.yaml
@@ -7,4 +7,7 @@ board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
 module: ???
 engine: vivado
+# yosys-only fields (ignored for engine=vivado)
+frontend: verilog
+yosys: yosys
 output_root: ???

--- a/dau_build/tests/test_yosys_backend.py
+++ b/dau_build/tests/test_yosys_backend.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from shutil import which
+
+import pytest
+
+from dau_build.build_steps import execute_override_task
+from dau_build.yosys_backend import YosysBackendRequest, _parse_cell_count, run_yosys_synthesis, yosys_script_text
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_IDENTITY_SPEC = _REPO_ROOT / "examples" / "identity" / "dau-build.yaml"
+
+
+def _slang_available() -> bool:
+    if which("yosys") is None:
+        return False
+    try:
+        proc = subprocess.run(["yosys", "-m", "slang", "-p", "help read_slang"], capture_output=True, text=True)
+    except FileNotFoundError:
+        return False
+    return proc.returncode == 0
+
+
+requires_yosys = pytest.mark.skipif(which("yosys") is None, reason="yosys not found")
+requires_slang = pytest.mark.skipif(not _slang_available(), reason="yosys-slang plugin not found")
+
+
+def test_yosys_script_text_selects_frontend() -> None:
+    request = YosysBackendRequest(top_module="top", sources=(Path("a.sv"), Path("b.sv")), output_root=Path("out"))
+    verilog = yosys_script_text(request)
+    assert "read_verilog -sv a.sv b.sv" in verilog
+    assert "synth -top top" in verilog
+    assert verilog.strip().endswith("stat")
+
+    slang = yosys_script_text(request.model_copy(update={"frontend": "slang"}))
+    assert "read_slang --top top a.sv b.sv" in slang
+
+
+def test_yosys_script_text_elaborate_only_when_synth_disabled() -> None:
+    request = YosysBackendRequest(top_module="top", sources=(Path("a.sv"),), output_root=Path("out"), synth=False)
+    script = yosys_script_text(request)
+    assert "hierarchy -top top" in script
+    assert "check -assert" in script
+    assert "synth -top" not in script
+
+
+def test_parse_cell_count_handles_both_stat_formats() -> None:
+    assert _parse_cell_count("Number of cells:                 42\n") == 42
+    assert _parse_cell_count("=== top ===\n   696 wires\n   977 cells\n") == 977
+    assert _parse_cell_count("no stat here") is None
+
+
+@requires_yosys
+def test_run_yosys_synthesizes_a_module(tmp_path: Path) -> None:
+    source = tmp_path / "counter.sv"
+    source.write_text(
+        "module counter(input logic clk, input logic rst, output logic [3:0] q);\n"
+        "  always_ff @(posedge clk) q <= rst ? 4'd0 : q + 4'd1;\n"
+        "endmodule\n",
+        encoding="utf-8",
+    )
+    result = run_yosys_synthesis(YosysBackendRequest(top_module="counter", sources=(source,), output_root=tmp_path / "out"))
+    assert result.passed
+    assert result.returncode == 0
+    assert result.cell_count and result.cell_count > 0
+    assert result.script_path.is_file()
+    assert result.log_path.is_file()
+
+
+@requires_yosys
+def test_run_yosys_reports_a_synthesis_failure(tmp_path: Path) -> None:
+    source = tmp_path / "bad.sv"
+    source.write_text("module bad; missing_module u(); endmodule\n", encoding="utf-8")
+    result = run_yosys_synthesis(YosysBackendRequest(top_module="bad", sources=(source,), output_root=tmp_path / "out"))
+    assert not result.passed
+    assert result.returncode != 0
+
+
+@requires_yosys
+def test_synthesize_task_engine_yosys_runs_real_synthesis(tmp_path: Path) -> None:
+    result = execute_override_task(
+        ("task=tasks/build/synthesize", "engine=yosys", "module=identity", f"spec_path={_IDENTITY_SPEC}", f"output_root={tmp_path}")
+    )
+    assert result.step == "synthesize"
+    assert "engine=yosys frontend=verilog" in result.message
+    assert "status=synthesized" in result.message
+    assert (tmp_path / "dau_yosys.ys").is_file()
+
+
+@requires_slang
+def test_synthesize_task_engine_yosys_slang_frontend(tmp_path: Path) -> None:
+    result = execute_override_task(
+        ("task=tasks/build/synthesize", "engine=yosys", "frontend=slang", "module=identity", f"spec_path={_IDENTITY_SPEC}", f"output_root={tmp_path}")
+    )
+    assert result.step == "synthesize"
+    assert "engine=yosys frontend=slang" in result.message
+    assert "status=synthesized" in result.message

--- a/dau_build/yosys_backend.py
+++ b/dau_build/yosys_backend.py
@@ -1,0 +1,113 @@
+"""yosys synthesis backend.
+
+Unlike the Vivado backend, which generates a plan for a vendor tool run
+elsewhere, yosys is open-source and runnable directly — so this backend
+generates a yosys script and executes it, giving a real elaboration/synthesis
+check (in CI, not just a plan).
+
+Two SystemVerilog frontends are supported:
+
+- ``verilog`` — yosys's built-in ``read_verilog -sv``. Handles plain
+  synthesizable SV (the dau-build sources), needs no plugin.
+- ``slang`` — the yosys-slang plugin (``read_slang``), the same slang engine
+  as the project's ``pyslang`` parser. Full SV (packages, interfaces); loaded
+  with ``yosys -m slang``.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Literal
+
+from ccflow import BaseModel
+
+# yosys stat prints "Number of cells: N" (older) or "N cells" (0.6x+)
+_CELL_COUNT_RE = re.compile(r"Number of cells:\s*(\d+)|(\d+)\s+cells\b")
+
+
+class YosysBackendError(RuntimeError):
+    pass
+
+
+class YosysBackendRequest(BaseModel):
+    top_module: str
+    sources: tuple[Path, ...]
+    output_root: Path
+    frontend: Literal["verilog", "slang"] = "verilog"
+    # run full generic synthesis (synth -top) vs. elaborate-and-check only
+    synth: bool = True
+    yosys: str = "yosys"
+    script_name: str = "dau_yosys.ys"
+    log_name: str = "yosys.log"
+
+
+class YosysSynthesisResult(BaseModel):
+    top_module: str
+    frontend: str
+    passed: bool
+    returncode: int
+    cell_count: int | None
+    script_path: Path
+    log_path: Path
+
+
+def yosys_script_text(request: YosysBackendRequest) -> str:
+    """The yosys script that reads the sources with the selected frontend and
+    synthesizes (or elaborates and checks) the top module."""
+    files = " ".join(_quote(str(source)) for source in request.sources)
+    if request.frontend == "slang":
+        read = f"read_slang --top {request.top_module} {files}"
+    else:
+        read = f"read_verilog -sv {files}"
+    lines = [read]
+    if request.synth:
+        lines.append(f"synth -top {request.top_module}")
+    else:
+        lines += [f"hierarchy -top {request.top_module}", "proc", "check -assert"]
+    lines.append("stat")
+    return "\n".join(lines) + "\n"
+
+
+def write_yosys_backend_artifacts(request: YosysBackendRequest) -> Path:
+    """Write the yosys script under ``output_root`` and return its path."""
+    request.output_root.mkdir(parents=True, exist_ok=True)
+    script_path = request.output_root / request.script_name
+    script_path.write_text(yosys_script_text(request), encoding="utf-8")
+    return script_path
+
+
+def run_yosys_synthesis(request: YosysBackendRequest) -> YosysSynthesisResult:
+    """Write the script and run yosys. ``passed`` is the process exit status —
+    yosys exits non-zero on an elaboration/synthesis error. Raises
+    ``YosysBackendError`` if the yosys executable is not found."""
+    script_path = write_yosys_backend_artifacts(request)
+    argv = [request.yosys]
+    if request.frontend == "slang":
+        argv += ["-m", "slang"]
+    argv += ["-s", str(script_path)]
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True)
+    except FileNotFoundError as exc:
+        raise YosysBackendError(f"yosys executable {request.yosys!r} not found") from exc
+    log_path = request.output_root / request.log_name
+    log_path.write_text(proc.stdout + proc.stderr, encoding="utf-8")
+    return YosysSynthesisResult(
+        top_module=request.top_module,
+        frontend=request.frontend,
+        passed=proc.returncode == 0,
+        returncode=proc.returncode,
+        cell_count=_parse_cell_count(proc.stdout),
+        script_path=script_path,
+        log_path=log_path,
+    )
+
+
+def _parse_cell_count(log: str) -> int | None:
+    counts = [int(a or b) for a, b in _CELL_COUNT_RE.findall(log)]
+    return counts[-1] if counts else None
+
+
+def _quote(path: str) -> str:
+    return f'"{path}"' if " " in path else path

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -135,31 +135,44 @@ They are independent groups, composed together into a task's
 physical dpv1 definition can be reused regardless of which backend produced a
 bitstream.
 
-## Backends: Vivado today, others later
+## Backends: Vivado and yosys
 
-**Only the Vivado backend is real today.** Understanding the current shape makes
-clear what adding another backend involves.
+Two synthesis engines are real: **Vivado** (the FPGA bitstream flow) and
+**yosys** (open-source synthesis). They differ in an important way that shapes
+how each is used.
 
 `BackendConfig` has two fields, `name` and `invocation`, and it is a *label*, not
 a driver. `invocation` (`standard` vs `dry-run`) is surfaced in the resolved
 config as metadata and is not branched on. The `backends/none` option is that
-label with no toolchain behind it — a dry-run. So selecting `backend=backends/...`
-changes what the resolved config *reports*, not what codegen runs.
+label with no toolchain behind it. So selecting `backend=backends/...` changes
+what the resolved config *reports*, not what codegen runs.
 
-What actually runs codegen is the synthesis engine. `SynthesizeTask.engine` is a
-`Literal["vivado"]` — it accepts nothing else — and the task unconditionally
-writes the Vivado backend handoff. The real backend implementation lives in
-`vivado_backend.py`, which generates text artifacts (overlay Tcl, build Tcl, a
-key=value manifest, a command plan) and never spawns Vivado itself; that happens
-in the `execute=true` build tasks and in `hardware_plan.py`. There is no dispatch
-table keyed on backend name — the wiring from `engine="vivado"` to the Vivado
-generator is direct.
+What actually runs is the synthesis engine. `SynthesizeTask.engine` is a
+`Literal["vivado", "yosys"]`, and the task dispatches on it:
 
-So the config-group plumbing, the open registry, the `_target_` indirection, and
-the search-path extension are all backend-agnostic and ready; what is missing for,
-say, a yosys/nextpnr flow is a second *implementation*: a backend module
-paralleling `vivado_backend.py`, a widened `engine` literal with real dispatch,
-and its task configs. There is no yosys, nextpnr, or other backend scaffolding in
-the tree today — not a stub, not a config file. That is a deliberate honesty about
-the current state, not an oversight. [Extending dau-build](../how-to/extend-dau-build.md)
-walks through exactly what a new backend requires.
+- **`engine=vivado`** writes a Vivado backend *handoff* — the real
+  implementation in `vivado_backend.py` generates text artifacts (overlay Tcl,
+  build Tcl, a key=value manifest, a command plan) but never spawns Vivado;
+  that happens later in the `execute=true` build tasks and in `hardware_plan.py`.
+  Vivado is not present in CI, so this path is plan-only there.
+- **`engine=yosys`** *runs* synthesis. `yosys_backend.py` generates a yosys
+  script and executes it, so the generated top is actually elaborated and
+  synthesized — a real check, not a plan. yosys is open-source and installs in
+  CI, which is the point: `engine=yosys` turns synthesis into something the test
+  suite can exercise on every run.
+
+The yosys backend supports two SystemVerilog frontends, selected with
+`frontend=`: `verilog` (yosys's built-in `read_verilog -sv`, enough for
+dau-build's own synthesizable sources) and `slang` (the yosys-slang plugin's
+`read_slang`, the same slang engine as the project's `pyslang` parser, for the
+full SV surface — packages, interfaces — that the private cores use). The
+frontend is a script-generation detail; the run path is identical.
+
+There is no dispatch *table* keyed on backend name — the wiring from each engine
+value to its generator is direct. That is enough for two engines; a third (a
+nextpnr place-and-route flow, another vendor) would add its own module and engine
+branch. The config-group plumbing, the open registry, the `_target_`
+indirection, and the search-path extension are all backend-agnostic, so most of a
+new backend composes from a package without touching dau-build —
+[Extending dau-build](../how-to/extend-dau-build.md) walks through exactly what a
+new backend requires, using yosys as the worked example.

--- a/docs/how-to/extend-dau-build.md
+++ b/docs/how-to/extend-dau-build.md
@@ -94,46 +94,41 @@ add `mypkg/config/platform/platforms/<vendor>/<board>.yaml` targeting
 
 ## Add a synthesis backend
 
-Adding a *real* backend (for example a yosys/nextpnr flow) is more than a config
-file, because today `BackendConfig` is only a label and synthesis codegen is
-hard-wired to Vivado. Read
+Adding a *real* backend is more than a config file, because `BackendConfig` is
+only a label — the engine that runs codegen is `SynthesizeTask.engine`. The
+yosys backend is the worked example of a second engine; read
 [the backend section of the architecture explanation](../explanation/architecture.md)
-first — it describes exactly what is a label and what is wired.
-
-A new backend requires four things:
+first, then use `yosys_backend.py` as the template. A new backend requires:
 
 1. **A backend label**, so it is selectable. Add
-   `<pkg>/config/backend/backends/yosys.yaml` reusing the existing model:
+   `<pkg>/config/backend/backends/<name>.yaml` reusing the existing model
+   (this is exactly `backends/yosys.yaml`):
 
    ```yaml
    # @package backend
 
    _target_: dau_build.build_config.BackendConfig
-   name: yosys
+   name: nextpnr
    invocation: standard
    ```
 
    By itself this only changes the reported metadata in the resolved config.
 
-1. **A backend module** that generates the flow's artifacts, paralleling
-   `dau_build/vivado_backend.py`: its own request/artifact `ccflow.BaseModel`s
-   and `generate_*`/`validate_*` entry points, emitting whatever scripts and
-   manifests the yosys/nextpnr flow needs, with a backend identity string
-   analogous to `dau_build.vivado_backend.vivado_overlay`.
+1. **A backend module.** Parallel `dau_build/yosys_backend.py` (or
+   `vivado_backend.py`): its own request/result `ccflow.BaseModel`s and entry
+   points that either generate a plan (Vivado's Tcl/manifests) or generate and
+   run a tool (yosys's script + `run_yosys_synthesis`).
 
-1. **Real engine dispatch.** `SynthesizeTask.engine` is currently
-   `Literal["vivado"]` and the task calls the Vivado handoff unconditionally.
-   Widen the literal to include your engine and replace that unconditional call
-   with a branch on `engine`. This is the change that must land *in dau-build*
-   (or in a fork), since the dispatch lives there — the other pieces can live in
-   your package.
+1. **Engine dispatch.** `SynthesizeTask.engine` is `Literal["vivado", "yosys"]`
+   and the task branches on it (`_synthesize_with_yosys`). Widen the literal and
+   add a branch for your engine. This is the change that lands *in dau-build*
+   (or a fork), since the dispatch lives there.
 
-1. **Build and validate tasks**, paralleling `build-vivado-artifacts.yaml` and
-   `validate-vivado-artifacts.yaml`, each targeting a new build-step
-   `ccflow.CallableModel` for your backend.
+1. **Any build/validate tasks** your flow needs, paralleling the Vivado ones,
+   each targeting a new `ccflow.CallableModel`.
 
-Everything except step 3 composes purely from your package via the search path.
-Until a backend implements steps 2–4, selecting its label runs no real codegen.
+The config label composes purely from your package via the search path; the
+engine branch is the one piece that lives in dau-build.
 
 ## Try it without packaging
 

--- a/docs/how-to/run-a-build.md
+++ b/docs/how-to/run-a-build.md
@@ -6,8 +6,10 @@ composed and checked on your development machine, and only the `execute=true`
 step needs a Vivado host.
 
 The stages are **synthesize → stage → build → validate**, then hand off to
-[programming the board](program-hardware.md). Vivado is the only backend today,
-so every backend-specific command below is a `vivado` command.
+[programming the board](program-hardware.md). This guide is the Vivado bitstream
+flow, so every backend-specific command below is a `vivado` command. For a fast
+open-source synthesis check that runs anywhere, use `engine=yosys` on the
+synthesize task instead (see the [task catalog](../reference/tasks-and-steps.md)).
 
 Field lists for each task are in the [task catalog](../reference/tasks-and-steps.md).
 To see the full resolved config for any command before running it, prefix it with

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -107,15 +107,16 @@ shell: xdma-ddr
 
 `backend=backends/vivado` composes `BackendConfig` into the `backend` key.
 
-| Option            | `name`   | `invocation` | Description                    |
-| ----------------- | -------- | ------------ | ------------------------------ |
-| `backends/vivado` | `vivado` | `standard`   | The Vivado/XDMA backend.       |
-| `backends/none`   | `none`   | `dry-run`    | No vendor toolchain (dry-run). |
+| Option            | `name`   | `invocation` | Description                         |
+| ----------------- | -------- | ------------ | ----------------------------------- |
+| `backends/vivado` | `vivado` | `standard`   | The Vivado/XDMA backend.            |
+| `backends/yosys`  | `yosys`  | `standard`   | Open-source synthesis (runs in CI). |
+| `backends/none`   | `none`   | `dry-run`    | No vendor toolchain (dry-run).      |
 
-`BackendConfig` fields: `name` (str), `invocation` (str). Vivado is the only
-backend with a real implementation. See
-[the architecture explanation](../explanation/architecture.md) for
-current-vs-future backend support.
+`BackendConfig` fields: `name` (str), `invocation` (str). It is a label; the
+engine that runs codegen is `SynthesizeTask.engine` (`vivado` or `yosys`). See
+[the architecture explanation](../explanation/architecture.md) for how the two
+engines differ.
 
 ## `platform`
 

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -48,10 +48,17 @@ bench; `simulator=verilator` compiles and runs a Verilator testbench via a named
 
 ### `tasks/build/synthesize` — `SynthesizeTask`
 
-Writes the generated DAU top, DAU manifest, `artlink.manifest/v0` bundle, and the
-`vivado/<artifact-stem>.manifest` backend handoff at `build_status=planned`. Does
-not invoke Vivado. Required: `module`, `output_root`. Default `engine: vivado`.
-Mode: **run** (produces a planned manifest).
+Writes the generated DAU top, manifest, and `artlink.manifest/v0` bundle, then
+dispatches on `engine`. Required: `module`, `output_root`.
+
+- `engine=vivado` (default) writes the `vivado/<artifact-stem>.manifest` backend
+  handoff at `build_status=planned` and does not invoke Vivado.
+- `engine=yosys` runs a real synthesis of the generated top with yosys, failing
+  the task if synthesis fails. `frontend=verilog` (default) uses
+  `read_verilog -sv`; `frontend=slang` uses the yosys-slang plugin; `yosys` sets
+  the executable.
+
+Mode: **run**.
 
 ### `tasks/build/build-shell-project` — `BuildShellProjectTask`
 


### PR DESCRIPTION
## What

Adds a second, open-source synthesis engine (yosys) so the build path runs *real* synthesis in CI, not just a Vivado plan. This is what lets more of the suite actually exercise synthesis on every run.

- **`yosys_backend.py`** — generates a yosys script and runs it, returning pass/fail + cell count. Two SystemVerilog frontends: `verilog` (`read_verilog -sv`, built in — enough for dau-build\047s own synthesizable SV) and `slang` (yosys-slang `read_slang`, the same slang engine as the project\047s `pyslang` parser, for the package/interface-heavy private SV).
- **`SynthesizeTask.engine`** widens to `vivado|yosys` and dispatches. `engine=yosys` elaborates and synthesizes the generated top and fails the task on any synthesis error. New `frontend`/`yosys` fields; the `engine=vivado` path and message are byte-unchanged.
- **`backend=backends/yosys`** label.
- **CI** installs `yosys` + `yosys-slang` from the public `dau-dev/tools` v0.0.13 debs, so the synthesis tests run there. Tests gate on tool availability (`which("yosys")` / slang plugin) and skip cleanly where absent.

## Validation

- Verilog path validated locally against the identity example (real synth: 977 cells; undefined-module → failure). 224 passed + 1 skipped (the slang test, which runs in CI).
- The `slang` frontend runs for the first time in *this PR\047s CI* — it validates the exact `read_slang` invocation. If the syntax needs adjusting, CI will show it.
- ruff clean; yardang build zero warnings; README passes mdformat.

## Notes / follow-ups

- `read_verilog -sv` covers dau-build\047s bundled SV; `frontend=slang` is for the private cores\047 fuller SV.
- yosys is a synthesis *check*, not a bitstream flow — the Vivado engine still owns the FPGA build/program path.