### PR TITLE
Make the synthesis engine hydra-first (backend group = engines)

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -60,11 +60,15 @@ class ResolvedBuildConfig(BaseModel):
         operators, and memory derive from the spec directly. A composed
         ``board=``/``backend=`` Hydra group wins over the spec-derived
         default when provided; ``backend_name`` (e.g. a task's synthesis
-        engine) selects the backend when no ``backend=`` group is given."""
+        engine) selects the backend when no ``backend=`` group is given.
+
+        A composed backend may be a synthesis *engine* model (carrying extra
+        fields like a yosys frontend); it is normalized here to the ``name`` +
+        ``invocation`` label the resolved config reports."""
         return cls(
             spec=spec,
             board=board or BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
-            backend=backend or BackendConfig(name=backend_name or spec.backend, invocation="dry-run"),
+            backend=_backend_label(backend, backend_name, spec),
             driver=DriverConfig(os="host", transport="xdma"),
             operators=OperatorConfig(set_name="spec", names=spec.operators),
             memory=MemoryConfig(),
@@ -81,3 +85,14 @@ class ResolvedBuildConfig(BaseModel):
                 f"memory\thost_staging_bytes={self.memory.host_staging_bytes} device_staging_bytes={self.memory.device_staging_bytes}",
             )
         )
+
+
+def _backend_label(backend, backend_name: str | None, spec: DauBuildSpec) -> BackendConfig:
+    """Normalize a composed backend (a BackendConfig or a synthesis engine
+    model with extra fields) to the name+invocation label the resolved config
+    reports, or derive it from ``backend_name`` / the spec."""
+    if isinstance(backend, BackendConfig):
+        return backend
+    if backend is not None:
+        return BackendConfig(name=backend.name, invocation=getattr(backend, "invocation", "standard"))
+    return BackendConfig(name=backend_name or spec.backend, invocation="dry-run")

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any, ClassVar, Literal, TypeVar
 
-from ccflow import CallableModel, Flow, NullContext, ResultBase
+from ccflow import BaseModel, CallableModel, Flow, NullContext, ResultBase
 from pydantic import Field, ValidationError, field_validator
 
 from dau_build.hardware_plan import (
@@ -402,24 +402,28 @@ class SimulateTask(ModuleSelectionModel):
         )
 
 
-class SynthesizeTask(ModuleSelectionModel):
-    engine: Literal["vivado", "yosys"]
-    output_root: Path
-    # yosys-only: the SystemVerilog frontend and executable
-    frontend: Literal["verilog", "slang"] = "verilog"
-    yosys: str = "yosys"
+class SynthesisEngine(BaseModel):
+    """A synthesis engine selected from the ``backend`` config group. Each
+    engine is a polymorphic, fully hydra-configurable model
+    (``backend=backends/yosys backend.frontend=slang``); ``SynthesizeTask``
+    delegates to ``synthesize`` — there is no engine ``Literal`` or dispatch
+    ``if``."""
 
