### PR TITLE
Consolidate the CLI to a single dau-build entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Two synthesis engines are supported: Vivado (the FPGA bitstream flow) and yosys 
 Build the checked-in identity example — no board or vendor tools required:
 
 ```bash
-dau-build task=tasks/spec/inspect  spec_path=examples/identity/dau-build.yaml
-dau-build task=tasks/spec/build     spec_path=examples/identity/dau-build.yaml output_root=outputs/identity
-dau-build task=tasks/spec/validate  manifest_path=outputs/identity/dau-identity.manifest root=outputs/identity
-dau-build task=tasks/sim/simulate   module=dau_identity_top spec_path=examples/identity/dau-build.yaml
+dau-build task=tasks/spec/inspect  model.spec_path=examples/identity/dau-build.yaml
+dau-build task=tasks/spec/build     model.spec_path=examples/identity/dau-build.yaml model.output_root=outputs/identity
+dau-build task=tasks/spec/validate  model.manifest_path=outputs/identity/dau-identity.manifest model.root=outputs/identity
+dau-build task=tasks/sim/simulate   model.module=dau_identity_top model.spec_path=examples/identity/dau-build.yaml
 ```
 
 Task and step names are path-style, mirroring the config tree (`task=tasks/spec/inspect`, `step=steps/inspect`).

