### PR TITLE
Make driver and memory composable config groups (audit #7)

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -55,12 +55,15 @@ class ResolvedBuildConfig(BaseModel):
         board: BoardConfig | None = None,
         backend: BackendConfig | None = None,
         backend_name: str | None = None,
+        driver: DriverConfig | None = None,
+        memory: MemoryConfig | None = None,
     ) -> ResolvedBuildConfig:
         """The build config as a view over the spec. Board, driver,
         operators, and memory derive from the spec directly. A composed
-        ``board=``/``backend=`` Hydra group wins over the spec-derived
-        default when provided; ``backend_name`` (e.g. a task's synthesis
-        engine) selects the backend when no ``backend=`` group is given.
+        ``board=``/``backend=``/``driver=``/``memory=`` Hydra group wins over
+        the spec-derived default when provided; ``backend_name`` (e.g. a task's
+        synthesis engine) selects the backend when no ``backend=`` group is
+        given.
 
         A composed backend may be a synthesis *engine* model (carrying extra
         fields like a yosys frontend); it is normalized here to the ``name`` +
@@ -69,9 +72,9 @@ class ResolvedBuildConfig(BaseModel):
             spec=spec,
             board=board or BoardConfig(name=spec.platform, platform=spec.platform, shell=spec.shell),
             backend=_backend_label(backend, backend_name, spec),
-            driver=DriverConfig(os="host", transport="xdma"),
+            driver=driver or DriverConfig(os="host", transport="xdma"),
             operators=OperatorConfig(set_name="spec", names=spec.operators),
-            memory=MemoryConfig(),
+            memory=memory or MemoryConfig(),
         )
 
     def to_text(self) -> str:

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -36,11 +36,11 @@ def _build_spec_api():
     return build_spec
 
 
-def _resolve_build_config(spec, *, board=None, backend=None, backend_name=None):
+def _resolve_build_config(spec, *, board=None, backend=None, backend_name=None, driver=None, memory=None):
     """Deferred for the same reason: build_config imports build_spec."""
     from dau_build.build_config import ResolvedBuildConfig
 
-    return ResolvedBuildConfig.from_spec(spec, board=board, backend=backend, backend_name=backend_name)
+    return ResolvedBuildConfig.from_spec(spec, board=board, backend=backend, backend_name=backend_name, driver=driver, memory=memory)
 
 
 class BuildStepError(ValueError):
@@ -77,9 +77,11 @@ class SpecPathModel(BuildCallableModel):
     spec_path: Path | None = None
     board: Any = None
     backend: Any = None
+    driver: Any = None
+    memory: Any = None
 
     def _resolved(self, spec, *, backend_name=None):
-        return _resolve_build_config(spec, board=self.board, backend=self.backend, backend_name=backend_name)
+        return _resolve_build_config(spec, board=self.board, backend=self.backend, backend_name=backend_name, driver=self.driver, memory=self.memory)
 
     def load_spec(self):
         build_spec = self.spec

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -7,6 +7,8 @@ defaults:
   - optional platform: null
   - optional board: null
   - optional backend: null
+  - optional driver: null
+  - optional memory: null
   - optional simulator: null
   - optional spec: null
   - optional plan: null

--- a/dau_build/config/driver/drivers/host.yaml
+++ b/dau_build/config/driver/drivers/host.yaml
@@ -1,0 +1,6 @@
+# @package driver
+
+# driver=drivers/host — the host-side driver (OS + transport)
+_target_: dau_build.build_config.DriverConfig
+os: host
+transport: xdma

--- a/dau_build/config/memory/memories/default.yaml
+++ b/dau_build/config/memory/memories/default.yaml
@@ -1,0 +1,6 @@
+# @package memory
+
+# memory=memories/default — build-time staging buffers (bytes)
+_target_: dau_build.build_config.MemoryConfig
+host_staging_bytes: 0
+device_staging_bytes: 0

--- a/dau_build/config/step/steps/explain.yaml
+++ b/dau_build/config/step/steps/explain.yaml
@@ -5,3 +5,5 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}

--- a/dau_build/config/step/steps/generate.yaml
+++ b/dau_build/config/step/steps/generate.yaml
@@ -5,4 +5,6 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 output_root: ???

--- a/dau_build/config/step/steps/inspect.yaml
+++ b/dau_build/config/step/steps/inspect.yaml
@@ -5,3 +5,5 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}

--- a/dau_build/config/step/steps/resolved-config.yaml
+++ b/dau_build/config/step/steps/resolved-config.yaml
@@ -5,3 +5,5 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}

--- a/dau_build/config/step/steps/simulate.yaml
+++ b/dau_build/config/step/steps/simulate.yaml
@@ -5,6 +5,8 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 output_root: null
 simulate_engine: svparser
 simulate_profile: null

--- a/dau_build/config/step/steps/synthesis.yaml
+++ b/dau_build/config/step/steps/synthesis.yaml
@@ -5,4 +5,6 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 output_root: ???

--- a/dau_build/config/step/steps/validate.yaml
+++ b/dau_build/config/step/steps/validate.yaml
@@ -5,3 +5,5 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}

--- a/dau_build/config/step/steps/write.yaml
+++ b/dau_build/config/step/steps/write.yaml
@@ -5,4 +5,6 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 output_root: ???

--- a/dau_build/config/task/tasks/build/synthesize.yaml
+++ b/dau_build/config/task/tasks/build/synthesize.yaml
@@ -7,5 +7,7 @@ board: ${oc.select:board,null}
 # the synthesis engine is the composed backend group (default vivado);
 # select+configure it with backend=backends/yosys backend.frontend=slang
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 module: ???
 output_root: ???

--- a/dau_build/config/task/tasks/sim/simulate.yaml
+++ b/dau_build/config/task/tasks/sim/simulate.yaml
@@ -5,6 +5,8 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 module: ""
 output_root: null
 # the simulator is the composed simulator group (default svparser);

--- a/dau_build/config/task/tasks/spec/build.yaml
+++ b/dau_build/config/task/tasks/spec/build.yaml
@@ -5,4 +5,6 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 output_root: ???

--- a/dau_build/config/task/tasks/spec/inspect.yaml
+++ b/dau_build/config/task/tasks/spec/inspect.yaml
@@ -5,3 +5,5 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}

--- a/dau_build/config/task/tasks/spec/validate.yaml
+++ b/dau_build/config/task/tasks/spec/validate.yaml
@@ -5,5 +5,7 @@ spec_path: null
 spec: ${oc.select:spec,null}
 board: ${oc.select:board,null}
 backend: ${oc.select:backend,null}
+driver: ${oc.select:driver,null}
+memory: ${oc.select:memory,null}
 manifest_path: null
 root: null

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -101,6 +101,8 @@ def test_public_override_dispatch_runs_packaged_task_configs(monkeypatch) -> Non
         "spec_path": "examples/identity/dau-build.yaml",
         "board": None,
         "backend": None,
+        "driver": None,
+        "memory": None,
         "module": "dau_identity_top",
         "output_root": None,
         "simulator": None,
@@ -223,3 +225,25 @@ def test_board_and_backend_groups_override_spec_derived_resolved_config() -> Non
     assert "board\tname=vivado-xdma" in derived.message  # spec-derived: board name = platform
     assert "board\tname=dpv1" in composed.message  # composed board wins
     assert "backend\tname=vivado invocation=standard" in composed.message  # composed backend wins
+
+
+def test_driver_and_memory_config_groups_compose_and_override() -> None:
+    # driver=/memory= compose into the resolved config; fields are overridable
+    spec = "examples/identity/dau-build.yaml"
+    result = cfg_run(
+        base_load_config(
+            root_config_dir=str(_CONFIG_DIR),
+            root_config_name="base",
+            overrides=[
+                "step=steps/resolved-config",
+                f"model.spec_path={spec}",
+                "driver=drivers/host",
+                "memory=memories/default",
+                "memory.host_staging_bytes=4096",
+            ],
+            basepath=str(_CONFIG_DIR),
+            debug=False,
+        ).cfg
+    )
+    assert "driver\tos=host transport=xdma" in result.message
+    assert "memory\thost_staging_bytes=4096 device_staging_bytes=0" in result.message

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -16,6 +16,8 @@ defaults:
   - optional platform: null
   - optional board: null
   - optional backend: null
+  - optional driver: null
+  - optional memory: null
   - optional simulator: null
   - optional spec: null
   - optional plan: null
@@ -25,7 +27,7 @@ defaults:
 
 Every group except `callable` is `optional … null`: nothing is selected unless
 overridden. A run selects exactly one of `task=` or `step=` to populate `model`,
-optionally augmented by `spec=`, `board=`, `backend=`, `simulator=`, `platform=`, and `plan=`.
+optionally augmented by `spec=`, `board=`, `backend=`, `driver=`, `memory=`, `simulator=`, `platform=`, and `plan=`.
 
 Each option file begins with a `# @package <key>` directive that places its
 content under that top-level key. Tasks and steps use `# @package model`; the
@@ -38,6 +40,8 @@ other groups use their singular key (`# @package board`, etc.).
 | `spec`      | `spec`         | `dau_build.build_spec.BuildSpec`          | A composed build spec (Hydra-native alternative to `spec_path`). |
 | `board`     | `board`        | `dau_build.build_config.BoardConfig`      | A board's build-config view.                                     |
 | `backend`   | `backend`      | a `SynthesisEngine` (e.g. `VivadoEngine`) | The synthesis engine.                                            |
+| `driver`    | `driver`       | `dau_build.build_config.DriverConfig`     | The host driver (OS + transport) in the resolved config.         |
+| `memory`    | `memory`       | `dau_build.build_config.MemoryConfig`     | The build-time staging buffers in the resolved config.           |
 | `simulator` | `simulator`    | a `Simulator` (e.g. `VerilatorSimulator`) | The simulator (used by `SimulateTask`).                          |
 | `platform`  | `platform`     | `dau_build.platforms.PlatformDefinition`  | The full physical platform definition.                           |
 | `plan`      | `plan`         | a `HardwarePlan` (e.g. `RecoveryPlan`)    | The hardware-session plan (`HardwarePlanTask`).                  |
@@ -125,6 +129,16 @@ hydra-configurable — e.g. `backend=backends/yosys backend.frontend=slang` or
 or `slang` (yosys-slang); `yosys` sets the executable. See
 [the architecture explanation](../explanation/architecture.md) for how the two
 engines differ.
+
+## `driver` and `memory`
+
+`driver=drivers/<name>` and `memory=memories/<name>` compose a `DriverConfig`
+(`os`, `transport`) and `MemoryConfig` (`host_staging_bytes`,
+`device_staging_bytes`) into the resolved build config, winning over the
+spec-derived defaults (`drivers/host` = `host`/`xdma`; `memories/default` =
+zeros). They surface in the `resolved-config` step and are the axes a future
+board/platform (dpv2) selects. Overridable like any group, e.g.
+`memory=memories/default memory.host_staging_bytes=4096`.
 
 ## `simulator`
 


### PR DESCRIPTION
Forward-looking follow-up for dpv2.

`ResolvedBuildConfig.from_spec` hardcoded `DriverConfig(os="host", transport="xdma")` and `MemoryConfig()` as Python literals. Promoted them to `driver=` / `memory=` config groups (`drivers/host`, `memories/default`), composed the same way `board=`/`backend=` are, winning over the spec-derived defaults.

This is the dpv2/cross-platform hook: a future board/platform selects its own driver (transport) and memory (staging) without editing dau-build.

- `from_spec` accepts `driver=`/`memory=`; `SpecPathModel` gains `driver`/`memory` (`Any`), threaded through `_resolved`.
- They compose into every resolved-config-producing step/task and are fully overridable, e.g. `memory=memories/default memory.host_staging_bytes=4096`.

## Validation

Full suite 224 passed + 1 skipped (added a driver/memory composition test); ruff clean; yardang zero warnings. Docs: new `driver`/`memory` config-group section + table rows.