-    @Flow.call
-    def __call__(self, context: NullContext) -> BuildStepResult:
-        spec = self.load_spec_and_validate_module()
-        resolved = self._resolved(spec, backend_name=self.engine)
-        artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
-        if self.engine == "yosys":
-            return self._synthesize_with_yosys(spec, artifacts)
+    name: str
+    invocation: str = "standard"
+
+    def synthesize(self, *, task: "SynthesizeTask", spec, artifacts, resolved) -> BuildStepResult:
+        raise NotImplementedError
+
+
+class VivadoEngine(SynthesisEngine):
+    name: str = "vivado"
+
+    def synthesize(self, *, task: "SynthesizeTask", spec, artifacts, resolved) -> BuildStepResult:
         backend_artifacts = _write_vivado_backend_handoff(
             spec,
-            selected_module=self.module,
-            output_root=self.output_root,
+            selected_module=task.module,
+            output_root=task.output_root,
             dau_artifact_bundle_path=artifacts.artifact_manifest_path,
             platform=resolved.board.platform,
             shell=resolved.board.shell,
@@ -428,13 +432,19 @@ class SynthesizeTask(ModuleSelectionModel):
         return BuildStepResult(
             step="synthesize",
             message=(
-                f"dau-build-synthesize\ttask=synthesize engine={self.engine} module={self.module} spec={self.spec_label} "
-                f"output_root={self.output_root} manifest={artifacts.manifest_path} top_sv={artifacts.top_sv_path} "
+                f"dau-build-synthesize\ttask=synthesize engine={self.name} module={task.module} spec={task.spec_label} "
+                f"output_root={task.output_root} manifest={artifacts.manifest_path} top_sv={artifacts.top_sv_path} "
                 f"backend_manifest={backend_artifacts.manifest_path} command_plan={backend_artifacts.command_plan_path} status=handoff-written"
             ),
         )
 
-    def _synthesize_with_yosys(self, spec, artifacts) -> BuildStepResult:
+
+class YosysEngine(SynthesisEngine):
+    name: str = "yosys"
+    frontend: Literal["verilog", "slang"] = "verilog"
+    yosys: str = "yosys"
+
+    def synthesize(self, *, task: "SynthesizeTask", spec, artifacts, resolved) -> BuildStepResult:
         # yosys is runnable (unlike the Vivado plan), so this actually
         # elaborates and synthesizes the generated top — a real check
         from dau_build.yosys_backend import YosysBackendError, YosysBackendRequest, run_yosys_synthesis
@@ -442,7 +452,7 @@ class SynthesizeTask(ModuleSelectionModel):
         request = YosysBackendRequest(
             top_module=spec.top_name,
             sources=(artifacts.top_sv_path, *spec.sources),
-            output_root=self.output_root,
+            output_root=task.output_root,
             frontend=self.frontend,
             yosys=self.yosys,
         )
@@ -455,11 +465,31 @@ class SynthesizeTask(ModuleSelectionModel):
         return BuildStepResult(
             step="synthesize",
             message=(
-                f"dau-build-synthesize\ttask=synthesize engine=yosys frontend={self.frontend} module={self.module} "
-                f"spec={self.spec_label} top={spec.top_name} output_root={self.output_root} "
+                f"dau-build-synthesize\ttask=synthesize engine={self.name} frontend={self.frontend} module={task.module} "
+                f"spec={task.spec_label} top={spec.top_name} output_root={task.output_root} "
                 f"script={result.script_path} cells={result.cell_count} status=synthesized"
             ),
         )
+
+
+class SynthesizeTask(ModuleSelectionModel):
+    output_root: Path
+
+    @Flow.call
+    def __call__(self, context: NullContext) -> BuildStepResult:
+        spec = self.load_spec_and_validate_module()
+        engine = self._engine()
+        resolved = self._resolved(spec, backend_name=engine.name)
+        artifacts = _build_spec_api().write_dau_build_artifacts(spec, output_root=self.output_root)
+        return engine.synthesize(task=self, spec=spec, artifacts=artifacts, resolved=resolved)
+
+    def _engine(self) -> SynthesisEngine:
+        # the engine is the composed `backend` group option; default to Vivado
+        if isinstance(self.backend, SynthesisEngine):
+            return self.backend
+        if self.backend is None:
+            return VivadoEngine()
+        raise BuildStepError(f"backend {getattr(self.backend, 'name', self.backend)!r} is not a synthesis engine")
 
 
 def _bitstream_from_shell_build_manifest(manifest_path: Path) -> Path:

--- a/dau_build/config/backend/backends/vivado.yaml
+++ b/dau_build/config/backend/backends/vivado.yaml
@@ -1,6 +1,6 @@
 # @package backend
 
-# backend=backends/vivado
-_target_: dau_build.build_config.BackendConfig
+# backend=backends/vivado — the Vivado synthesis engine (FPGA bitstream flow)
+_target_: dau_build.build_steps.VivadoEngine
 name: vivado
 invocation: standard

--- a/dau_build/config/backend/backends/yosys.yaml
+++ b/dau_build/config/backend/backends/yosys.yaml
@@ -1,6 +1,9 @@
 # @package backend
 
-# backend=backends/yosys (open-source synthesis; runnable in CI)
-_target_: dau_build.build_config.BackendConfig
+# backend=backends/yosys — open-source synthesis engine (runs in CI).
+# Fully configurable, e.g. backend=backends/yosys backend.frontend=slang
+_target_: dau_build.build_steps.YosysEngine
 name: yosys
 invocation: standard
+frontend: verilog
+yosys: yosys

--- a/dau_build/config/task/tasks/build/synthesize.yaml
+++ b/dau_build/config/task/tasks/build/synthesize.yaml
@@ -4,10 +4,8 @@ _target_: dau_build.build_steps.SynthesizeTask
 spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
+# the synthesis engine is the composed backend group (default vivado);
+# select+configure it with backend=backends/yosys backend.frontend=slang
 backend: ${oc.select:backend,null}
 module: ???
-engine: vivado
-# yosys-only fields (ignored for engine=vivado)
-frontend: verilog
-yosys: yosys
 output_root: ???

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -73,7 +73,6 @@ def test_execute_override_task_maps_synthesize_engine_to_backend_handoff(tmp_pat
     result = execute_override_task(
         (
             "task=tasks/build/synthesize",
-            "engine=vivado",
             "module=dau_identity_top",
             f"spec_path={spec_path}",
             f"output_root={output_root}",
@@ -101,7 +100,6 @@ def test_synthesize_vivado_consumes_arrow_lite_aggregator_bundle_for_flash_and_s
     synthesize_result = execute_override_task(
         (
             "task=tasks/build/synthesize",
-            "engine=vivado",
             "module=stream_doubler",
             f"spec_path={spec_path}",
             f"output_root={output_root}",
@@ -145,7 +143,6 @@ def test_manifest_driven_flash_rejects_planned_backend_manifest(tmp_path: Path) 
     execute_override_task(
         (
             "task=tasks/build/synthesize",
-            "engine=vivado",
             "module=stream_doubler",
             f"spec_path={spec_path}",
             f"output_root={output_root}",
@@ -164,7 +161,6 @@ def test_manifest_driven_smoke_rejects_incomplete_built_backend_manifest(tmp_pat
     execute_override_task(
         (
             "task=tasks/build/synthesize",
-            "engine=vivado",
             "module=stream_doubler",
             f"spec_path={spec_path}",
             f"output_root={output_root}",

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -187,18 +187,20 @@ def _write_spec(tmp_path: Path) -> Path:
 
 
 def test_nested_board_and_backend_config_groups_compose() -> None:
-    # path-style group selection: board=boards/dau/dpv1 backend=backends/vivado
+    # path-style group selection: board=boards/dau/dpv1 backend=backends/vivado.
+    # the backend group composes a synthesis engine model.
     from hydra import compose, initialize_config_module
     from hydra.utils import instantiate
 
-    from dau_build.build_config import BackendConfig, BoardConfig
+    from dau_build.build_config import BoardConfig
+    from dau_build.build_steps import VivadoEngine
 
     with initialize_config_module(config_module="dau_build.config", version_base=None):
         cfg = compose(config_name="base", overrides=["board=boards/dau/dpv1", "backend=backends/vivado"])
     board = instantiate(cfg.board)
     backend = instantiate(cfg.backend)
     assert isinstance(board, BoardConfig) and board.name == "dpv1" and board.platform == "vivado-xdma"
-    assert isinstance(backend, BackendConfig) and backend.name == "vivado"
+    assert isinstance(backend, VivadoEngine) and backend.name == "vivado"
 
 
 def test_dau_build_registers_a_hydra_searchpath_entry_point() -> None:

--- a/dau_build/tests/test_yosys_backend.py
+++ b/dau_build/tests/test_yosys_backend.py
@@ -6,7 +6,7 @@ from shutil import which
 
 import pytest
 
-from dau_build.build_steps import execute_override_task
+from dau_build.config import run_request_config
 from dau_build.yosys_backend import YosysBackendRequest, _parse_cell_count, run_yosys_synthesis, yosys_script_text
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -79,9 +79,13 @@ def test_run_yosys_reports_a_synthesis_failure(tmp_path: Path) -> None:
 
 
 @requires_yosys
-def test_synthesize_task_engine_yosys_runs_real_synthesis(tmp_path: Path) -> None:
-    result = execute_override_task(
-        ("task=tasks/build/synthesize", "engine=yosys", "module=identity", f"spec_path={_IDENTITY_SPEC}", f"output_root={tmp_path}")
+def test_synthesize_task_yosys_engine_runs_real_synthesis(tmp_path: Path) -> None:
+    # the engine is the composed backend group: backend=backends/yosys
+    result = run_request_config(
+        "task",
+        "tasks/build/synthesize",
+        overrides=["backend=backends/yosys"],
+        model_values={"module": "identity", "spec_path": str(_IDENTITY_SPEC), "output_root": str(tmp_path)},
     )
     assert result.step == "synthesize"
     assert "engine=yosys frontend=verilog" in result.message
@@ -90,9 +94,13 @@ def test_synthesize_task_engine_yosys_runs_real_synthesis(tmp_path: Path) -> Non
 
 
 @requires_slang
-def test_synthesize_task_engine_yosys_slang_frontend(tmp_path: Path) -> None:
-    result = execute_override_task(
-        ("task=tasks/build/synthesize", "engine=yosys", "frontend=slang", "module=identity", f"spec_path={_IDENTITY_SPEC}", f"output_root={tmp_path}")
+def test_synthesize_task_yosys_slang_frontend_via_hydra_override(tmp_path: Path) -> None:
+    # the engine is fully hydra-configurable: backend.frontend=slang
+    result = run_request_config(
+        "task",
+        "tasks/build/synthesize",
+        overrides=["backend=backends/yosys", "backend.frontend=slang"],
+        model_values={"module": "identity", "spec_path": str(_IDENTITY_SPEC), "output_root": str(tmp_path)},
     )
     assert result.step == "synthesize"
     assert "engine=yosys frontend=slang" in result.message

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -138,41 +138,37 @@ bitstream.
 ## Backends: Vivado and yosys
 
 Two synthesis engines are real: **Vivado** (the FPGA bitstream flow) and
-**yosys** (open-source synthesis). They differ in an important way that shapes
-how each is used.
+**yosys** (open-source synthesis). The engine is chosen the hydra-first way —
+it *is* the `backend` config group. Each option instantiates a polymorphic
+`SynthesisEngine` model, and `SynthesizeTask` just delegates to
+`engine.synthesize(...)`. There is no engine `Literal` and no `if engine ==`
+dispatch branch; adding an engine is adding a model and a yaml.
 
-`BackendConfig` has two fields, `name` and `invocation`, and it is a *label*, not
-a driver. `invocation` (`standard` vs `dry-run`) is surfaced in the resolved
-config as metadata and is not branched on. The `backends/none` option is that
-label with no toolchain behind it. So selecting `backend=backends/...` changes
-what the resolved config *reports*, not what codegen runs.
+- **`backend=backends/vivado`** (the default) composes a `VivadoEngine`, which
+  writes a Vivado *handoff* — `vivado_backend.py` generates text artifacts
+  (overlay Tcl, build Tcl, a key=value manifest, a command plan) but never
+  spawns Vivado; that happens later in the `execute=true` build tasks and in
+  `hardware_plan.py`. Vivado is not present in CI, so this path is plan-only there.
+- **`backend=backends/yosys`** composes a `YosysEngine`, which *runs* synthesis.
+  `yosys_backend.py` generates a yosys script and executes it, so the generated
+  top is actually elaborated and synthesized — a real check, not a plan. yosys is
+  open-source and installs in CI, which is the point: it turns synthesis into
+  something the test suite can exercise on every run.
 
-What actually runs is the synthesis engine. `SynthesizeTask.engine` is a
-`Literal["vivado", "yosys"]`, and the task dispatches on it:
+Because the engine is a composed model, it is fully hydra-configurable. The
+`YosysEngine`'s SystemVerilog frontend is a field, set like any other override:
+`backend=backends/yosys backend.frontend=slang` (or `+backend.<field>=...`).
+`frontend=verilog` uses yosys's built-in `read_verilog -sv` (enough for
+dau-build's own synthesizable sources); `frontend=slang` uses the yosys-slang
+plugin's `read_slang`, the same slang engine as the project's `pyslang` parser,
+for the full SV surface (packages, interfaces) the private cores use.
 
-- **`engine=vivado`** writes a Vivado backend *handoff* — the real
-  implementation in `vivado_backend.py` generates text artifacts (overlay Tcl,
-  build Tcl, a key=value manifest, a command plan) but never spawns Vivado;
-  that happens later in the `execute=true` build tasks and in `hardware_plan.py`.
-  Vivado is not present in CI, so this path is plan-only there.
-- **`engine=yosys`** *runs* synthesis. `yosys_backend.py` generates a yosys
-  script and executes it, so the generated top is actually elaborated and
-  synthesized — a real check, not a plan. yosys is open-source and installs in
-  CI, which is the point: `engine=yosys` turns synthesis into something the test
-  suite can exercise on every run.
-
-The yosys backend supports two SystemVerilog frontends, selected with
-`frontend=`: `verilog` (yosys's built-in `read_verilog -sv`, enough for
-dau-build's own synthesizable sources) and `slang` (the yosys-slang plugin's
-`read_slang`, the same slang engine as the project's `pyslang` parser, for the
-full SV surface — packages, interfaces — that the private cores use). The
-frontend is a script-generation detail; the run path is identical.
-
-There is no dispatch *table* keyed on backend name — the wiring from each engine
-value to its generator is direct. That is enough for two engines; a third (a
-nextpnr place-and-route flow, another vendor) would add its own module and engine
-branch. The config-group plumbing, the open registry, the `_target_`
-indirection, and the search-path extension are all backend-agnostic, so most of a
-new backend composes from a package without touching dau-build —
+The engine model carries only `name`/`invocation` up to the resolved-config view
+(`ResolvedBuildConfig` normalizes it to that label), so an engine's own fields
+never leak into the build-config reporting. A third engine (a nextpnr
+place-and-route flow, another vendor) is a new `SynthesisEngine` subclass and a
+yaml; the config-group plumbing, the open registry, the `_target_` indirection,
+and the search-path extension are all engine-agnostic, so it can even come from a
+package without touching dau-build —
 [Extending dau-build](../how-to/extend-dau-build.md) walks through exactly what a
-new backend requires, using yosys as the worked example.
+new engine requires, using yosys as the worked example.

--- a/docs/how-to/extend-dau-build.md
+++ b/docs/how-to/extend-dau-build.md
@@ -92,43 +92,43 @@ add `mypkg/config/platform/platforms/<vendor>/<board>.yaml` targeting
 `dau_build.platforms.PlatformDefinition`. Select them with
 `board=boards/<vendor>/<board>` and `platform=platforms/<vendor>/<board>`.
 
-## Add a synthesis backend
+## Add a synthesis engine
 
-Adding a *real* backend is more than a config file, because `BackendConfig` is
-only a label — the engine that runs codegen is `SynthesizeTask.engine`. The
-yosys backend is the worked example of a second engine; read
+The synthesis engine is the `backend` config group: each option instantiates a
+polymorphic `SynthesisEngine` model, and `SynthesizeTask` delegates to
+`engine.synthesize(...)` — there is no dispatch `if` to edit. `YosysEngine` is
+the worked example; read
 [the backend section of the architecture explanation](../explanation/architecture.md)
-first, then use `yosys_backend.py` as the template. A new backend requires:
+first, then use `yosys_backend.py` + `YosysEngine` as the template. A new engine
+requires:
 
-1. **A backend label**, so it is selectable. Add
-   `<pkg>/config/backend/backends/<name>.yaml` reusing the existing model
-   (this is exactly `backends/yosys.yaml`):
+1. **An engine model** — a `SynthesisEngine` subclass with a `synthesize`
+   method and whatever fields it needs (like `YosysEngine.frontend`). Its
+   `synthesize` either generates a plan (Vivado's Tcl/manifests) or generates and
+   runs a tool (yosys's script + `run_yosys_synthesis`). Put its heavy backend
+   logic in a module paralleling `yosys_backend.py`.
+
+1. **A config option** so it is selectable and configurable. Add
+   `<pkg>/config/backend/backends/<name>.yaml` (this is exactly
+   `backends/yosys.yaml`):
 
    ```yaml
    # @package backend
 
-   _target_: dau_build.build_config.BackendConfig
+   _target_: mypkg.engines.NextpnrEngine
    name: nextpnr
    invocation: standard
    ```
 
-   By itself this only changes the reported metadata in the resolved config.
-
-1. **A backend module.** Parallel `dau_build/yosys_backend.py` (or
-   `vivado_backend.py`): its own request/result `ccflow.BaseModel`s and entry
-   points that either generate a plan (Vivado's Tcl/manifests) or generate and
-   run a tool (yosys's script + `run_yosys_synthesis`).
-
-1. **Engine dispatch.** `SynthesizeTask.engine` is `Literal["vivado", "yosys"]`
-   and the task branches on it (`_synthesize_with_yosys`). Widen the literal and
-   add a branch for your engine. This is the change that lands *in dau-build*
-   (or a fork), since the dispatch lives there.
+   It composes as `backend=backends/<name>` and is fully configurable via
+   `backend.<field>=...` — no change to `SynthesizeTask`.
 
 1. **Any build/validate tasks** your flow needs, paralleling the Vivado ones,
    each targeting a new `ccflow.CallableModel`.
 
-The config label composes purely from your package via the search path; the
-engine branch is the one piece that lives in dau-build.
+Because the engine is just a composed model, an engine defined in your own
+package composes purely via the search path — nothing lands in dau-build unless
+you extend the packaged set.
 
 ## Try it without packaging
 

--- a/docs/how-to/run-a-build.md
+++ b/docs/how-to/run-a-build.md
@@ -8,8 +8,9 @@ step needs a Vivado host.
 The stages are **synthesize → stage → build → validate**, then hand off to
 [programming the board](program-hardware.md). This guide is the Vivado bitstream
 flow, so every backend-specific command below is a `vivado` command. For a fast
-open-source synthesis check that runs anywhere, use `engine=yosys` on the
-synthesize task instead (see the [task catalog](../reference/tasks-and-steps.md)).
+open-source synthesis check that runs anywhere, select the yosys engine on the
+synthesize task instead (`backend=backends/yosys`; see the
+[task catalog](../reference/tasks-and-steps.md)).
 
 Field lists for each task are in the [task catalog](../reference/tasks-and-steps.md).
 To see the full resolved config for any command before running it, prefix it with

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -29,16 +29,16 @@ Each option file begins with a `# @package <key>` directive that places its
 content under that top-level key. Tasks and steps use `# @package model`; the
 other groups use their singular key (`# @package board`, etc.).
 
-| Group      | `@package` key | Instantiated model                       | Selects                                                          |
-| ---------- | -------------- | ---------------------------------------- | ---------------------------------------------------------------- |
-| `task`     | `model`        | a `…Task` `ccflow.CallableModel`         | The unit of work to run.                                         |
-| `step`     | `model`        | a `…Step` `ccflow.CallableModel`         | A lower-level plumbing operation.                                |
-| `spec`     | `spec`         | `dau_build.build_spec.BuildSpec`         | A composed build spec (Hydra-native alternative to `spec_path`). |
-| `board`    | `board`        | `dau_build.build_config.BoardConfig`     | A board's build-config view.                                     |
-| `backend`  | `backend`      | `dau_build.build_config.BackendConfig`   | The synthesis backend.                                           |
-| `platform` | `platform`     | `dau_build.platforms.PlatformDefinition` | The full physical platform definition.                           |
-| `design`   | `design`       | (none packaged)                          | Reserved; registered by extension packages.                      |
-| `callable` | —              | ccflow registry pointer                  | Fixed evaluator wiring; not normally overridden.                 |
+| Group      | `@package` key | Instantiated model                        | Selects                                                          |
+| ---------- | -------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| `task`     | `model`        | a `…Task` `ccflow.CallableModel`          | The unit of work to run.                                         |
+| `step`     | `model`        | a `…Step` `ccflow.CallableModel`          | A lower-level plumbing operation.                                |
+| `spec`     | `spec`         | `dau_build.build_spec.BuildSpec`          | A composed build spec (Hydra-native alternative to `spec_path`). |
+| `board`    | `board`        | `dau_build.build_config.BoardConfig`      | A board's build-config view.                                     |
+| `backend`  | `backend`      | a `SynthesisEngine` (e.g. `VivadoEngine`) | The synthesis engine.                                            |
+| `platform` | `platform`     | `dau_build.platforms.PlatformDefinition`  | The full physical platform definition.                           |
+| `design`   | `design`       | (none packaged)                           | Reserved; registered by extension packages.                      |
+| `callable` | —              | ccflow registry pointer                   | Fixed evaluator wiring; not normally overridden.                 |
 
 ## `task`
 
@@ -105,16 +105,20 @@ shell: xdma-ddr
 
 ## `backend`
 
-`backend=backends/vivado` composes `BackendConfig` into the `backend` key.
+`backend=backends/<name>` composes a synthesis engine into the `backend` key.
+`SynthesizeTask` uses it as the engine (default `backends/vivado`); other tasks
+use its `name`/`invocation` as the resolved-config backend label.
 
-| Option            | `name`   | `invocation` | Description                         |
-| ----------------- | -------- | ------------ | ----------------------------------- |
-| `backends/vivado` | `vivado` | `standard`   | The Vivado/XDMA backend.            |
-| `backends/yosys`  | `yosys`  | `standard`   | Open-source synthesis (runs in CI). |
-| `backends/none`   | `none`   | `dry-run`    | No vendor toolchain (dry-run).      |
+| Option            | Model           | Fields                                    | Description                           |
+| ----------------- | --------------- | ----------------------------------------- | ------------------------------------- |
+| `backends/vivado` | `VivadoEngine`  | `name`, `invocation`                      | Vivado handoff (FPGA bitstream flow). |
+| `backends/yosys`  | `YosysEngine`   | `name`, `invocation`, `frontend`, `yosys` | Open-source synthesis; runs in CI.    |
+| `backends/none`   | `BackendConfig` | `name`, `invocation`                      | No engine — a dry-run label.          |
 
-`BackendConfig` fields: `name` (str), `invocation` (str). It is a label; the
-engine that runs codegen is `SynthesizeTask.engine` (`vivado` or `yosys`). See
+The engines are polymorphic `SynthesisEngine` models, so they are fully
+hydra-configurable — e.g. `backend=backends/yosys backend.frontend=slang` or
+`+backend.<field>=...`. `YosysEngine.frontend` is `verilog` (`read_verilog -sv`)
+or `slang` (yosys-slang); `yosys` sets the executable. See
 [the architecture explanation](../explanation/architecture.md) for how the two
 engines differ.
 

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -49,16 +49,18 @@ bench; `simulator=verilator` compiles and runs a Verilator testbench via a named
 ### `tasks/build/synthesize` — `SynthesizeTask`
 
 Writes the generated DAU top, manifest, and `artlink.manifest/v0` bundle, then
-dispatches on `engine`. Required: `module`, `output_root`.
+delegates to the synthesis engine composed from the `backend` group (default
+`backends/vivado`). Required: `module`, `output_root`.
 
-- `engine=vivado` (default) writes the `vivado/<artifact-stem>.manifest` backend
-  handoff at `build_status=planned` and does not invoke Vivado.
-- `engine=yosys` runs a real synthesis of the generated top with yosys, failing
-  the task if synthesis fails. `frontend=verilog` (default) uses
-  `read_verilog -sv`; `frontend=slang` uses the yosys-slang plugin; `yosys` sets
-  the executable.
+- `backend=backends/vivado` writes the `vivado/<artifact-stem>.manifest` handoff
+  at `build_status=planned` and does not invoke Vivado.
+- `backend=backends/yosys` runs a real synthesis of the generated top with yosys,
+  failing the task if synthesis fails. The engine is fully configurable:
+  `backend.frontend=verilog` (default, `read_verilog -sv`) or
+  `backend.frontend=slang` (yosys-slang), and `backend.yosys=<exe>`.
 
-Mode: **run**.
+Mode: **run**. See the [config group reference](config-groups.md) for the engine
+models.
 
 ### `tasks/build/build-shell-project` — `BuildShellProjectTask`
 


### PR DESCRIPTION
## What

Makes the synthesis engine hydra-first, per the review: the engine *is* the `backend` config group now, not a `Literal` + if/else on the task.

- `SynthesisEngine` base + `VivadoEngine` / `YosysEngine` polymorphic models, each with a `synthesize()` method and its own fields (yosys carries `frontend`, `yosys`). `backends/{vivado,yosys}.yaml` instantiate them.
- `SynthesizeTask` drops the `engine: Literal[...]`, the `if engine ==` dispatch, and the bolted-on `frontend`/`yosys` fields. It uses the composed backend as the engine (default Vivado) and delegates to `engine.synthesize(...)`.
- `ResolvedBuildConfig.from_spec` normalizes a composed engine to the `name`+`invocation` backend label, so engine-specific fields never leak into the resolved-config view.

## Fully hydra-configurable

The engine is a composed model, so every field is a hydra override:

```
dau-build-cfg task=tasks/build/synthesize backend=backends/yosys backend.frontend=slang \\
  model.module=identity model.spec_path=... model.output_root=out
# and +backend.<field>=... adds arbitrary config
```

Verified via `dau-build-cfg-explain` that `backend.frontend=slang` and `+backend.threads=4` compose into the `YosysEngine` model.

## Naming note

You wrote `+engine.whatever`; since you also picked “backend group becomes the engines,” the group stays `backend`, so the override key is `backend.` (a backend now *is* an engine). If you’d rather the group be spelled `engine`, I can rename it — that’s a broader change (the `backend` label is woven through `ResolvedBuildConfig` and ~20 step yamls), so I kept the smaller, chosen shape. Say the word.

## Validation

- Default vivado, `backend=backends/yosys` (real synth, 977 cells), and `backend.frontend=` override all validated locally.
- Full suite 224 passed + 1 slang-skip (slang runs in CI). F51 lazy-import guard still green (engines are light ccflow models). ruff clean; yardang build zero warnings.
- Docs updated: architecture, config-groups, task catalog, extend-guide, run-a-build.