### PR TITLE
Type the shell build status as a model (audit #5)

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -666,13 +666,12 @@ class BuildShellProjectTask(BuildCallableModel):
             self.output_root,
             name=self.manifest_name,
             source_paths=self.source_paths,
-            metadata={**self.metadata, **status},
+            metadata={**self.metadata, **status.model_dump(exclude_none=True)},
         )
         return BuildStepResult(
             step="build-shell-project",
             message=(
-                f"dau-build-shell\ttask=build-shell-project output_root={self.output_root}"
-                f" wns={status.get('wns_ns')} manifest={manifest_path} status=built"
+                f"dau-build-shell\ttask=build-shell-project output_root={self.output_root} wns={status.wns_ns} manifest={manifest_path} status=built"
             ),
         )
 

--- a/dau_build/shell_build.py
+++ b/dau_build/shell_build.py
@@ -15,15 +15,17 @@ import hashlib
 import re
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from artlink import Artifact, Digest
+from ccflow import BaseModel
 
 from .packaging import ArtifactManifest
 
 __all__ = (
     "SHELL_BUILD_MANIFEST_NAME",
     "ShellBuildError",
+    "ShellBuildStatus",
     "run_shell_project_build",
     "parse_shell_build_console",
     "shell_build_manifest",
@@ -39,13 +41,22 @@ class ShellBuildError(ValueError):
     pass
 
 
+class ShellBuildStatus(BaseModel):
+    """The outcome of a shell project build, parsed from the Vivado console."""
+
+    build_status: Literal["built", "failed", "unknown"]
+    wns_ns: float | None = None
+    failed_stage: str | None = None
+    return_code: int | None = None
+
+
 def run_shell_project_build(
     output_root: Path,
     *,
     script: str = "build_mm_job.tcl",
     vivado_executable: str = "vivado",
     console_log: str = "console.log",
-) -> dict[str, Any]:
+) -> ShellBuildStatus:
     """Execute the generated project script in batch mode from inside the
     output root (the scripts resolve their artifacts relative to
     themselves) and return the parsed build status."""
@@ -62,26 +73,26 @@ def run_shell_project_build(
             check=False,
         )
     status = parse_shell_build_console(log_path.read_text(encoding="utf-8"))
-    status["return_code"] = completed.returncode
-    if completed.returncode != 0 or status["build_status"] != "built":
+    status.return_code = completed.returncode
+    if completed.returncode != 0 or status.build_status != "built":
         raise ShellBuildError(
-            f"shell build failed (exit {completed.returncode}, status {status['build_status']}"
-            + (f", stage {status['failed_stage']}" if status.get("failed_stage") else "")
+            f"shell build failed (exit {completed.returncode}, status {status.build_status}"
+            + (f", stage {status.failed_stage}" if status.failed_stage else "")
             + f"): see {log_path.as_posix()}"
         )
     return status
 
 
-def parse_shell_build_console(console_text: str) -> dict[str, Any]:
+def parse_shell_build_console(console_text: str) -> ShellBuildStatus:
     """Extract the build outcome the generated scripts print: the
     DAU_MM_JOB_BUILD_OK/FAILED marker and the routed worst negative slack."""
     ok = _BUILD_OK_PATTERN.search(console_text)
     if ok:
-        return {"build_status": "built", "wns_ns": float(ok.group("wns"))}
+        return ShellBuildStatus(build_status="built", wns_ns=float(ok.group("wns")))
     failed = _BUILD_FAILED_PATTERN.search(console_text)
     if failed:
-        return {"build_status": "failed", "failed_stage": failed.group("stage")}
-    return {"build_status": "unknown"}
+        return ShellBuildStatus(build_status="failed", failed_stage=failed.group("stage"))
+    return ShellBuildStatus(build_status="unknown")
 
 
 def _digest(path: Path) -> Digest:

--- a/dau_build/tests/test_shell_build.py
+++ b/dau_build/tests/test_shell_build.py
@@ -12,6 +12,7 @@ from dau_build.packaging import load_artifact_manifest
 from dau_build.shell_build import (
     SHELL_BUILD_MANIFEST_NAME,
     ShellBuildError,
+    ShellBuildStatus,
     parse_shell_build_console,
     run_shell_project_build,
     shell_build_manifest,
@@ -39,9 +40,9 @@ def _fake_vivado(tmp_path: Path) -> Path:
 
 
 def test_parse_console_markers() -> None:
-    assert parse_shell_build_console("noise\nDAU_MM_JOB_BUILD_OK wns=0.321\n") == {"build_status": "built", "wns_ns": 0.321}
-    assert parse_shell_build_console("DAU_MM_JOB_BUILD_FAILED synthesis\n") == {"build_status": "failed", "failed_stage": "synthesis"}
-    assert parse_shell_build_console("vivado died\n") == {"build_status": "unknown"}
+    assert parse_shell_build_console("noise\nDAU_MM_JOB_BUILD_OK wns=0.321\n") == ShellBuildStatus(build_status="built", wns_ns=0.321)
+    assert parse_shell_build_console("DAU_MM_JOB_BUILD_FAILED synthesis\n") == ShellBuildStatus(build_status="failed", failed_stage="synthesis")
+    assert parse_shell_build_console("vivado died\n") == ShellBuildStatus(build_status="unknown")
 
 
 def test_manifest_packages_outputs_with_digests(tmp_path: Path) -> None:
@@ -75,8 +76,8 @@ def test_run_build_with_stub_vivado(tmp_path: Path) -> None:
     output_root.mkdir()
     (output_root / "build_mm_job.tcl").write_text("# generated\n")
     status = run_shell_project_build(output_root, vivado_executable=str(_fake_vivado(tmp_path)))
-    assert status["build_status"] == "built"
-    assert status["wns_ns"] == 0.123
+    assert status.build_status == "built"
+    assert status.wns_ns == 0.123
     assert (output_root / "dau_mm_job.bit").is_file()
 
 


### PR DESCRIPTION
Audit follow-up #5.

`run_shell_project_build` / `parse_shell_build_console` returned a `dict[str, Any]` mutated by string key (`status["return_code"] = ...`, `status.get("failed_stage")`). Replaced with a typed `ShellBuildStatus(BaseModel)`:

```python
class ShellBuildStatus(BaseModel):
    build_status: Literal["built", "failed", "unknown"]
    wns_ns: float | None = None
    failed_stage: str | None = None
    return_code: int | None = None
```

Callers use attributes; the manifest metadata is fed via `model_dump(exclude_none=True)` (unchanged content). Full suite 223 passed + 1 skipped; ruff clean.

See the PR discussion for my assessment of the remaining audit items (#4/#6/#7/#8) — several are cross-package glue or premature, so I recommend leaving them.