### PR TITLE
Make the simulator hydra-first (audit #1)

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -310,13 +310,58 @@ class ValidateTask(SpecPathModel):
         return BuildStepResult(step="validate", message=f"dau-build-spec-valid\tspec={self.spec_label}")
 
 
-class SimulateTask(ModuleSelectionModel):
-    # spec_path/module are optional for profile-only Verilator runs, where a
-    # registered profile already carries its sources and top module
-    spec_path: Path | None = None
-    module: str = ""
-    simulator: Literal["cocotb", "svparser", "verilator"] = "svparser"
-    output_root: Path | None = None
+class Simulator(BaseModel):
+    """A simulator selected from the ``simulator`` config group. Each is a
+    polymorphic, hydra-configurable model (``simulator=simulators/verilator
+    simulator.profile=...``); ``SimulateTask`` delegates to ``simulate`` —
+    there is no simulator ``Literal`` or dispatch ``if`` on the task."""
+
+    name: str
+
+    def simulate(self, *, task: "SimulateTask") -> BuildStepResult:
+        raise NotImplementedError
+
+
+class SvparserSimulator(Simulator):
+    name: str = "svparser"
+
+    def simulate(self, *, task: "SimulateTask") -> BuildStepResult:
+        return task._validate_and_generate(self.name)
+
+
+class CocotbSimulator(Simulator):
+    name: str = "cocotb"
+    profile: str | None = None
+    profile_manifest: tuple[Path, ...] = ()
+
+    @field_validator("profile_manifest", mode="before")
+    @classmethod
+    def _split_profile_manifest_paths(cls, value):
+        return _split_path_tuple(value)
+
+    def simulate(self, *, task: "SimulateTask") -> BuildStepResult:
+        if self.profile and task._no_spec():
+            from dau_sim.integrations.cocotb import run_cocotb_testbench
+
+            from dau_build.simulation_profiles import resolve_profile
+
+            profile = resolve_profile(self.profile, profile_manifests=self.profile_manifest)
+            # the cocotb runner raises on any failing test
+            run_cocotb_testbench(
+                sources=profile.sources,
+                hdl_toplevel=profile.hdl_toplevel,
+                test_module=profile.test_module,
+                build_dir=task._profile_work_dir(profile.name),
+            )
+            return BuildStepResult(
+                step="simulate",
+                message=f"dau-build-simulate\ttask=simulate simulator=cocotb profile={profile.name} status=passed",
+            )
+        return task._validate_and_generate(self.name)
+
+
+class VerilatorSimulator(Simulator):
+    name: str = "verilator"
     profile: str | None = None
     profile_manifest: tuple[Path, ...] = ()
     testbench_path: Path | None = None
@@ -330,75 +375,94 @@ class SimulateTask(ModuleSelectionModel):
     def _split_profile_manifest_paths(cls, value):
         return _split_path_tuple(value)
 
-    @Flow.call
-    def __call__(self, context: NullContext) -> BuildStepResult:
-        no_spec = self.spec is None and self.spec_path is None
-        if self.simulator in ("verilator", "cocotb") and self.profile and no_spec:
-            return self._run_registered_profile()
-        if no_spec or not self.module:
-            raise BuildStepError(
-                "task=simulate requires a spec (spec=<name> or spec_path=<file>) and module (or simulator=verilator profile=<name> for a registered profile)"
-            )
-        spec = self.load_spec_and_validate_module()
-        output_root = self.output_root or self.spec_base_dir / ".dau-build-sim"
-        if self.simulator in {"svparser", "cocotb"}:
-            self._resolved(spec)
-            _build_spec_api().generate_dau_build_artifacts(spec, output_root=output_root)
-            return BuildStepResult(
-                step="simulate",
-                message=f"dau-build-simulate\ttask=simulate simulator={self.simulator} module={self.module} spec={self.spec_label} status=validated",
-            )
-        step_data: dict[str, Any] = {"spec": self.spec} if self.spec is not None else {"spec_path": str(self.spec_path)}
-        step_data.update(
-            {
-                "output_root": str(output_root),
-                "simulate.engine": "verilator",
-                "simulate.verilator": self.verilator,
-                "simulate.extra_args": self.extra_args,
-            }
+    def simulate(self, *, task: "SimulateTask") -> BuildStepResult:
+        if self.profile and task._no_spec():
+            return self._run_registered_profile(task)
+        spec = task.require_spec_and_module()
+        if self.testbench_path is None:
+            raise BuildStepError("missing required override: simulator.testbench_path")
+        if not self.top_module:
+            raise BuildStepError("missing required override: simulator.top_module")
+        work_dir = task.sim_output_root() / "verilator"
+        _run_verilator_bench(
+            spec,
+            extra_sources=(self.testbench_path,),
+            top_module=self.top_module,
+            expect_stdout=self.expect_stdout,
+            verilator=self.verilator,
+            extra_args=self.extra_args,
+            work_dir=work_dir,
         )
-        if self.profile:
-            step_data["simulate.profile"] = self.profile
-        if self.profile_manifest:
-            step_data["simulate.profile_manifest"] = self._stringify_override_value(self.profile_manifest)
-        if self.testbench_path:
-            step_data["simulate.testbench_path"] = str(self.testbench_path)
-        if self.top_module:
-            step_data["simulate.top_module"] = self.top_module
-        if self.expect_stdout:
-            step_data["simulate.expect_stdout"] = self.expect_stdout
-        result = _execute_callable_model(SimulateStep, step_data, request_kind="step", request_name="simulate")
-        return BuildStepResult(step="simulate", message=f"{result.message} task=simulate simulator=verilator module={self.module}")
+        return BuildStepResult(
+            step="simulate",
+            message=(
+                f"dau-build-simulate\ttask=simulate simulator=verilator module={task.module} spec={task.spec_label} "
+                f"testbench_top={self.top_module} work_dir={work_dir} status=passed"
+            ),
+        )
 
-    def _run_registered_profile(self) -> BuildStepResult:
-        from dau_sim.integrations.cocotb import CocotbProfile, run_cocotb_testbench
+    def _run_registered_profile(self, task: "SimulateTask") -> BuildStepResult:
         from dau_sim.integrations.verilator import run_verilator_testbench
 
         from dau_build.simulation_profiles import resolve_profile
 
         profile = resolve_profile(self.profile, profile_manifests=self.profile_manifest)
-        work_root = self.output_root or Path.cwd() / ".dau-build-sim"
-        work_dir = work_root / profile.name
-        work_dir.mkdir(parents=True, exist_ok=True)
-        if isinstance(profile, CocotbProfile):
-            # the cocotb runner raises on any failing test
-            run_cocotb_testbench(
-                sources=profile.sources,
-                hdl_toplevel=profile.hdl_toplevel,
-                test_module=profile.test_module,
-                build_dir=work_dir,
-            )
-            return BuildStepResult(
-                step="simulate",
-                message=f"dau-build-simulate	task=simulate simulator=cocotb profile={profile.name} status=passed",
-            )
-        result = run_verilator_testbench(sources=profile.sources, top_module=profile.top_module, work_dir=work_dir)
+        result = run_verilator_testbench(sources=profile.sources, top_module=profile.top_module, work_dir=task._profile_work_dir(profile.name))
         marker = self.expect_stdout or profile.expect_stdout
         if marker not in result.stdout:
             raise BuildStepError(f"profile {profile.name!r} did not report {marker!r}")
         return BuildStepResult(
             step="simulate",
-            message=f"dau-build-simulate	task=simulate simulator=verilator profile={profile.name} status=passed marker={marker}",
+            message=f"dau-build-simulate\ttask=simulate simulator=verilator profile={profile.name} status=passed marker={marker}",
+        )
+
+
+class SimulateTask(ModuleSelectionModel):
+    # spec_path/module are optional for profile-only Verilator runs, where a
+    # registered profile already carries its sources and top module
+    spec_path: Path | None = None
+    module: str = ""
+    output_root: Path | None = None
+    # the simulator is the composed `simulator` group option; default svparser
+    simulator: Any = None
+
+    @Flow.call
+    def __call__(self, context: NullContext) -> BuildStepResult:
+        return self._simulator().simulate(task=self)
+
+    def _simulator(self) -> Simulator:
+        if isinstance(self.simulator, Simulator):
+            return self.simulator
+        if self.simulator is None:
+            return SvparserSimulator()
+        raise BuildStepError(f"simulator {getattr(self.simulator, 'name', self.simulator)!r} is not a simulator")
+
+    def _no_spec(self) -> bool:
+        return self.spec is None and self.spec_path is None
+
+    def sim_output_root(self) -> Path:
+        return self.output_root or self.spec_base_dir / ".dau-build-sim"
+
+    def _profile_work_dir(self, profile_name: str) -> Path:
+        work_dir = (self.output_root or Path.cwd() / ".dau-build-sim") / profile_name
+        work_dir.mkdir(parents=True, exist_ok=True)
+        return work_dir
+
+    def require_spec_and_module(self):
+        if self._no_spec() or not self.module:
+            raise BuildStepError(
+                "task=simulate requires a spec (spec=<name> or spec_path=<file>) and module "
+                "(or simulator=simulators/verilator with simulator.profile=<name> for a registered profile)"
+            )
+        return self.load_spec_and_validate_module()
+
+    def _validate_and_generate(self, simulator_name: str) -> BuildStepResult:
+        spec = self.require_spec_and_module()
+        self._resolved(spec)
+        _build_spec_api().generate_dau_build_artifacts(spec, output_root=self.sim_output_root())
+        return BuildStepResult(
+            step="simulate",
+            message=f"dau-build-simulate\ttask=simulate simulator={simulator_name} module={self.module} spec={self.spec_label} status=validated",
         )
 
 
@@ -1168,6 +1232,29 @@ def _unique_paths(paths: Iterable[Path | str]) -> tuple[Path, ...]:
     for path in paths:
         unique[Path(path)] = None
     return tuple(unique.keys())
+
+
+def _run_verilator_bench(spec, *, extra_sources, top_module, expect_stdout, verilator, extra_args, work_dir):
+    """Run a Verilator testbench over the spec sources plus extra sources;
+    raise BuildStepError on failure or missing expected stdout."""
+    try:
+        from dau_sim.integrations.verilator import VerilatorExecutionError, VerilatorUnavailableError, run_verilator_testbench
+    except ModuleNotFoundError as exc:
+        raise BuildStepError("verilator simulation requires dau-sim to be importable") from exc
+    all_sources = _unique_paths((*spec.sources, *extra_sources))
+    try:
+        result = run_verilator_testbench(
+            sources=all_sources,
+            top_module=top_module,
+            work_dir=work_dir,
+            verilator=verilator,
+            extra_args=tuple(shlex.split(extra_args)),
+        )
+    except (FileNotFoundError, ValueError, VerilatorExecutionError, VerilatorUnavailableError) as exc:
+        raise BuildStepError(str(exc)) from exc
+    if expect_stdout and expect_stdout not in result.stdout:
+        raise BuildStepError(f"verilator stdout did not contain expected text {expect_stdout!r}")
+    return result
 
 
 def _split_path_tuple(value) -> tuple[Path, ...]:

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -7,6 +7,7 @@ defaults:
   - optional platform: null
   - optional board: null
   - optional backend: null
+  - optional simulator: null
   - optional spec: null
   - optional design: null
   - callable: callable

--- a/dau_build/config/simulator/simulators/cocotb.yaml
+++ b/dau_build/config/simulator/simulators/cocotb.yaml
@@ -1,0 +1,7 @@
+# @package simulator
+
+# simulator=simulators/cocotb — validate, or run a registered cocotb profile
+_target_: dau_build.build_steps.CocotbSimulator
+name: cocotb
+profile: null
+profile_manifest: []

--- a/dau_build/config/simulator/simulators/svparser.yaml
+++ b/dau_build/config/simulator/simulators/svparser.yaml
@@ -1,0 +1,5 @@
+# @package simulator
+
+# simulator=simulators/svparser — parse-and-validate (no external simulator)
+_target_: dau_build.build_steps.SvparserSimulator
+name: svparser

--- a/dau_build/config/simulator/simulators/verilator.yaml
+++ b/dau_build/config/simulator/simulators/verilator.yaml
@@ -1,0 +1,12 @@
+# @package simulator
+
+# simulator=simulators/verilator — run a Verilator testbench or registered profile
+_target_: dau_build.build_steps.VerilatorSimulator
+name: verilator
+profile: null
+profile_manifest: []
+testbench_path: null
+top_module: null
+expect_stdout: null
+verilator: verilator
+extra_args: ""

--- a/dau_build/config/task/tasks/sim/simulate.yaml
+++ b/dau_build/config/task/tasks/sim/simulate.yaml
@@ -5,13 +5,8 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
-module: ???
-simulator: svparser
+module: ""
 output_root: null
-profile: null
-profile_manifest: []
-testbench_path: null
-top_module: null
-expect_stdout: null
-verilator: verilator
-extra_args: ""
+# the simulator is the composed simulator group (default svparser);
+# select+configure with simulator=simulators/verilator simulator.profile=...
+simulator: ${oc.select:simulator,null}

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -8,6 +8,7 @@ from ccflow import CallableModel
 
 from dau_build.build_spec import main
 from dau_build.build_steps import BuildStepError, BuildStepResult, SimulateTask, execute_override_request, execute_override_task
+from dau_build.config import run_request_config
 from dau_build.vivado_backend import VivadoBackendArtifactValidation, VivadoBackendRequest, generate_vivado_backend_artifacts
 
 _SV_DIR = (Path(__file__).parent / ".." / "sv").resolve()
@@ -18,7 +19,8 @@ def test_execute_override_request_accepts_public_task_simulate_surface(tmp_path:
 
     spec_path = _write_spec(tmp_path)
 
-    result = execute_override_request(("task=tasks/sim/simulate", "simulator=svparser", "module=dau_identity_top", f"spec_path={spec_path}"))
+    # default simulator is svparser (no simulator= group override)
+    result = execute_override_request(("task=tasks/sim/simulate", "module=dau_identity_top", f"spec_path={spec_path}"))
 
     assert result == BuildStepResult(
         step="simulate",
@@ -29,7 +31,13 @@ def test_execute_override_request_accepts_public_task_simulate_surface(tmp_path:
 def test_execute_override_task_accepts_public_cocotb_simulate_surface(tmp_path: Path) -> None:
     spec_path = _write_spec(tmp_path)
 
-    result = execute_override_task(("task=tasks/sim/simulate", "simulator=cocotb", "module=dau_identity_top", f"spec_path={spec_path}"))
+    # the simulator is the composed simulator group
+    result = run_request_config(
+        "task",
+        "tasks/sim/simulate",
+        overrides=["simulator=simulators/cocotb"],
+        model_values={"module": "dau_identity_top", "spec_path": str(spec_path)},
+    )
 
     assert result == BuildStepResult(
         step="simulate",
@@ -41,7 +49,7 @@ def test_execute_override_task_requires_selected_module_to_match_spec(tmp_path: 
     spec_path = _write_spec(tmp_path)
 
     with pytest.raises(BuildStepError, match="module 'missing' is not provided by spec"):
-        execute_override_task(("task=tasks/sim/simulate", "simulator=svparser", "module=missing", f"spec_path={spec_path}"))
+        execute_override_task(("task=tasks/sim/simulate", "module=missing", f"spec_path={spec_path}"))
 
 
 def test_spec_tasks_inspect_build_and_validate_a_bundle(tmp_path: Path) -> None:
@@ -362,7 +370,7 @@ def test_execute_override_task_validates_vivado_artifacts_in_process(tmp_path: P
 def test_dau_build_main_dispatches_public_task_arguments(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = main(["task=tasks/sim/simulate", "simulator=svparser", "module=dau_identity_top", f"spec_path={spec_path}"])
+    exit_code = main(["task=tasks/sim/simulate", "module=dau_identity_top", f"spec_path={spec_path}"])
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [

--- a/dau_build/tests/test_cfg_cli.py
+++ b/dau_build/tests/test_cfg_cli.py
@@ -15,11 +15,9 @@ def test_cfg_cli_runs_profile_only_simulate(tmp_path: Path, capsys) -> None:
     exit_code = main(
         [
             "task=tasks/sim/simulate",
-            "model.simulator=verilator",
-            "model.spec_path=null",
-            "model.module=''",
-            "model.profile=counter-profile",
-            f"model.profile_manifest={manifest_path}",
+            "simulator=simulators/verilator",
+            "simulator.profile=counter-profile",
+            f"simulator.profile_manifest=[{manifest_path}]",
             f"model.output_root={tmp_path}",
         ]
     )
@@ -37,10 +35,8 @@ def test_profile_only_simulate_falls_back_to_manifest_registry() -> None:
         main(
             [
                 "task=tasks/sim/simulate",
-                "model.simulator=verilator",
-                "model.spec_path=null",
-                "model.module=''",
-                "model.profile=not-a-registered-profile",
+                "simulator=simulators/verilator",
+                "simulator.profile=not-a-registered-profile",
             ]
         )
 
@@ -68,9 +64,10 @@ def test_cfg_cli_open_registration_via_config_dir_overlay(tmp_path: Path, capsys
                 "_target_: dau_build.build_steps.SimulateTask",
                 "spec_path: null",
                 "module: ''",
-                "simulator: verilator",
-                "profile: counter-profile",
-                f"profile_manifest: [{manifest_path}]",
+                "simulator:",
+                "  _target_: dau_build.build_steps.VerilatorSimulator",
+                "  profile: counter-profile",
+                f"  profile_manifest: [{manifest_path}]",
                 f"output_root: {tmp_path / 'work'}",
             )
         )

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -88,7 +88,6 @@ def test_public_override_dispatch_runs_packaged_task_configs(monkeypatch) -> Non
     result = execute_override_request(
         (
             "task=tasks/sim/simulate",
-            "simulator=svparser",
             "module=dau_identity_top",
             "spec_path=examples/identity/dau-build.yaml",
         )
@@ -103,15 +102,8 @@ def test_public_override_dispatch_runs_packaged_task_configs(monkeypatch) -> Non
         "board": None,
         "backend": None,
         "module": "dau_identity_top",
-        "simulator": "svparser",
         "output_root": None,
-        "profile": None,
-        "profile_manifest": [],
-        "testbench_path": None,
-        "top_module": None,
-        "expect_stdout": None,
-        "verilator": "verilator",
-        "extra_args": "",
+        "simulator": None,
     }
 
 

--- a/dau_build/tests/test_simulate_profile_task.py
+++ b/dau_build/tests/test_simulate_profile_task.py
@@ -3,21 +3,23 @@ from shutil import which
 
 import pytest
 
-from dau_build.build_steps import BuildStepError, execute_override_task
+from dau_build.build_steps import BuildStepError
+from dau_build.config import run_request_config
 from dau_build.tests.test_build_steps import _write_counter_testbench
 
 
 @pytest.mark.skipif(which("verilator") is None, reason="verilator not found")
 def test_profile_only_simulate_runs(tmp_path):
     manifest_path = _write_self_contained_counter_manifest(tmp_path)
-    result = execute_override_task(
-        [
-            "task=tasks/sim/simulate",
-            "simulator=verilator",
-            "profile=counter-profile",
-            f"profile_manifest={manifest_path}",
-            f"output_root={tmp_path}",
-        ]
+    result = run_request_config(
+        "task",
+        "tasks/sim/simulate",
+        overrides=[
+            "simulator=simulators/verilator",
+            "simulator.profile=counter-profile",
+            f"simulator.profile_manifest=[{manifest_path}]",
+        ],
+        model_values={"output_root": str(tmp_path)},
     )
     assert "status=passed" in result.message
     assert "profile=counter-profile" in result.message
@@ -25,7 +27,7 @@ def test_profile_only_simulate_runs(tmp_path):
 
 def test_simulate_without_spec_or_profile_fails_typed(tmp_path):
     with pytest.raises(BuildStepError, match="requires a spec"):
-        execute_override_task(["task=tasks/sim/simulate", "simulator=verilator"])
+        run_request_config("task", "tasks/sim/simulate", overrides=["simulator=simulators/verilator"])
 
 
 def _write_self_contained_counter_manifest(tmp_path) -> Path:

--- a/dau_build/tests/test_simulation_profiles.py
+++ b/dau_build/tests/test_simulation_profiles.py
@@ -85,7 +85,7 @@ def test_cocotb_profile_parses_and_runs_through_simulate_task(tmp_path) -> None:
     import pytest as _pytest
     from dau_sim.integrations.cocotb import CocotbProfile
 
-    from dau_build.build_steps import SimulateTask
+    from dau_build.build_steps import CocotbSimulator, SimulateTask
     from dau_build.simulation_profiles import resolve_profile
 
     profiles_yaml = tmp_path / "profiles.yaml"
@@ -119,9 +119,7 @@ def test_cocotb_profile_parses_and_runs_through_simulate_task(tmp_path) -> None:
     if which("verilator") is None:
         _pytest.skip("verilator not found")
     result = SimulateTask(
-        simulator="cocotb",
-        profile="ready-valid-sum-cocotb",
-        profile_manifest=(manifest_yaml,),
+        simulator=CocotbSimulator(profile="ready-valid-sum-cocotb", profile_manifest=(manifest_yaml,)),
         output_root=tmp_path / "work",
     )(None)
     assert "simulator=cocotb" in result.message and "status=passed" in result.message

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -16,6 +16,7 @@ defaults:
   - optional platform: null
   - optional board: null
   - optional backend: null
+  - optional simulator: null
   - optional spec: null
   - optional design: null
   - callable: callable
@@ -23,22 +24,23 @@ defaults:
 
 Every group except `callable` is `optional … null`: nothing is selected unless
 overridden. A run selects exactly one of `task=` or `step=` to populate `model`,
-optionally augmented by `spec=`, `board=`, `backend=`, and `platform=`.
+optionally augmented by `spec=`, `board=`, `backend=`, `simulator=`, and `platform=`.
 
 Each option file begins with a `# @package <key>` directive that places its
 content under that top-level key. Tasks and steps use `# @package model`; the
 other groups use their singular key (`# @package board`, etc.).
 
-| Group      | `@package` key | Instantiated model                        | Selects                                                          |
-| ---------- | -------------- | ----------------------------------------- | ---------------------------------------------------------------- |
-| `task`     | `model`        | a `…Task` `ccflow.CallableModel`          | The unit of work to run.                                         |
-| `step`     | `model`        | a `…Step` `ccflow.CallableModel`          | A lower-level plumbing operation.                                |
-| `spec`     | `spec`         | `dau_build.build_spec.BuildSpec`          | A composed build spec (Hydra-native alternative to `spec_path`). |
-| `board`    | `board`        | `dau_build.build_config.BoardConfig`      | A board's build-config view.                                     |
-| `backend`  | `backend`      | a `SynthesisEngine` (e.g. `VivadoEngine`) | The synthesis engine.                                            |
-| `platform` | `platform`     | `dau_build.platforms.PlatformDefinition`  | The full physical platform definition.                           |
-| `design`   | `design`       | (none packaged)                           | Reserved; registered by extension packages.                      |
-| `callable` | —              | ccflow registry pointer                   | Fixed evaluator wiring; not normally overridden.                 |
+| Group       | `@package` key | Instantiated model                        | Selects                                                          |
+| ----------- | -------------- | ----------------------------------------- | ---------------------------------------------------------------- |
+| `task`      | `model`        | a `…Task` `ccflow.CallableModel`          | The unit of work to run.                                         |
+| `step`      | `model`        | a `…Step` `ccflow.CallableModel`          | A lower-level plumbing operation.                                |
+| `spec`      | `spec`         | `dau_build.build_spec.BuildSpec`          | A composed build spec (Hydra-native alternative to `spec_path`). |
+| `board`     | `board`        | `dau_build.build_config.BoardConfig`      | A board's build-config view.                                     |
+| `backend`   | `backend`      | a `SynthesisEngine` (e.g. `VivadoEngine`) | The synthesis engine.                                            |
+| `simulator` | `simulator`    | a `Simulator` (e.g. `VerilatorSimulator`) | The simulator (used by `SimulateTask`).                          |
+| `platform`  | `platform`     | `dau_build.platforms.PlatformDefinition`  | The full physical platform definition.                           |
+| `design`    | `design`       | (none packaged)                           | Reserved; registered by extension packages.                      |
+| `callable`  | —              | ccflow registry pointer                   | Fixed evaluator wiring; not normally overridden.                 |
 
 ## `task`
 
@@ -121,6 +123,21 @@ hydra-configurable — e.g. `backend=backends/yosys backend.frontend=slang` or
 or `slang` (yosys-slang); `yosys` sets the executable. See
 [the architecture explanation](../explanation/architecture.md) for how the two
 engines differ.
+
+## `simulator`
+
+`simulator=simulators/<name>` composes a `Simulator` model into the `simulator`
+key; `SimulateTask` uses it as the simulator (default `simulators/svparser`).
+
+| Option                 | Model                | Fields                                                                                                            |
+| ---------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `simulators/svparser`  | `SvparserSimulator`  | `name`                                                                                                            |
+| `simulators/cocotb`    | `CocotbSimulator`    | `name`, `profile`, `profile_manifest`                                                                             |
+| `simulators/verilator` | `VerilatorSimulator` | `name`, `profile`, `profile_manifest`, `testbench_path`, `top_module`, `expect_stdout`, `verilator`, `extra_args` |
+
+Like the engines, simulators are polymorphic and fully hydra-configurable — e.g.
+`simulator=simulators/verilator simulator.profile=<name>` or
+`+simulator.<field>=...`.
 
 ## `platform`
 

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -41,10 +41,14 @@ Validates a generated artifact bundle when `manifest_path` is given (with option
 
 ### `tasks/sim/simulate` — `SimulateTask`
 
-Validates or simulates a module against the build spec. Required: `module`.
-Default `simulator: svparser` (validation only); `simulator=cocotb` runs a cocotb
-bench; `simulator=verilator` compiles and runs a Verilator testbench via a named
-`profile` or explicit `testbench_path`/`top_module`. Mode: **run**.
+Validates or simulates a module, delegating to the simulator composed from the
+`simulator` group (default `simulators/svparser`). `simulators/svparser` and
+`simulators/cocotb` validate the module against the spec; `simulators/verilator`
+runs a Verilator testbench (via `simulator.testbench_path`/`simulator.top_module`)
+or a registered profile (`simulator.profile`). Select+configure the simulator
+with, e.g., `simulator=simulators/verilator simulator.profile=<name>`. Mode:
+**run**. See the [config group reference](config-groups.md) for the simulator
+models.
 
 ### `tasks/build/synthesize` — `SynthesizeTask`
 


### PR DESCRIPTION
First of the audit follow-ups. Same fix as the synthesis engine, applied to the simulator.

## What

`SimulateTask` had `simulator: Literal["cocotb","svparser","verilator"]` + an `if/else` dispatch + simulator-specific fields bolted onto the task (and a hand-assembled config dict forwarded to `SimulateStep`). Now:

- `SvparserSimulator` / `CocotbSimulator` / `VerilatorSimulator` polymorphic models (a `Simulator` base), each owning its fields and a `simulate()` method, selected from a new `simulator` config group.
- `SimulateTask` drops the Literal/branch/bolted-on fields and delegates to `simulator.simulate(task=self)`. Fully hydra-configurable: `simulator=simulators/verilator simulator.profile=<name>` / `+simulator.<field>=...`.
- `SimulateStep` (the low-level step) is left as plumbing, like `SynthesisStep`; the shared verilator run is extracted to `_run_verilator_bench`.

## Behavior

Default simulator is `svparser` (unchanged messages). Selecting/configuring a non-default simulator now goes through the hydra CLIs (`dau-build-cfg`/`dau-build-run`), like the engine; the flat `dau-build task=tasks/sim/simulate` still runs the default svparser.

## Validation

- Full suite 224 passed + 1 skipped (yosys-slang, runs in CI). ruff clean; yardang zero warnings.
- Docs updated: task catalog + a new `simulator` config-group section.

Remaining audit items (your pick): #2 hardware plans, #3 spec model_validate, #4-9 the rest.