### PR TITLE
Make hardware plans hydra-first; delete the argparse CLI (audit #2)

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -8,19 +8,13 @@ from ccflow import BaseModel, CallableModel, Flow, NullContext, ResultBase
 from pydantic import Field, ValidationError, field_validator
 
 from dau_build.hardware_plan import (
+    HardwarePlan,
     HardwareToolchainConfig,
-    build_and_program_plan,
     execute_plan_steps,
-    flash_plan as hardware_flash_plan,
     format_plan_steps,
-    local_build_and_program_plan,
-    recovery_plan,
     stage_shell_plan,
     stage_vivado_overlay_plan,
     stage_vivado_project_plan,
-    thunderbolt_hold_plan,
-    thunderbolt_release_plan,
-    validate_bitstream_plan,
     validate_vivado_artifacts,
     validate_vivado_artifacts_step,
     vivado_overlay_build_step,
@@ -999,17 +993,10 @@ class BuildVivadoArtifactsTask(BuildOverlayArtifactsTask):
 
 
 class HardwarePlanTask(BuildCallableModel):
-    plan: Literal[
-        "build-and-program",
-        "flash",
-        "local-build-and-program",
-        "recovery",
-        "thunderbolt-hold",
-        "thunderbolt-release",
-        "validate-bitstream",
-    ]
+    # the plan is the composed `plan` group option (a HardwarePlan model that
+    # owns its own required fields); the task holds the shared toolchain config
+    plan: Any = None
     work_root: Path
-    source_shell_root: Path | None = None
     bitstream: Path | None = None
     vivado: str = "vivado"
     vivado_invocation: Literal["standard", "source-only"] = "standard"
@@ -1017,28 +1004,11 @@ class HardwarePlanTask(BuildCallableModel):
     openfpgaloader: str = "openFPGALoader"
     jtag_cable: str = "digilent_hs2"
     endpoint_bdf: str = "0000:04:00.0"
-    dau_core_root: Path | None = None
-    dau_driver_root: Path | None = None
-    dau_utils_root: Path | None = None
-    overlay_tcl: Path = Path("scripts/dau_overlay.tcl")
-    python: str = "python3"
-    vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
     execute: bool = False
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        plan_result = self._plan_result()
-        if self.execute:
-            return_code = execute_plan_steps(plan_result)
-            if return_code != 0:
-                raise BuildStepError(f"hardware plan {self.plan!r} failed with exit code {return_code}")
-            return BuildStepResult(
-                step="hardware-plan",
-                message=f"dau-build-hardware-plan\ttask=hardware-plan plan={self.plan} steps={len(plan_result)} status=executed",
-            )
-        return BuildStepResult(step="hardware-plan", message=format_plan_steps(plan_result))
-
-    def _plan_result(self):
+        plan = self._plan()
         config = HardwareToolchainConfig(
             work_root=self.work_root,
             vivado_executable=self.vivado,
@@ -1049,39 +1019,21 @@ class HardwarePlanTask(BuildCallableModel):
             jtag_cable=self.jtag_cable,
             endpoint_bdf=self.endpoint_bdf,
         )
-        composers = {
-            "build-and-program": lambda: build_and_program_plan(config),
-            "local-build-and-program": lambda: local_build_and_program_plan(
-                config,
-                dau_core_root=self._required_path("dau_core_root"),
-                dau_driver_root=self._required_path("dau_driver_root"),
-                source_shell_root=self.source_shell_root,
-                dau_utils_root=self.dau_utils_root,
-                overlay_tcl=self.overlay_tcl,
-                python=self.python,
-                vivado_settings=self.vivado_settings,
-            ),
-            "validate-bitstream": lambda: validate_bitstream_plan(
-                config,
-                dau_core_root=self._required_path("dau_core_root"),
-                dau_driver_root=self._required_path("dau_driver_root"),
-                dau_utils_root=self.dau_utils_root,
-                python=self.python,
-            ),
-            "flash": lambda: hardware_flash_plan(
-                config, dau_utils_root=self.dau_utils_root, python=self.python, vivado_settings=self.vivado_settings
-            ),
-            "recovery": lambda: recovery_plan(config),
-            "thunderbolt-hold": lambda: thunderbolt_hold_plan(config),
-            "thunderbolt-release": lambda: thunderbolt_release_plan(config),
-        }
-        return composers[self.plan]()
+        plan_result = plan.compose(config)
+        if self.execute:
+            return_code = execute_plan_steps(plan_result)
+            if return_code != 0:
+                raise BuildStepError(f"hardware plan {plan.name!r} failed with exit code {return_code}")
+            return BuildStepResult(
+                step="hardware-plan",
+                message=f"dau-build-hardware-plan\ttask=hardware-plan plan={plan.name} steps={len(plan_result)} status=executed",
+            )
+        return BuildStepResult(step="hardware-plan", message=format_plan_steps(plan_result))
 
-    def _required_path(self, field_name: str) -> Path:
-        value = getattr(self, field_name)
-        if value is None:
-            raise BuildStepError(f"task=hardware-plan plan={self.plan} requires {field_name}")
-        return value
+    def _plan(self) -> HardwarePlan:
+        if isinstance(self.plan, HardwarePlan):
+            return self.plan
+        raise BuildStepError("task=hardware-plan requires plan=plans/<name> (see dau_build/config/plan)")
 
 
 def _model_types_from_config_group(kind: str) -> Mapping[str, type[BuildCallableModel]]:

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -9,6 +9,7 @@ defaults:
   - optional backend: null
   - optional simulator: null
   - optional spec: null
+  - optional plan: null
   - optional design: null
   - callable: callable
 

--- a/dau_build/config/plan/plans/build-and-program.yaml
+++ b/dau_build/config/plan/plans/build-and-program.yaml
@@ -1,0 +1,3 @@
+# @package plan
+_target_: dau_build.hardware_plan.BuildAndProgramPlan
+name: build-and-program

--- a/dau_build/config/plan/plans/flash.yaml
+++ b/dau_build/config/plan/plans/flash.yaml
@@ -1,0 +1,6 @@
+# @package plan
+_target_: dau_build.hardware_plan.FlashPlan
+name: flash
+dau_utils_root: null
+python: python3
+vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh

--- a/dau_build/config/plan/plans/local-build-and-program.yaml
+++ b/dau_build/config/plan/plans/local-build-and-program.yaml
@@ -1,0 +1,10 @@
+# @package plan
+_target_: dau_build.hardware_plan.LocalBuildAndProgramPlan
+name: local-build-and-program
+dau_core_root: ???
+dau_driver_root: ???
+source_shell_root: null
+dau_utils_root: null
+overlay_tcl: scripts/dau_overlay.tcl
+python: python3
+vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh

--- a/dau_build/config/plan/plans/recovery.yaml
+++ b/dau_build/config/plan/plans/recovery.yaml
@@ -1,0 +1,3 @@
+# @package plan
+_target_: dau_build.hardware_plan.RecoveryPlan
+name: recovery

--- a/dau_build/config/plan/plans/thunderbolt-hold.yaml
+++ b/dau_build/config/plan/plans/thunderbolt-hold.yaml
@@ -1,0 +1,3 @@
+# @package plan
+_target_: dau_build.hardware_plan.ThunderboltHoldPlan
+name: thunderbolt-hold

--- a/dau_build/config/plan/plans/thunderbolt-release.yaml
+++ b/dau_build/config/plan/plans/thunderbolt-release.yaml
@@ -1,0 +1,3 @@
+# @package plan
+_target_: dau_build.hardware_plan.ThunderboltReleasePlan
+name: thunderbolt-release

--- a/dau_build/config/plan/plans/validate-bitstream.yaml
+++ b/dau_build/config/plan/plans/validate-bitstream.yaml
@@ -1,0 +1,7 @@
+# @package plan
+_target_: dau_build.hardware_plan.ValidateBitstreamPlan
+name: validate-bitstream
+dau_core_root: ???
+dau_driver_root: ???
+dau_utils_root: null
+python: python3

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -1,9 +1,10 @@
 # @package model
 
 _target_: dau_build.build_steps.HardwarePlanTask
-plan: ???
+# the plan is the composed plan group; select+configure with
+# plan=plans/local-build-and-program plan.dau_core_root=... plan.dau_driver_root=...
+plan: ${oc.select:plan,null}
 work_root: ???
-source_shell_root: null
 bitstream: null
 vivado: vivado
 vivado_invocation: standard
@@ -11,10 +12,4 @@ vivado_mount_root: null
 openfpgaloader: openFPGALoader
 jtag_cable: digilent_hs2
 endpoint_bdf: "0000:04:00.0"
-dau_core_root: null
-dau_driver_root: null
-dau_utils_root: null
-overlay_tcl: scripts/dau_overlay.tcl
-python: python3
-vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh
 execute: false

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import argparse
 import base64
 import shlex
 import subprocess
@@ -613,98 +612,104 @@ def execute_plan_steps(steps: Sequence[ToolStep]) -> int:
     return 0
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Print Vivado build/program/recovery command plans")
-    parser.add_argument(
-        "plan",
-        choices=(
-            "build-and-program",
-            "flash",
-            "local-build-and-program",
-            "recovery",
-            "thunderbolt-hold",
-            "thunderbolt-release",
-            "validate-bitstream",
-        ),
-        help="Command plan to print",
-    )
-    parser.add_argument("--work-root", required=True, type=Path, help="Path to the Vivado project root")
-    parser.add_argument("--source-shell-root", type=Path, help="Read-only Vivado shell seed copied into --work-root before staging/building")
-    parser.add_argument("--bitstream", type=Path, help="Bitstream path to program; relative paths are resolved under --work-root")
-    parser.add_argument("--vivado", default="vivado", help="Vivado executable to use in build plans")
-    parser.add_argument(
-        "--vivado-invocation",
-        default="standard",
-        choices=("standard", "source-only"),
-        help="Use 'source-only' for wrappers that already run Vivado in batch source mode",
-    )
-    parser.add_argument(
-        "--vivado-mount-root",
-        type=Path,
-        help="Host root mounted by a source-only Vivado wrapper; generated Tcl paths are made relative to the staged workdir",
-    )
-    parser.add_argument("--openfpgaloader", default="openFPGALoader", help="openFPGALoader executable to use")
-    parser.add_argument("--jtag-cable", default="digilent_hs2", help="openFPGALoader cable profile")
-    parser.add_argument("--endpoint-bdf", default="0000:04:00.0", help="PCI endpoint BDF for recovery/check steps")
-    parser.add_argument("--dau-core-root", type=Path, help="Path to the local dau-core checkout")
-    parser.add_argument("--dau-driver-root", type=Path, help="Path to the local dau-driver checkout")
-    parser.add_argument("--dau-utils-root", type=Path, help="Path to the local dau-utils checkout")
-    parser.add_argument(
-        "--overlay-tcl", default=Path("scripts/dau_overlay.tcl"), type=Path, help="Overlay TCL path relative to the local Vivado root"
-    )
-    parser.add_argument("--python", default="python3", help="Local Python executable for hardware smoke tests and source-checkout runtime PM")
-    parser.add_argument("--vivado-settings", default=Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"), type=Path, help="Remote Vivado settings script")
-    parser.add_argument("--execute", action="store_true", help="Execute the selected plan instead of printing it")
-    args = parser.parse_args(argv)
+class HardwarePlan(BaseModel):
+    """A hardware-session plan selected from the ``plan`` config group. Each is
+    a polymorphic model owning its required fields; ``HardwarePlanTask``
+    delegates to ``compose`` — there is no plan ``Literal`` or dict-of-lambdas
+    dispatch."""
 
-    config = HardwareToolchainConfig(
-        work_root=args.work_root,
-        vivado_executable=args.vivado,
-        vivado_invocation=args.vivado_invocation,
-        vivado_mount_root=args.vivado_mount_root,
-        bitstream_path=args.bitstream,
-        openfpgaloader_executable=args.openfpgaloader,
-        jtag_cable=args.jtag_cable,
-        endpoint_bdf=args.endpoint_bdf,
-    )
-    if args.plan == "build-and-program":
-        steps = build_and_program_plan(config)
-    elif args.plan == "local-build-and-program":
-        if args.dau_core_root is None or args.dau_driver_root is None:
-            parser.error("local-build-and-program requires --dau-core-root and --dau-driver-root")
-        steps = local_build_and_program_plan(
+    name: str
+
+    def compose(self, config: "HardwareToolchainConfig") -> tuple[ToolStep, ...]:
+        raise NotImplementedError
+
+
+class BuildAndProgramPlan(HardwarePlan):
+    name: str = "build-and-program"
+
+    def compose(self, config):
+        return build_and_program_plan(config)
+
+
+class RecoveryPlan(HardwarePlan):
+    name: str = "recovery"
+
+    def compose(self, config):
+        return recovery_plan(config)
+
+
+class ThunderboltHoldPlan(HardwarePlan):
+    name: str = "thunderbolt-hold"
+
+    def compose(self, config):
+        return thunderbolt_hold_plan(config)
+
+
+class ThunderboltReleasePlan(HardwarePlan):
+    name: str = "thunderbolt-release"
+
+    def compose(self, config):
+        return thunderbolt_release_plan(config)
+
+
+class FlashPlan(HardwarePlan):
+    name: str = "flash"
+    dau_utils_root: Path | None = None
+    python: str = "python3"
+    vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
+
+    def compose(self, config):
+        return flash_plan(config, dau_utils_root=self.dau_utils_root, python=self.python, vivado_settings=self.vivado_settings)
+
+
+class ValidateBitstreamPlan(HardwarePlan):
+    name: str = "validate-bitstream"
+    dau_core_root: Path
+    dau_driver_root: Path
+    dau_utils_root: Path | None = None
+    python: str = "python3"
+
+    def compose(self, config):
+        return validate_bitstream_plan(
             config,
-            dau_core_root=args.dau_core_root,
-            dau_driver_root=args.dau_driver_root,
-            source_shell_root=args.source_shell_root,
-            dau_utils_root=args.dau_utils_root,
-            overlay_tcl=args.overlay_tcl,
-            python=args.python,
-            vivado_settings=args.vivado_settings,
+            dau_core_root=self.dau_core_root,
+            dau_driver_root=self.dau_driver_root,
+            dau_utils_root=self.dau_utils_root,
+            python=self.python,
         )
-    elif args.plan == "validate-bitstream":
-        if args.dau_core_root is None or args.dau_driver_root is None:
-            parser.error("validate-bitstream requires --dau-core-root and --dau-driver-root")
-        steps = validate_bitstream_plan(
+
+
+class LocalBuildAndProgramPlan(HardwarePlan):
+    name: str = "local-build-and-program"
+    dau_core_root: Path
+    dau_driver_root: Path
+    source_shell_root: Path | None = None
+    dau_utils_root: Path | None = None
+    overlay_tcl: Path = Path("scripts/dau_overlay.tcl")
+    python: str = "python3"
+    vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
+
+    def compose(self, config):
+        return local_build_and_program_plan(
             config,
-            dau_core_root=args.dau_core_root,
-            dau_driver_root=args.dau_driver_root,
-            dau_utils_root=args.dau_utils_root,
-            python=args.python,
+            dau_core_root=self.dau_core_root,
+            dau_driver_root=self.dau_driver_root,
+            source_shell_root=self.source_shell_root,
+            dau_utils_root=self.dau_utils_root,
+            overlay_tcl=self.overlay_tcl,
+            python=self.python,
+            vivado_settings=self.vivado_settings,
         )
-    elif args.plan == "flash":
-        steps = flash_plan(config, dau_utils_root=args.dau_utils_root, python=args.python, vivado_settings=args.vivado_settings)
-    elif args.plan == "recovery":
-        steps = recovery_plan(config)
-    elif args.plan == "thunderbolt-hold":
-        steps = thunderbolt_hold_plan(config)
-    else:
-        steps = thunderbolt_release_plan(config)
-    if args.execute:
-        return execute_plan_steps(steps)
-    print(format_plan_steps(steps))
-    return 0
 
 
-if __name__ == "__main__":
-    raise SystemExit(main())
+for _plan_cls in (
+    HardwarePlan,
+    BuildAndProgramPlan,
+    RecoveryPlan,
+    ThunderboltHoldPlan,
+    ThunderboltReleasePlan,
+    FlashPlan,
+    ValidateBitstreamPlan,
+    LocalBuildAndProgramPlan,
+):
+    _plan_cls.model_rebuild()

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -387,9 +387,7 @@ def test_dau_build_main_dispatches_public_task_arguments(tmp_path: Path, capsys)
 def test_dau_build_cfg_dispatches_hardware_plan_via_group(capsys) -> None:
     from dau_build.cli import main as cfg_main
 
-    exit_code = cfg_main(
-        ["task=tasks/hardware/hardware-plan", "plan=plans/thunderbolt-release", "model.work_root=/repo/projects/vivado-shell"]
-    )
+    exit_code = cfg_main(["task=tasks/hardware/hardware-plan", "plan=plans/thunderbolt-release", "model.work_root=/repo/projects/vivado-shell"])
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -206,8 +206,14 @@ def test_execute_override_task_plans_identity_smoke_test() -> None:
     )
 
 
-def test_execute_override_task_accepts_public_hardware_plan_surface() -> None:
-    result = execute_override_task(("task=tasks/hardware/hardware-plan", "plan=thunderbolt-release", "work_root=/repo/projects/vivado-shell"))
+def test_hardware_plan_task_via_plan_group() -> None:
+    # the plan is the composed plan group: plan=plans/thunderbolt-release
+    result = run_request_config(
+        "task",
+        "tasks/hardware/hardware-plan",
+        overrides=["plan=plans/thunderbolt-release"],
+        model_values={"work_root": "/repo/projects/vivado-shell"},
+    )
 
     assert result == BuildStepResult(
         step="hardware-plan",
@@ -378,8 +384,12 @@ def test_dau_build_main_dispatches_public_task_arguments(tmp_path: Path, capsys)
     ]
 
 
-def test_dau_build_main_dispatches_public_hardware_plan_arguments(capsys) -> None:
-    exit_code = main(["task=tasks/hardware/hardware-plan", "plan=thunderbolt-release", "work_root=/repo/projects/vivado-shell"])
+def test_dau_build_cfg_dispatches_hardware_plan_via_group(capsys) -> None:
+    from dau_build.cli import main as cfg_main
+
+    exit_code = cfg_main(
+        ["task=tasks/hardware/hardware-plan", "plan=plans/thunderbolt-release", "model.work_root=/repo/projects/vivado-shell"]
+    )
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1,19 +1,18 @@
 import base64
-import runpy
 import shlex
-import sys
 from pathlib import Path
 
 import pytest
 
 import dau_build.hardware_plan as hardware_plan
 import dau_build.vivado_backend as vivado_backend
+from dau_build.build_steps import BuildStepError
+from dau_build.config import run_request_config
 from dau_build.hardware_plan import (
     HardwareToolchainConfig,
     build_and_program_plan,
     flash_plan,
     local_build_and_program_plan,
-    main,
     recovery_plan,
     stage_shell_plan,
     stage_vivado_overlay_plan,
@@ -34,6 +33,18 @@ from dau_build.vivado_backend import (
     validate_vivado_project_artifact_bundle,
     write_dau_overlay_tcl,
 )
+
+
+def _run_plan(plan: str, *, plan_fields=(), **model_values):
+    """Run the hardware-plan task with plan=plans/<plan>; plan_fields are
+    plan.<k>=<v> overrides, the rest are model.<k> values."""
+    return run_request_config(
+        "task",
+        "tasks/hardware/hardware-plan",
+        overrides=[f"plan=plans/{plan}", *plan_fields],
+        model_values=model_values,
+    )
+
 
 EXPECTED_PCI_RESCAN_BDFS = (
     "0000:03:01.0",
@@ -667,11 +678,10 @@ def test_thunderbolt_power_plans_hold_and_release_runtime_pm() -> None:
     )
 
 
-def test_cli_prints_recovery_plan_without_running_privileged_commands(capsys) -> None:
-    exit_code = main(["recovery", "--work-root", "/repo/projects/vivado-shell"])
+def test_task_prints_recovery_plan_without_running_privileged_commands() -> None:
+    result = _run_plan("recovery", work_root="/repo/projects/vivado-shell")
 
-    assert exit_code == 0
-    lines = capsys.readouterr().out.splitlines()
+    lines = result.message.splitlines()
     assert lines[0] == "thunderbolt-hold\tdau-pci-runtime-pm hold --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
     assert lines[1:4] == [
         "remove-endpoint\tsh -c 'test ! -e /sys/bus/pci/devices/0000:04:00.0/remove || echo 1 > /sys/bus/pci/devices/0000:04:00.0/remove'",
@@ -682,25 +692,12 @@ def test_cli_prints_recovery_plan_without_running_privileged_commands(capsys) ->
     assert EXPECTED_LSPCI_ENDPOINT_SNIPPET in lines[4]
 
 
-def test_cli_prints_thunderbolt_release_plan(capsys) -> None:
-    exit_code = main(["thunderbolt-release", "--work-root", "/repo/projects/vivado-shell"])
+def test_task_prints_thunderbolt_release_plan() -> None:
+    result = _run_plan("thunderbolt-release", work_root="/repo/projects/vivado-shell")
 
-    assert exit_code == 0
-    lines = capsys.readouterr().out.splitlines()
+    lines = result.message.splitlines()
     assert len(lines) == 1
     assert lines[0] == "thunderbolt-release\tdau-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
-
-
-def test_module_entrypoint_prints_plan_for_uninstalled_checkout(capsys, monkeypatch) -> None:
-    monkeypatch.setattr(sys, "argv", ["vivado-xdma", "thunderbolt-release", "--work-root", "/repo/projects/vivado-shell"])
-    monkeypatch.delitem(sys.modules, "dau_build.hardware_plan", raising=False)
-
-    with pytest.raises(SystemExit) as exc_info:
-        runpy.run_module("dau_build.hardware_plan", run_name="__main__")
-
-    assert exc_info.value.code == 0
-    lines = capsys.readouterr().out.splitlines()
-    assert lines == ["thunderbolt-release\tdau-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"]
 
 
 def test_local_build_and_program_plan_stages_overlay_programs_and_runs_hardware_smoke() -> None:
@@ -956,44 +953,32 @@ def test_local_flash_plan_uses_vivado_flash_script_inside_runtime_pm_session() -
     assert "vivado -mode batch -source scripts/flash.tcl" in steps[1].argv[2]
 
 
-def test_cli_local_build_can_stage_shell_before_overlay(capsys) -> None:
-    exit_code = main(
-        [
-            "local-build-and-program",
-            "--source-shell-root",
-            "/repo/reference/vivado-shell",
-            "--work-root",
-            "/repo/dau-build/outputs/vivado",
-            "--dau-core-root",
-            "/repo/dau-core",
-            "--dau-driver-root",
-            "/repo/dau-driver",
-        ]
+def test_task_local_build_can_stage_shell_before_overlay() -> None:
+    result = _run_plan(
+        "local-build-and-program",
+        plan_fields=[
+            "plan.source_shell_root=/repo/reference/vivado-shell",
+            "plan.dau_core_root=/repo/dau-core",
+            "plan.dau_driver_root=/repo/dau-driver",
+        ],
+        work_root="/repo/dau-build/outputs/vivado",
     )
 
-    assert exit_code == 0
-    lines = capsys.readouterr().out.splitlines()
+    lines = result.message.splitlines()
     assert len(lines) == 12
     assert lines[0].startswith("stage-shell\tsh -c ")
     assert lines[2].startswith("write-dau-overlay\tsh -c ")
     assert lines[3].startswith("write-vivado-build-script\tsh -c ")
 
 
-def test_cli_prints_local_build_and_program_plan(capsys) -> None:
-    exit_code = main(
-        [
-            "local-build-and-program",
-            "--work-root",
-            "/repo/projects/vivado-shell",
-            "--dau-core-root",
-            "/repo/dau-core",
-            "--dau-driver-root",
-            "/repo/dau-driver",
-        ]
+def test_task_prints_local_build_and_program_plan() -> None:
+    result = _run_plan(
+        "local-build-and-program",
+        plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.dau_driver_root=/repo/dau-driver"],
+        work_root="/repo/projects/vivado-shell",
     )
 
-    assert exit_code == 0
-    lines = capsys.readouterr().out.splitlines()
+    lines = result.message.splitlines()
     assert len(lines) == 11
     assert lines[0].startswith("thunderbolt-hold\tdau-pci-runtime-pm hold ")
     assert lines[1].startswith("write-dau-overlay\tsh -c ")
@@ -1003,23 +988,15 @@ def test_cli_prints_local_build_and_program_plan(capsys) -> None:
     assert lines[10].startswith("thunderbolt-release\tdau-pci-runtime-pm release ")
 
 
-def test_cli_prints_validate_bitstream_plan_without_vivado(capsys) -> None:
-    exit_code = main(
-        [
-            "validate-bitstream",
-            "--work-root",
-            "/repo/projects/vivado-shell",
-            "--bitstream",
-            "/tmp/candidate.bit",
-            "--dau-core-root",
-            "/repo/dau-core",
-            "--dau-driver-root",
-            "/repo/dau-driver",
-        ]
+def test_task_prints_validate_bitstream_plan_without_vivado() -> None:
+    result = _run_plan(
+        "validate-bitstream",
+        plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.dau_driver_root=/repo/dau-driver"],
+        work_root="/repo/projects/vivado-shell",
+        bitstream="/tmp/candidate.bit",
     )
 
-    assert exit_code == 0
-    lines = capsys.readouterr().out.splitlines()
+    lines = result.message.splitlines()
     assert len(lines) == 8
     assert lines[0].startswith("thunderbolt-hold\tdau-pci-runtime-pm hold ")
     assert lines[3] == "program-volatile\topenFPGALoader -c digilent_hs2 /tmp/candidate.bit"
@@ -1028,7 +1005,7 @@ def test_cli_prints_validate_bitstream_plan_without_vivado(capsys) -> None:
     assert all("vivado" not in line.lower() for line in lines)
 
 
-def test_cli_execute_runs_plan_steps_in_order(monkeypatch) -> None:
+def test_task_execute_runs_plan_steps_in_order(monkeypatch) -> None:
     calls = []
 
     class Completed:
@@ -1040,9 +1017,8 @@ def test_cli_execute_runs_plan_steps_in_order(monkeypatch) -> None:
 
     monkeypatch.setattr(hardware_plan.subprocess, "run", fake_run)
 
-    exit_code = main(["thunderbolt-release", "--work-root", "/repo/projects/vivado-shell", "--execute"])
+    _run_plan("thunderbolt-release", work_root="/repo/projects/vivado-shell", execute=True)
 
-    assert exit_code == 0
     assert calls == [
         (
             "dau-pci-runtime-pm",
@@ -1073,20 +1049,14 @@ def test_cli_execute_releases_runtime_pm_after_failed_local_plan_step(monkeypatc
 
     monkeypatch.setattr(hardware_plan.subprocess, "run", fake_run)
 
-    exit_code = main(
-        [
+    with pytest.raises(BuildStepError, match="exit code 23"):
+        _run_plan(
             "local-build-and-program",
-            "--work-root",
-            "/repo/projects/vivado-shell",
-            "--dau-core-root",
-            "/repo/dau-core",
-            "--dau-driver-root",
-            "/repo/dau-driver",
-            "--execute",
-        ]
-    )
+            plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.dau_driver_root=/repo/dau-driver"],
+            work_root="/repo/projects/vivado-shell",
+            execute=True,
+        )
 
-    assert exit_code == 23
     assert len(calls) == 3
     assert calls[0][1] == "hold"
     assert calls[1][0:2] == ("sh", "-c")

--- a/docs/how-to/program-hardware.md
+++ b/docs/how-to/program-hardware.md
@@ -26,18 +26,22 @@ The named plans are `local-build-and-program`, `build-and-program`,
 Always look at the sequence first. Omit `execute=true` and the task prints the
 ordered steps without touching the board:
 
+The plan is a config group (`plan=plans/<name>`); its own fields are
+`plan.<field>=` overrides and the shared toolchain fields are `model.<field>=`,
+so use the composing CLI (`dau-build-cfg` or `dau-build-run`):
+
 ```bash
-dau-build task=tasks/hardware/hardware-plan \
-  plan=local-build-and-program \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  dau_utils_root=/path/to/dau-utils
+dau-build-cfg task=tasks/hardware/hardware-plan \
+  plan=plans/local-build-and-program \
+  plan.source_shell_root=/path/to/vivado-shell-seed \
+  plan.dau_core_root=/path/to/dau-core \
+  plan.dau_driver_root=/path/to/dau-driver \
+  plan.dau_utils_root=/path/to/dau-utils \
+  model.work_root=outputs/vivado
 ```
 
 Read the printed steps. When they look right, re-run the same command with
-`execute=true` appended.
+`model.execute=true` appended.
 
 ## Program a fresh build
 
@@ -45,14 +49,14 @@ Read the printed steps. When they look right, re-run the same command with
 programs and verifies the device. Add `execute=true` to run it on the host:
 
 ```bash
-dau-build task=tasks/hardware/hardware-plan \
-  plan=local-build-and-program \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  dau_utils_root=/path/to/dau-utils \
-  execute=true
+dau-build-cfg task=tasks/hardware/hardware-plan \
+  plan=plans/local-build-and-program \
+  plan.source_shell_root=/path/to/vivado-shell-seed \
+  plan.dau_core_root=/path/to/dau-core \
+  plan.dau_driver_root=/path/to/dau-driver \
+  plan.dau_utils_root=/path/to/dau-utils \
+  model.work_root=outputs/vivado \
+  model.execute=true
 ```
 
 The plan holds runtime power management, writes the overlay/build Tcl, runs the
@@ -63,8 +67,8 @@ magic register and prints `DAU_SMOKE_OK`), and finally releases power management
 If any step fails, the release step still runs.
 
 If you already have a bitstream and only want to program it, use
-`build-and-program` with `bitstream=<path>` instead — it skips staging and the
-Vivado build.
+`plan=plans/build-and-program` with `model.bitstream=<path>` instead — it skips
+staging and the Vivado build.
 
 ## Validate an already-built bitstream
 
@@ -72,14 +76,14 @@ To program a specific bitstream and run the full endpoint-and-smoke check withou
 building anything, use `validate-bitstream`:
 
 ```bash
-dau-build task=tasks/hardware/hardware-plan \
-  plan=validate-bitstream \
-  work_root=outputs/vivado \
-  bitstream=/path/to/Top_wrapper.bit \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  dau_utils_root=/path/to/dau-utils \
-  execute=true
+dau-build-cfg task=tasks/hardware/hardware-plan \
+  plan=plans/validate-bitstream \
+  plan.dau_core_root=/path/to/dau-core \
+  plan.dau_driver_root=/path/to/dau-driver \
+  plan.dau_utils_root=/path/to/dau-utils \
+  model.work_root=outputs/vivado \
+  model.bitstream=/path/to/Top_wrapper.bit \
+  model.execute=true
 ```
 
 The XDMA kernel module must already be loaded; for a Vivado shell checkout it
@@ -93,10 +97,10 @@ the safe order: hold power management, remove the endpoint via sysfs, program a
 known-good volatile bitstream, then rescan and re-check:
 
 ```bash
-dau-build task=tasks/hardware/hardware-plan \
-  plan=recovery \
-  work_root=outputs/vivado \
-  execute=true
+dau-build-cfg task=tasks/hardware/hardware-plan \
+  plan=plans/recovery \
+  model.work_root=outputs/vivado \
+  model.execute=true
 ```
 
 This recovers the link without a reboot in most cases. If the endpoint still does

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -18,13 +18,14 @@ defaults:
   - optional backend: null
   - optional simulator: null
   - optional spec: null
+  - optional plan: null
   - optional design: null
   - callable: callable
 ```
 
 Every group except `callable` is `optional … null`: nothing is selected unless
 overridden. A run selects exactly one of `task=` or `step=` to populate `model`,
-optionally augmented by `spec=`, `board=`, `backend=`, `simulator=`, and `platform=`.
+optionally augmented by `spec=`, `board=`, `backend=`, `simulator=`, `platform=`, and `plan=`.
 
 Each option file begins with a `# @package <key>` directive that places its
 content under that top-level key. Tasks and steps use `# @package model`; the
@@ -39,6 +40,7 @@ other groups use their singular key (`# @package board`, etc.).
 | `backend`   | `backend`      | a `SynthesisEngine` (e.g. `VivadoEngine`) | The synthesis engine.                                            |
 | `simulator` | `simulator`    | a `Simulator` (e.g. `VerilatorSimulator`) | The simulator (used by `SimulateTask`).                          |
 | `platform`  | `platform`     | `dau_build.platforms.PlatformDefinition`  | The full physical platform definition.                           |
+| `plan`      | `plan`         | a `HardwarePlan` (e.g. `RecoveryPlan`)    | The hardware-session plan (`HardwarePlanTask`).                  |
 | `design`    | `design`       | (none packaged)                           | Reserved; registered by extension packages.                      |
 | `callable`  | —              | ccflow registry pointer                   | Fixed evaluator wiring; not normally overridden.                 |
 
@@ -153,6 +155,25 @@ byte-for-byte identical to the known-good core.
 `dsp`), `PlatformMemory` (`kind`, `size_bytes`, `mig_prj`,
 `bandwidth_bytes_per_s`), and `HostLink` (`interface`, `pcie_lanes`,
 `xdma_personality`).
+
+## `plan`
+
+`plan=plans/<name>` composes a `HardwarePlan` model into the `plan` key;
+`HardwarePlanTask` delegates to it. Each plan owns its required fields (so
+pydantic enforces them, rather than a runtime check).
+
+| Option                          | Model                      | Extra fields                                                                                                                |
+| ------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `plans/build-and-program`       | `BuildAndProgramPlan`      | —                                                                                                                           |
+| `plans/local-build-and-program` | `LocalBuildAndProgramPlan` | `dau_core_root`, `dau_driver_root` (req), `source_shell_root`, `dau_utils_root`, `overlay_tcl`, `python`, `vivado_settings` |
+| `plans/validate-bitstream`      | `ValidateBitstreamPlan`    | `dau_core_root`, `dau_driver_root` (req), `dau_utils_root`, `python`                                                        |
+| `plans/flash`                   | `FlashPlan`                | `dau_utils_root`, `python`, `vivado_settings`                                                                               |
+| `plans/recovery`                | `RecoveryPlan`             | —                                                                                                                           |
+| `plans/thunderbolt-hold`        | `ThunderboltHoldPlan`      | —                                                                                                                           |
+| `plans/thunderbolt-release`     | `ThunderboltReleasePlan`   | —                                                                                                                           |
+
+Configure a plan with `plan.<field>=…`; see
+[Program a bitstream on dpv1](../how-to/program-hardware.md).
 
 ## `design`
 

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -114,9 +114,12 @@ Required: `work_root`. Mode: **plan**.
 
 ### `tasks/hardware/hardware-plan` — `HardwarePlanTask`
 
-Produces a live hardware-session command sequence for a named `plan` (e.g.
-`local-build-and-program`, `validate-bitstream`, `flash`, `recovery`). Required:
-`plan`, `work_root`. Mode: **plan** (pass `execute=true` on the hardware host).
+Produces a live hardware-session command sequence for the plan composed from the
+`plan` group (`plan=plans/<name>`). The task holds the shared toolchain fields
+(`work_root`, `bitstream`, `vivado`, `jtag_cable`, …); each plan owns its own
+fields (e.g. `plan.dau_core_root`). Required: `plan`, `work_root`. Mode: **plan**
+(pass `execute=true` on the hardware host). See the
+[config group reference](config-groups.md) for the plan models.
 
 ### `tasks/flash/flash` — `FlashTask`
 


### PR DESCRIPTION
Second audit follow-up.

## What

`HardwarePlanTask.plan` was a `Literal` + a `composers` dict-of-lambdas (with a *second* redundant `if/elif` in an unregistered `argparse` `main()`), and per-plan required fields were nullable on the god-task, enforced by a hand-rolled `_required_path`.

- `HardwarePlan` base + one model per plan (`RecoveryPlan`, `LocalBuildAndProgramPlan`, …), each owning its required fields and a `compose()` method, selected from a new `plan` config group. Required fields (`dau_core_root`, `dau_driver_root`) are now non-optional on the subclasses — pydantic enforces them, so `_required_path` is deleted.
- `HardwarePlanTask` holds the shared toolchain fields and delegates to `self.plan.compose(config)` — no Literal, no dict dispatch.
- **Deleted** the unregistered `argparse` `main()` + `__main__` (finding #9) and its second dispatch. The plan-composition functions stay and back the models. The old argparse-CLI tests move to the hydra task surface.

## Usage

```
dau-build-cfg task=tasks/hardware/hardware-plan \\
  plan=plans/local-build-and-program \\
  plan.dau_core_root=... plan.dau_driver_root=... model.work_root=... model.execute=true
```

Missing a required plan field now raises a typed `MissingMandatoryValue` at compose time instead of a hand-rolled runtime check.

## Validation

- Full suite 223 passed + 1 skipped. ruff clean; yardang zero warnings.
- Docs updated: program-hardware how-to, task catalog, and a new `plan` config-group section.

Remaining: #3 spec model_validate, #4-9 the rest.