--- a/dau_build/__init__.py
+++ b/dau_build/__init__.py
@@ -1,6 +1,6 @@
 from importlib import import_module
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 _SVPARSER_EXPORTS = frozenset(
     {

--- a/dau_build/build_spec.py
+++ b/dau_build/build_spec.py
@@ -269,46 +269,6 @@ def dau_artifact_manifest(spec: DauBuildSpec, *, design: Design, top_sv_path: Pa
     return ArtifactManifest(name=spec.name, intent="output", artifacts=artifacts)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """``dau-build``: dispatch a task through the registry from the flat
-    ``task=<path> field=value`` surface (see docs/reference/commands.md)."""
-    import sys
-
-    from dau_build.build_steps import BuildStepError, execute_override_request
-
-    arguments = sys.argv[1:] if argv is None else argv
-    if not arguments or not _looks_like_override_request(arguments[0]):
-        print("usage: dau-build task=<path> [field=value ...]  (see docs/reference/commands.md)", file=sys.stderr)
-        return 2
-    try:
-        result = execute_override_request(arguments)
-    except (BuildStepError, DauBuildSpecError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-    print(result.message)
-    return 0
-
-
-def main_callable_steps(argv: list[str] | None = None) -> int:
-    import sys
-
-    from dau_build.build_steps import BuildStepError, execute_override_step
-
-    arguments = sys.argv[1:] if argv is None else argv
-    try:
-        result = execute_override_step(arguments)
-    except (BuildStepError, DauBuildSpecError) as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-    print(result.message)
-    return 0
-
-
-def _looks_like_override_request(argument: str) -> bool:
-    normalized_argument = argument[1:] if argument.startswith("+") else argument
-    return "=" in normalized_argument
-
-
 def dau_build_spec_summary(spec: DauBuildSpec) -> str:
     summary = (
         "dau-build-spec\t"
@@ -527,7 +487,3 @@ def _bundle_path(root: Path, path: Path) -> Path:
     if path.is_absolute():
         return path
     return root / path
-
-
-if __name__ == "__main__":
-    raise SystemExit(main())

--- a/dau_build/cli.py
+++ b/dau_build/cli.py
@@ -1,19 +1,22 @@
-"""ccflow-registry CLI surface for dau-build (the ccflow-etl-style path).
+"""The dau-build CLI: run a task through the ccflow model registry.
 
-The task dispatch has always loaded through the hydra config tree in
-``dau_build/config`` (``request_config``/``run_request_config``); this module
-exposes that machinery directly on the command line:
+Task dispatch loads through the hydra config tree in ``dau_build/config``
+(``request_config``/``run_request_config``); this module exposes that
+machinery on the command line as the single ``dau-build`` entry point:
 
-    dau-build-cfg task=tasks/sim/simulate model.simulator=verilator model.profile=<name>
-    dau-build-cfg task=tasks/build/synthesize spec=specs/identity model.module=m \\
-        model.engine=vivado model.output_root=out
-    dau-build-cfg --config-dir ./my-configs task=my-custom-task
-    dau-build-cfg-explain task=synthesize ...   # resolved config, no execution
+    dau-build task=tasks/sim/simulate simulator=simulators/verilator model.profile=<name>
+    dau-build task=tasks/build/synthesize spec=specs/identity model.module=m \\
+        backend=backends/vivado model.output_root=out
+    dau-build --config-dir ./my-configs task=my-custom-task
+    dau-build --explain task=tasks/build/synthesize ...   # resolved config, no run
 
-Open registration: a ``--config-dir`` overlay can add new task configs (and
-new ``_target_`` models from any importable package) without modifying
-dau-build. The legacy ``dau-build task=... key=value`` front-end remains for
-the flat roadmap syntax; both converge on the same registry execution.
+Overrides are hydra overrides: ``group=option`` selects a config group
+(``backend=``, ``simulator=``, ``design=``, ``plan=``, ``board=``, ``spec=``,
+``step=``) and ``model.field=value`` sets a task field.
+
+Open registration: a ``--config-dir`` overlay (or a package's own
+``hydra.lernaplugins`` entry point) can add new task configs and new
+``_target_`` models without modifying dau-build.
 """
 
 from __future__ import annotations
@@ -28,11 +31,12 @@ from dau_build.build_steps import BuildStepError, BuildStepResult
 
 def _parse(argv: list[str] | None) -> tuple[argparse.Namespace, list[str]]:
     parser = argparse.ArgumentParser(
-        prog="dau-build-cfg",
+        prog="dau-build",
         description="Run a dau-build task through the ccflow model registry with hydra composition.",
     )
     parser.add_argument("--config-dir", default=None, help="user config overlay directory (open registration)")
-    parser.add_argument("overrides", nargs="*", help="hydra overrides, e.g. task=simulate model.profile=...")
+    parser.add_argument("--explain", action="store_true", help="print the resolved config instead of running the task")
+    parser.add_argument("overrides", nargs="*", help="hydra overrides, e.g. task=... backend=backends/yosys model.output_root=...")
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
     return args, list(args.overrides)
 
@@ -44,6 +48,9 @@ def main(argv: list[str] | None = None) -> int:
 
     args, overrides = _parse(argv)
     result = compose_config(overrides, config_dir=args.config_dir)
+    if args.explain:
+        print(OmegaConf.to_yaml(result.cfg, resolve=True))
+        return 0
     if "model" not in result.cfg:
         raise BuildStepError("no task selected; pass task=<name> (see dau_build/config/task) or a --config-dir overlay")
     outcome = cfg_run(result.cfg)
@@ -52,40 +59,6 @@ def main(argv: list[str] | None = None) -> int:
     elif outcome is not None:
         print(outcome)
     return 0
-
-
-def explain(argv: list[str] | None = None) -> int:
-    from dau_build.config import compose_config
-
-    args, overrides = _parse(argv)
-    result = compose_config(overrides, config_dir=args.config_dir)
-    print(OmegaConf.to_yaml(result.cfg, resolve=True))
-    return 0
-
-
-def _hydra_run(cfg):
-    from ccflow.utils.hydra import cfg_run
-
-    outcome = cfg_run(cfg)
-    if isinstance(outcome, BuildStepResult):
-        print(outcome.message)
-    elif outcome is not None:
-        print(outcome)
-    return outcome
-
-
-def run(argv: list[str] | None = None):
-    """The single ccflow-etl-style CLI: a Hydra app over ``dau_build/config``
-    with the search path active, so packaged and search-path-registered
-    config groups compose uniformly:
-
-        dau-build-run task=tasks/... board=boards/dau/dpv1 backend=backends/vivado
-
-    Search-path packages (their own ``hydra.lernaplugins`` entry point) add
-    boards/backends/designs/tasks without editing dau-build."""
-    import hydra
-
-    return hydra.main(config_path="config", config_name="base", version_base=None)(_hydra_run)()
 
 
 if __name__ == "__main__":

--- a/dau_build/config/__init__.py
+++ b/dau_build/config/__init__.py
@@ -89,7 +89,7 @@ def compose_config(
 ) -> ConfigLoadResult:
     """Compose the dau-build hydra config with raw overrides (group selection,
     field overrides, user --config-dir overlays). The public entry for the
-    dau-build-cfg CLI surface."""
+    dau-build CLI surface."""
     return _load_base_config(overrides, config_dir=config_dir, version_base=version_base)
 
 

--- a/dau_build/tests/test_build_spec.py
+++ b/dau_build/tests/test_build_spec.py
@@ -7,9 +7,9 @@ from dau_build.build_spec import (
     DauBuildSpec,
     design_manifest_items,
     generate_dau_build_artifacts,
-    main,
     write_dau_build_artifacts,
 )
+from dau_build.cli import main
 from dau_build.packaging import artifact_modules, load_artifact_manifest
 
 _SV_DIR = (Path(__file__).parent / ".." / "sv").resolve()
@@ -222,7 +222,7 @@ def test_generate_dau_build_artifacts_emits_stream_job_top_boundary_for_stream_m
 def test_cli_build_emits_dau_native_artifact_bundle(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = main(["task=tasks/spec/build", f"spec_path={spec_path}", f"output_root={tmp_path / 'out'}"])
+    exit_code = main(["task=tasks/spec/build", f"model.spec_path={spec_path}", f"model.output_root={tmp_path / 'out'}"])
 
     assert exit_code == 0
     assert (tmp_path / "out" / "generated" / "dau_identity_top.sv").is_file()
@@ -285,7 +285,7 @@ def test_generate_dau_build_artifacts_rejects_unknown_requested_module(tmp_path:
 def test_cli_inspect_reports_spec_without_generating_outputs(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = _main_exit_code(["task=tasks/spec/inspect", f"spec_path={spec_path}"])
+    exit_code = _main_exit_code(["task=tasks/spec/inspect", f"model.spec_path={spec_path}"])
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [
@@ -297,10 +297,10 @@ def test_cli_inspect_reports_spec_without_generating_outputs(tmp_path: Path, cap
 def test_cli_validate_accepts_spec_and_artifact_bundle(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    spec_exit_code = _main_exit_code(["task=tasks/spec/validate", f"spec_path={spec_path}"])
-    build_exit_code = main(["task=tasks/spec/build", f"spec_path={spec_path}", f"output_root={tmp_path / 'out'}"])
+    spec_exit_code = _main_exit_code(["task=tasks/spec/validate", f"model.spec_path={spec_path}"])
+    build_exit_code = main(["task=tasks/spec/build", f"model.spec_path={spec_path}", f"model.output_root={tmp_path / 'out'}"])
     bundle_exit_code = _main_exit_code(
-        ["task=tasks/spec/validate", f"manifest_path={tmp_path / 'out' / 'dau-identity.manifest'}", f"root={tmp_path / 'out'}"]
+        ["task=tasks/spec/validate", f"model.manifest_path={tmp_path / 'out' / 'dau-identity.manifest'}", f"model.root={tmp_path / 'out'}"]
     )
 
     assert spec_exit_code == 0
@@ -517,7 +517,7 @@ def test_cli_inspect_reports_manifest_input_origins(tmp_path: Path, capsys) -> N
         encoding="utf-8",
     )
 
-    exit_code = _main_exit_code(["task=tasks/spec/inspect", f"spec_path={spec_path}"])
+    exit_code = _main_exit_code(["task=tasks/spec/inspect", f"model.spec_path={spec_path}"])
 
     assert exit_code == 0
     origin = package_manifest_path.resolve().as_posix()

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -6,7 +6,6 @@ from shutil import which
 import pytest
 from ccflow import CallableModel
 
-from dau_build.build_spec import main_callable_steps
 from dau_build.build_steps import (
     STEP_MODEL_TYPES,
     TASK_MODEL_TYPES,
@@ -17,6 +16,7 @@ from dau_build.build_steps import (
     execute_override_step,
     parse_override_dict,
 )
+from dau_build.cli import main
 
 _SV_DIR = (Path(__file__).parent / ".." / "sv").resolve()
 
@@ -258,7 +258,7 @@ def test_execute_step_validates_required_overrides(tmp_path: Path) -> None:
 def test_callable_steps_entrypoint_prints_result(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = main_callable_steps(["step=steps/validate", f"spec_path={spec_path}"])
+    exit_code = main(["step=steps/validate", f"model.spec_path={spec_path}"])
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [f"dau-build-spec-valid\tspec={spec_path}"]

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -6,8 +6,8 @@ import pytest
 import tomllib
 from ccflow import CallableModel
 
-from dau_build.build_spec import main
 from dau_build.build_steps import BuildStepError, BuildStepResult, SimulateTask, execute_override_request, execute_override_task
+from dau_build.cli import main
 from dau_build.config import run_request_config
 from dau_build.vivado_backend import VivadoBackendArtifactValidation, VivadoBackendRequest, generate_vivado_backend_artifacts
 
@@ -376,7 +376,7 @@ def test_execute_override_task_validates_vivado_artifacts_in_process(tmp_path: P
 def test_dau_build_main_dispatches_public_task_arguments(tmp_path: Path, capsys) -> None:
     spec_path = _write_spec(tmp_path)
 
-    exit_code = main(["task=tasks/sim/simulate", "module=dau_identity_top", f"spec_path={spec_path}"])
+    exit_code = main(["task=tasks/sim/simulate", "model.module=dau_identity_top", f"model.spec_path={spec_path}"])
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [
@@ -400,13 +400,9 @@ def test_package_scripts_stay_on_hydra_style_dau_build_entrypoints() -> None:
     scripts = pyproject["project"]["scripts"]
 
     assert "dau-hardware-plan" not in scripts
-    assert scripts == {
-        "dau-build": "dau_build.build_spec:main",
-        "dau-build-steps": "dau_build.build_spec:main_callable_steps",
-        "dau-build-cfg": "dau_build.cli:main",
-        "dau-build-cfg-explain": "dau_build.cli:explain",
-        "dau-build-run": "dau_build.cli:run",
-    }
+    # one CLI: dau-build is the hydra composition entry point. Steps, config
+    # explain, and the hydra.main variant are gone (step=/--explain cover them).
+    assert scripts == {"dau-build": "dau_build.cli:main"}
     # the config tree is registered on the Hydra search path for extension
     assert pyproject["project"]["entry-points"]["hydra.lernaplugins"]["dau-build"] == "pkg:dau_build.config"
 

--- a/dau_build/tests/test_cfg_cli.py
+++ b/dau_build/tests/test_cfg_cli.py
@@ -5,7 +5,7 @@ from shutil import which
 
 import pytest
 
-from dau_build.cli import explain, main
+from dau_build.cli import main
 from dau_build.tests.test_simulate_profile_task import _write_self_contained_counter_manifest
 
 
@@ -42,7 +42,7 @@ def test_profile_only_simulate_falls_back_to_manifest_registry() -> None:
 
 
 def test_cfg_explain_prints_resolved_config(capsys) -> None:
-    exit_code = explain(["task=tasks/build/synthesize", "model.spec_path=spec.yaml", "model.module=m", "model.output_root=out"])
+    exit_code = main(["--explain", "task=tasks/build/synthesize", "model.spec_path=spec.yaml", "model.module=m", "model.output_root=out"])
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "_target_: dau_build.build_steps.SynthesizeTask" in captured.out

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -50,22 +50,20 @@ Because groups are just directories and options are just files, the config tree
 derived by globbing the tree (`_model_types_from_config_group`), so there is no
 second place to register it.
 
-## Why there are two override syntaxes
+## The override syntax
 
-Two families of CLI exist because two audiences want different things.
+`dau-build` composes the config tree and runs the result, so a single command
+carries three kinds of override. `task=<path>` (or `step=<path>`) selects the
+runnable and composes it *into* the `model` key. `<group>=<option>` selects a
+config group — `spec=specs/identity`, `board=boards/dau/dpv1`,
+`backend=backends/vivado`. And `model.<field>=value` sets a field on the selected
+model. The `model.` prefix is not decoration: because the task is composed into
+the `model` key, its fields are addressed under `model.`.
 
-The flat CLIs (`dau-build`, `dau-build-steps`) take `task=<path> field=value` with
-no prefix — the terse form for driving a single task from a shell or a Makefile.
-The Hydra CLIs (`dau-build-cfg`, `dau-build-cfg-explain`, `dau-build-run`) take
-`task=<path> model.<field>=value` and also accept group selections like
-`spec=specs/identity board=boards/dau/dpv1 backend=backends/vivado`. The `model.`
-prefix is not decoration: on these CLIs the task is composed *into* the `model`
-key, so its fields are addressed under `model.`. Both families converge on the
-same registry execution — the flat form is sugar over the composed form.
-
-`dau-build-run` is the fullest expression of the idea: a Hydra `hydra.main`
-application, so it inherits Hydra's own conventions (`+group=option` to add a
-group, `-m` multirun) and, crucially, the active search path.
+Names are path-style (`tasks/sim/simulate`, `backend=backends/yosys`) because
+they *are* paths into the config tree — the same reason adding a task is adding a
+file. Passing `--explain` composes the overrides without running, printing the
+resolved config so you can see exactly what they produced.
 
 ## ccflow owns ordering and caching
 
@@ -90,7 +88,7 @@ The mechanism is honored by the lerna search-path bridge (`lerna` on PyPI); the
 entry point is inert without it, so a package that relies on cross-package
 composition depends on `lerna` directly. The private `dau` package is the working
 example: it registers `pkg:dau.config`, which adds `task=dpv1-shell`, and with
-`dau` installed `dau-build-run task=dpv1-shell` resolves that task with no
+`dau` installed `dau-build task=dpv1-shell` resolves that task with no
 `--config-dir` overlay. dau-build never imports `dau` — extension flows one way,
 through the search path, which keeps the public tool free of private
 dependencies. See [Extending dau-build](../how-to/extend-dau-build.md) for how to

--- a/docs/how-to/extend-dau-build.md
+++ b/docs/how-to/extend-dau-build.md
@@ -60,14 +60,14 @@ A task is a config file plus the `ccflow.CallableModel` it targets.
    tree, so there is nothing else to register — the `_target_` may point at any
    importable module.
 
-1. Run it through dau-build's Hydra CLI:
+1. Run it through the `dau-build` CLI:
 
    ```bash
-   dau-build-run task=tasks/<category>/<name> model.some_field=value
+   dau-build task=tasks/<category>/<name> model.some_field=value
    ```
 
 The private `dau` package does exactly this to add `task=dpv1-shell`: with `dau`
-installed, `dau-build-run task=dpv1-shell model.shell=... model.output_root=...`
+installed, `dau-build task=dpv1-shell design=designs/bar-noc model.output_root=...`
 resolves a task defined entirely in `dau`, with no `--config-dir` overlay.
 
 ## Add a board or platform
@@ -132,11 +132,11 @@ you extend the packaged set.
 
 ## Try it without packaging
 
-To test a config overlay before packaging it, point the argparse CLI at a
-directory with `--config-dir`:
+To test a config overlay before packaging it, point the CLI at a directory with
+`--config-dir`:
 
 ```bash
-dau-build-cfg --config-dir ./my-configs task=tasks/<category>/<name> model.some_field=value
+dau-build --config-dir ./my-configs task=tasks/<category>/<name> model.some_field=value
 ```
 
 The overlay's groups merge into the tree for that run, and its `_target_` models

--- a/docs/how-to/program-hardware.md
+++ b/docs/how-to/program-hardware.md
@@ -27,11 +27,10 @@ Always look at the sequence first. Omit `execute=true` and the task prints the
 ordered steps without touching the board:
 
 The plan is a config group (`plan=plans/<name>`); its own fields are
-`plan.<field>=` overrides and the shared toolchain fields are `model.<field>=`,
-so use the composing CLI (`dau-build-cfg` or `dau-build-run`):
+`plan.<field>=` overrides and the shared toolchain fields are `model.<field>=`:
 
 ```bash
-dau-build-cfg task=tasks/hardware/hardware-plan \
+dau-build task=tasks/hardware/hardware-plan \
   plan=plans/local-build-and-program \
   plan.source_shell_root=/path/to/vivado-shell-seed \
   plan.dau_core_root=/path/to/dau-core \
@@ -49,7 +48,7 @@ Read the printed steps. When they look right, re-run the same command with
 programs and verifies the device. Add `execute=true` to run it on the host:
 
 ```bash
-dau-build-cfg task=tasks/hardware/hardware-plan \
+dau-build task=tasks/hardware/hardware-plan \
   plan=plans/local-build-and-program \
   plan.source_shell_root=/path/to/vivado-shell-seed \
   plan.dau_core_root=/path/to/dau-core \
@@ -76,7 +75,7 @@ To program a specific bitstream and run the full endpoint-and-smoke check withou
 building anything, use `validate-bitstream`:
 
 ```bash
-dau-build-cfg task=tasks/hardware/hardware-plan \
+dau-build task=tasks/hardware/hardware-plan \
   plan=plans/validate-bitstream \
   plan.dau_core_root=/path/to/dau-core \
   plan.dau_driver_root=/path/to/dau-driver \
@@ -97,7 +96,7 @@ the safe order: hold power management, remove the endpoint via sysfs, program a
 known-good volatile bitstream, then rescan and re-check:
 
 ```bash
-dau-build-cfg task=tasks/hardware/hardware-plan \
+dau-build task=tasks/hardware/hardware-plan \
   plan=plans/recovery \
   model.work_root=outputs/vivado \
   model.execute=true
@@ -113,8 +112,8 @@ To flash and to run a smoke test against a `built` shell-build manifest, use the
 bitstream digest before touching the board):
 
 ```bash
-dau-build task=tasks/flash/flash manifest_path=outputs/vivado/shell-build.artifacts.yaml
-dau-build task=tasks/flash/smoke-test test=identity
+dau-build task=tasks/flash/flash model.manifest_path=outputs/vivado/shell-build.artifacts.yaml
+dau-build task=tasks/flash/smoke-test model.test=identity
 ```
 
 Both require `build_status=built` when given a manifest, and both emit a safe plan

--- a/docs/how-to/run-a-build.md
+++ b/docs/how-to/run-a-build.md
@@ -13,8 +13,8 @@ synthesize task instead (`backend=backends/yosys`; see the
 [task catalog](../reference/tasks-and-steps.md)).
 
 Field lists for each task are in the [task catalog](../reference/tasks-and-steps.md).
-To see the full resolved config for any command before running it, prefix it with
-`dau-build-cfg-explain`.
+To see the full resolved config for any command before running it, add `--explain`
+(e.g. `dau-build --explain task=tasks/build/synthesize ...`).
 
 ## Synthesize the handoff
 
@@ -23,7 +23,7 @@ handoff. This writes a manifest at `build_status=planned` and does **not** invok
 Vivado:
 
 ```bash
-dau-build-cfg task=tasks/build/synthesize \
+dau-build task=tasks/build/synthesize \
   spec=specs/identity \
   model.module=dau_identity_top \
   model.output_root=outputs/identity
@@ -44,19 +44,19 @@ stage/build/validate command contract, use `stage-vivado-project`:
 
 ```bash
 dau-build task=tasks/stage/stage-vivado-project \
-  source_shell_root=/path/to/vivado-shell-seed \
-  work_root=outputs/vivado \
-  dau_core_root=/path/to/dau-core \
-  dau_driver_root=/path/to/dau-driver \
-  artifact_stem=dau-vivado
+  model.source_shell_root=/path/to/vivado-shell-seed \
+  model.work_root=outputs/vivado \
+  model.dau_core_root=/path/to/dau-core \
+  model.dau_driver_root=/path/to/dau-driver \
+  model.artifact_stem=dau-vivado
 ```
 
 If you only need the overlay artifacts, use `tasks/stage/stage-vivado-overlay`
-instead (it requires `work_root` and `dau_core_root`). To fold a DAU artifact
-bundle into the overlay, add `dau_artifact_bundle=<bundle.yaml>`. If your Vivado
-runs through a wrapper that only accepts a Tcl source path, add
-`vivado_invocation=source-only`, and if that wrapper mounts the current directory
-in a container, also add `vivado_mount_root=/path/to/dau`.
+instead (it requires `model.work_root` and `model.dau_core_root`). To fold a DAU
+artifact bundle into the overlay, add `model.dau_artifact_bundle=<bundle.yaml>`. If
+your Vivado runs through a wrapper that only accepts a Tcl source path, add
+`model.vivado_invocation=source-only`, and if that wrapper mounts the current
+directory in a container, also add `model.vivado_mount_root=/path/to/dau`.
 
 ## Validate before you synthesize
 
@@ -66,8 +66,8 @@ Xilinx tools:
 
 ```bash
 dau-build task=tasks/validate/validate-vivado-artifacts \
-  work_root=outputs/vivado \
-  project_manifest_path=dau-vivado.project
+  model.work_root=outputs/vivado \
+  model.project_manifest_path=dau-vivado.project
 ```
 
 Do this on your development machine before moving to the Vivado host. A failure
@@ -81,9 +81,9 @@ so it is gated behind `execute=true`:
 
 ```bash
 dau-build task=tasks/build/build-vivado-artifacts \
-  work_root=outputs/vivado \
-  artifact_stem=dau-vivado \
-  execute=true
+  model.work_root=outputs/vivado \
+  model.artifact_stem=dau-vivado \
+  model.execute=true
 ```
 
 Once the bitstream, resource report, timing report, and Vivado log exist, this

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1,73 +1,78 @@
 # Command reference
 
-`dau-build` installs five console scripts. All of them ultimately run typed
-`ccflow.CallableModel`s composed from the Hydra config tree in
-`dau_build/config`. They differ in how arguments are parsed and which surface of
-the tree they expose.
-
-| Command                 | Entry point                                | Argument style                                 | Purpose                                            |
-| ----------------------- | ------------------------------------------ | ---------------------------------------------- | -------------------------------------------------- |
-| `dau-build`             | `dau_build.build_spec:main`                | flat `task=<path> field=value`                 | Flat task dispatch                                 |
-| `dau-build-steps`       | `dau_build.build_spec:main_callable_steps` | flat `step=<path> field=value`                 | Low-level step dispatch                            |
-| `dau-build-cfg`         | `dau_build.cli:main`                       | `[--config-dir DIR] task=<path> model.<f>=v`   | Compose and run a task through the registry        |
-| `dau-build-cfg-explain` | `dau_build.cli:explain`                    | same as `dau-build-cfg`                        | Print the resolved config; do not run              |
-| `dau-build-run`         | `dau_build.cli:run`                        | Hydra app: `task=<path> group=opt model.<f>=v` | Hydra `hydra.main` app with the search path active |
-
-Task and step names are **path-style**, mirroring the config tree: `task=tasks/sim/simulate`, `step=steps/inspect`. Short names (`task=simulate`) are not accepted. Field overrides carry a `model.` prefix on the Hydra CLIs (`dau-build-cfg`, `dau-build-cfg-explain`, `dau-build-run`) and no prefix on the flat CLIs (`dau-build`, `dau-build-steps`).
-
-The full set of task and step names and their fields is in the [task and step catalog](tasks-and-steps.md). The config groups selectable with `spec=`, `board=`, `backend=`, `platform=` are in the [config group reference](config-groups.md).
-
-## `dau-build`
+`dau-build` installs a single console script (entry point
+`dau_build.cli:main`). It runs typed `ccflow.CallableModel`s composed from the
+Hydra config tree in `dau_build/config`.
 
 ```text
-dau-build task=<path> [field=value ...]
+dau-build [--config-dir DIR] [--explain] <overrides ...>
 ```
 
-Dispatches a task through the registry from the flat surface — equivalent to `dau-build-cfg` without the `model.` prefix on field overrides. Exits non-zero with a usage message if the first argument is not a `key=value` override. For example, the spec operations (inspect, build, and validate a spec or generated bundle):
+| Option / argument | Description                                                                                                        |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--config-dir DIR` | A user config overlay directory. Its groups are merged into the tree (open registration).                        |
+| `--explain`        | Print the fully resolved config as YAML and exit without running.                                                 |
+| overrides          | Hydra overrides — see below.                                                                                       |
+
+## Overrides
+
+Every argument after the options is a Hydra override:
+
+| Form                  | Selects                                                                                          | Example                          |
+| --------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------- |
+| `task=<path>`         | the task to run (populates `model`)                                                             | `task=tasks/sim/simulate`        |
+| `step=<path>`         | a low-level step to run (populates `model`)                                                     | `step=steps/inspect`             |
+| `<group>=<option>`    | a config group option: `spec=`, `board=`, `backend=`, `simulator=`, `design=`, `plan=`, `platform=` | `backend=backends/yosys`         |
+| `model.<field>=value` | a field on the selected task/step model                                                         | `model.output_root=out`          |
+
+Task, step, and group option names are **path-style**, mirroring the config
+tree (`task=tasks/sim/simulate`, `step=steps/inspect`, `backend=backends/yosys`).
+Short names (`task=simulate`) are not accepted.
+
+`dau-build` raises an error if no `task=`/`step=` is selected (nothing populates
+`model`).
+
+The full set of task and step names and their fields is in the
+[task and step catalog](tasks-and-steps.md). The config groups selectable with
+`spec=`, `board=`, `backend=`, `platform=` are in the
+[config group reference](config-groups.md).
+
+## Examples
+
+Inspect, build, and validate a spec or generated bundle:
 
 ```text
-dau-build task=tasks/spec/inspect  spec_path=examples/identity/dau-build.yaml
-dau-build task=tasks/spec/build     spec_path=examples/identity/dau-build.yaml output_root=outputs/identity
-dau-build task=tasks/spec/validate  manifest_path=outputs/identity/dau-identity.manifest root=outputs/identity
+dau-build task=tasks/spec/inspect  model.spec_path=examples/identity/dau-build.yaml
+dau-build task=tasks/spec/build     model.spec_path=examples/identity/dau-build.yaml model.output_root=outputs/identity
+dau-build task=tasks/spec/validate  model.manifest_path=outputs/identity/dau-identity.manifest model.root=outputs/identity
 ```
 
-## `dau-build-steps`
+Select a config group — here the Yosys synthesis backend instead of the default
+Vivado engine:
 
 ```text
-dau-build-steps step=<path> [field=value ...]
+dau-build task=tasks/build/synthesize spec=specs/identity backend=backends/yosys model.output_root=out
 ```
 
-Dispatches a low-level step (see [steps](tasks-and-steps.md)). Fields carry no `model.` prefix. Steps are development/plumbing operations; user-facing workflows use tasks.
-
-## `dau-build-cfg`
+Inspect what a set of overrides composes to, without running:
 
 ```text
-dau-build-cfg [--config-dir DIR] task=<path> [group=option ...] [model.<field>=value ...]
+dau-build --explain task=tasks/build/synthesize spec=specs/identity backend=backends/yosys
 ```
 
-Composes the base config with the given overrides and runs the selected model through ccflow. Prints the model's result message.
-
-| Option         | Description                                                                                                   |
-| -------------- | ------------------------------------------------------------------------------------------------------------- |
-| `--config-dir` | A user config overlay directory. Its groups are merged into the tree (open registration).                     |
-| overrides      | Hydra overrides: group selections (`task=`, `spec=`, `board=`, `backend=`) and field sets (`model.<field>=`). |
-
-Raises an error if no `task=`/`step=` is selected (nothing populates `model`).
-
-## `dau-build-cfg-explain`
+Run a low-level step (development/plumbing; user-facing workflows use tasks):
 
 ```text
-dau-build-cfg-explain [--config-dir DIR] task=<path> [group=option ...] [model.<field>=value ...]
+dau-build step=steps/validate model.spec_path=examples/identity/dau-build.yaml
 ```
 
-Takes the same arguments as `dau-build-cfg` but prints the fully resolved config as YAML and does not run anything. Use it to inspect what a set of overrides composes to.
+## Open registration and cross-package composition
 
-## `dau-build-run`
-
-```text
-dau-build-run task=<path> [group=option ...] [model.<field>=value ...]
-```
-
-A Hydra `hydra.main` application over `dau_build/config` (config name `base`). The Hydra search path is active, so config groups registered by other installed packages compose uniformly alongside the packaged ones. Standard Hydra CLI conventions apply: use `+group=option` to add a group not present in the defaults, and `-m` for multirun.
-
-This is the recommended entry point for cross-package composition. For example, with the private `dau` package installed, `dau-build-run task=dpv1-shell` resolves a task defined in `dau`'s config tree with no `--config-dir` overlay. See [Extending dau-build](../how-to/extend-dau-build.md).
+The Hydra search path is active, so config groups registered by other installed
+packages (through their own `hydra.lernaplugins` entry point) compose uniformly
+alongside the packaged ones — no `--config-dir` overlay needed. For example,
+with the private `dau` package installed, `dau-build task=dpv1-shell
+design=designs/bar-noc` resolves a task defined in `dau`'s config tree. A
+`--config-dir DIR` overlay adds ad-hoc task configs (and new `_target_` models
+from any importable package) the same way. See
+[Extending dau-build](../how-to/extend-dau-build.md).

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -8,13 +8,13 @@ and its default execution mode.
 The complete field set with defaults for any task or step is self-describing:
 
 ```text
-dau-build-cfg-explain task=<path>
-dau-build-cfg-explain step=<path>
+dau-build --explain task=<path>
+dau-build --explain step=<path>
 ```
 
-Fields marked **required** have no default and must be overridden. On the Hydra
-CLIs (`dau-build-cfg`, `dau-build-run`) fields carry a `model.` prefix; on the
-flat CLIs (`dau-build`, `dau-build-steps`) they do not.
+Fields marked **required** have no default and must be overridden. Field
+overrides carry a `model.` prefix (`model.<field>=value`), since the selected
+task or step is composed into the `model` key.
 
 Tasks whose default is **plan** carry `execute: false` and produce plans,
 manifests, and staged files without invoking a vendor toolchain or touching

--- a/docs/tutorial/first-build.md
+++ b/docs/tutorial/first-build.md
@@ -7,17 +7,20 @@ end you will have run every stage of the plan-first build flow and seen what eac
 one produces.
 
 Work from the root of a `dau-build` checkout. Every command here uses the
-`examples/identity` design that ships with the package.
+`examples/identity` design that ships with the package. Each step shows the
+command to type in a shell block, then an **Output** block with what it prints —
+the output lines are tab-separated `label⇥key=value` status lines, so a leading
+word like `dau-build-spec` is a line label the task emits, not a command.
 
 ## Step 1 — Inspect the spec
 
 First, look at what the example declares. Run:
 
 ```bash
-dau-build task=tasks/spec/inspect spec_path=examples/identity/dau-build.yaml
+dau-build task=tasks/spec/inspect model.spec_path=examples/identity/dau-build.yaml
 ```
 
-You should see a summary line followed by the resolved inputs:
+**Output** — a summary line, then the resolved inputs:
 
 ```text
 dau-build-spec	name=identity-pipeline platform=vivado-xdma shell=xdma-ddr modules=identity sources=1 clock=clk reset=reset backend=vivado
@@ -37,10 +40,10 @@ backend — nothing has been generated yet.
 Now generate the build outputs into a fresh directory:
 
 ```bash
-dau-build task=tasks/spec/build spec_path=examples/identity/dau-build.yaml output_root=outputs/identity
+dau-build task=tasks/spec/build model.spec_path=examples/identity/dau-build.yaml model.output_root=outputs/identity
 ```
 
-The command prints the two headline artifacts it wrote:
+**Output** — the two headline artifacts it wrote:
 
 ```text
 dau-build-artifacts	manifest=outputs/identity/dau-identity.manifest top_sv=outputs/identity/generated/dau_identity_top.sv
@@ -51,6 +54,8 @@ Look at what landed in the output directory:
 ```bash
 ls outputs/identity
 ```
+
+**Output:**
 
 ```text
 dau-identity.artifacts.yaml   dau-identity.manifest   generated
@@ -66,14 +71,16 @@ Check that the generated bundle is internally consistent — that every file the
 manifest references exists and every required role is present:
 
 ```bash
-dau-build task=tasks/spec/validate manifest_path=outputs/identity/dau-identity.manifest root=outputs/identity
+dau-build task=tasks/spec/validate model.manifest_path=outputs/identity/dau-identity.manifest model.root=outputs/identity
 ```
+
+**Output:**
 
 ```text
 dau-build-artifacts-valid	manifest=outputs/identity/dau-identity.manifest top_sv=outputs/identity/generated/dau_identity_top.sv
 ```
 
-The `-valid` prefix confirms the bundle passed. If a referenced file were missing,
+The `-valid` label confirms the bundle passed. If a referenced file were missing,
 validation would fail here rather than deep inside a Vivado run later.
 
 ## Step 4 — Run a simulation check
@@ -83,8 +90,10 @@ The default simulator, `svparser`, parses and checks the module without needing
 any external simulator:
 
 ```bash
-dau-build task=tasks/sim/simulate module=dau_identity_top spec_path=examples/identity/dau-build.yaml
+dau-build task=tasks/sim/simulate model.module=dau_identity_top model.spec_path=examples/identity/dau-build.yaml
 ```
+
+**Output:**
 
 ```text
 dau-build-simulate	task=simulate simulator=svparser module=dau_identity_top spec=examples/identity/dau-build.yaml status=validated
@@ -92,15 +101,15 @@ dau-build-simulate	task=simulate simulator=svparser module=dau_identity_top spec
 
 `status=validated` means the module checked out against the build spec. Like the
 previous steps, `task=tasks/sim/simulate` selected a task from the config tree and
-the `module=` and `spec_path=` overrides supplied its fields.
+the `model.module=` and `model.spec_path=` overrides supplied its fields.
 
 ## What you have done
 
 You have run the identity design through the full plan-first flow: **inspect →
 build → validate → simulate**, and seen the artifacts each stage produces — all
 without a board or a vendor toolchain. Every step was the same shape —
-`dau-build task=<path> field=value` — because every dau-build operation is a task
-you select from the config tree and override.
+`dau-build task=<path> model.field=value` — because every dau-build operation is a
+task you select from the config tree and override.
 
 From here:
 
@@ -111,3 +120,5 @@ From here:
   [the architecture explanation](../explanation/architecture.md).
 - For the full set of commands, tasks, and config groups, see the
   [reference](../reference/commands.md).
+```
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 description = "Build tools for dau"
 readme = "README.md"
 license = { text = "Apache-2.0" }
-version = "0.3.0"
+version = "0.4.0"
 requires-python = ">=3.10"
 keywords = []
 
@@ -63,11 +63,7 @@ develop = [
 ]
 
 [project.scripts]
-dau-build = "dau_build.build_spec:main"
-dau-build-steps = "dau_build.build_spec:main_callable_steps"
-dau-build-cfg = "dau_build.cli:main"
-dau-build-cfg-explain = "dau_build.cli:explain"
-dau-build-run = "dau_build.cli:run"
+dau-build = "dau_build.cli:main"
 
 # Register dau-build's config tree on the Hydra search path (via the lerna
 # bridge). Its config groups become discoverable to the CLI and to any other
@@ -82,7 +78,7 @@ Repository = "https://github.com/dau-dev/dau-build"
 Homepage = "https://github.com/dau-dev/dau-build"
 
 [tool.bumpversion]
-current_version = "0.3.0"
+current_version = "0.4.0"
 commit = true
 tag = true
 commit_args = "-s"


### PR DESCRIPTION
Collapses the five dau-build console scripts down to one.

## Why

The surface had grown to five scripts by accretion:

| Script | Verdict |
|---|---|
| `dau-build` (flat `task=X field=value`) | could NOT select config groups — the hydra-first features (`backend=`, `simulator=`, `design=`, `plan=`) were unreachable from it |
| `dau-build-steps` | redundant — `step=` works in the composition CLI |
| `dau-build-cfg` | the real one (hydra compose + run) |
| `dau-build-cfg-explain` | a print variant of the above |
| `dau-build-run` | a second `hydra.main` path over the same tree |

The flat front-end was a trap: you learn `dau-build task=...` then hit a wall when you need `backend=backends/yosys`. One CLI does everything.

## What

`dau-build` now points at `dau_build.cli:main` — the hydra composition CLI:

```
dau-build [--config-dir DIR] [--explain] <overrides>
```

- `task=<path>` / `step=<path>` selects the runnable
- `<group>=<option>` selects a config group (`backend=`, `simulator=`, `design=`, `plan=`, `board=`, `spec=`)
- `model.<field>=value` sets a task/step field
- `--explain` prints the resolved config without running (replaces `dau-build-cfg-explain`)
- `--config-dir` overlays a user config dir

The Hydra search path stays active, so cross-package tasks (e.g. the private `dau` package's `task=dpv1-shell`) still resolve with no overlay — verified.

Removed `build_spec.main` / `main_callable_steps` (flat front-ends) and `cli.run` / `cli.explain`. Field overrides now always carry the `model.` prefix.

## Docs

Updated tutorial / how-to / reference / explanation to the one-CLI syntax. The tutorial now labels each expected-output block (**Output:**) and notes that a status line like `dau-build-spec\t...` is a line label the task prints, not a command — the confusion that prompted this.

## Breaking

Removes four console scripts and the flat no-prefix override form. Minor bump to **0.4.0**. Downstream `dau` consumes `dau_build.cli:main` programmatically (unaffected); its 43 tests pass. dau-build: 224 passed, 1 skipped.