### PR TITLE
Add slang-backed stream+status contract validation

### DIFF
--- a/dau_build/sv_contract.py
+++ b/dau_build/sv_contract.py
@@ -1,0 +1,100 @@
+"""Slang-backed stream+status contract validation.
+
+Every DAU operator tile speaks the same streaming contract (valid/ready row
+stream in and out, ``last`` batch delimiter, a trailing status stream, an
+optional trailing counter). Until now that contract was a naming convention
+enforced by nothing — a drifted port surfaced at Vivado elaboration, deep
+into a build. ``validate_stream_tile`` parses the module's real interface
+with pyslang and reports every violation at test/codegen time instead.
+
+Port names and directions are extracted straight from the syntax tree (no
+dimension evaluation, so parameterized widths — ``$clog2`` localparams,
+ternary expressions — do not block validation)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence
+
+try:
+    from pyslang import SyntaxKind, SyntaxTree
+except ImportError:  # pragma: no cover - version-dependent import layout
+    from pyslang.syntax import SyntaxKind, SyntaxTree
+
+# the stream+status contract: port name -> required direction
+STREAM_TILE_INPUTS = (
+    "clk",
+    "rst",
+    "input_valid",
+    "input_data",
+    "input_last",
+    "output_ready",
+    "status_ready",
+)
+STREAM_TILE_OUTPUTS = (
+    "input_ready",
+    "output_valid",
+    "output_data",
+    "output_last",
+    "status_valid",
+    "status_error",
+    "status_error_code",
+)
+
+
+class StreamContractError(ValueError):
+    """The module does not conform to the stream+status tile contract."""
+
+
+def module_ports(sources: Sequence[Path | str], module: str) -> dict[str, str]:
+    """Parse ``sources`` with pyslang and return ``{port_name: direction}``
+    for ``module``'s ANSI header ports (direction is ``input``/``output``/
+    ``inout``). Raises ``StreamContractError`` if the module is not found."""
+    for source in sources:
+        tree = SyntaxTree.fromFile(str(source))
+        for member in tree.root.members:
+            if member.kind != SyntaxKind.ModuleDeclaration:
+                continue
+            if member.header.name.value != module:
+                continue
+            ports: dict[str, str] = {}
+            port_list = member.header.ports
+            if port_list is None:
+                return ports
+            for port in port_list.ports:
+                if port.kind != SyntaxKind.ImplicitAnsiPort:
+                    continue
+                # valueText strips leading trivia (comments/whitespace)
+                direction = port.header.direction.valueText
+                ports[port.declarator.name.value] = direction
+            return ports
+    raise StreamContractError(f"module {module!r} not found in {[str(s) for s in sources]}")
+
+
+def validate_stream_tile(
+    sources: Sequence[Path | str],
+    module: str,
+    *,
+    count_port: str | None = None,
+) -> list[str]:
+    """Check ``module`` against the stream+status tile contract; return the
+    list of violations (empty means conforming). Fan-out tiles with vectored
+    per-lane ports conform as long as the names and directions match."""
+    ports = module_ports(sources, module)
+    violations: list[str] = []
+    for name in STREAM_TILE_INPUTS:
+        if name not in ports:
+            violations.append(f"missing input port {name!r}")
+        elif ports[name] != "input":
+            violations.append(f"port {name!r} must be an input, is {ports[name]!r}")
+    for name in STREAM_TILE_OUTPUTS:
+        if name not in ports:
+            violations.append(f"missing output port {name!r}")
+        elif ports[name] != "output":
+            violations.append(f"port {name!r} must be an output, is {ports[name]!r}")
+    if count_port is not None:
+        if count_port not in ports:
+            violations.append(f"missing declared count port {count_port!r}")
+        elif ports[count_port] != "output":
+            violations.append(f"count port {count_port!r} must be an output, is {ports[count_port]!r}")
+    return violations

--- a/dau_build/tests/test_sv_contract.py
+++ b/dau_build/tests/test_sv_contract.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dau_build.sv_contract import StreamContractError, module_ports, validate_stream_tile
+
+_CONFORMING = """
+module good_tile (
+    input  wire logic        clk,
+    input  wire logic        rst,
+    input  wire logic [31:0] cfg_thing,
+    input  wire logic        input_valid,
+    output logic             input_ready,
+    input  wire logic [63:0] input_data,
+    input  wire logic        input_last,
+    output logic             output_valid,
+    input  wire logic        output_ready,
+    output logic [63:0]      output_data,
+    output logic             output_last,
+    output logic             status_valid,
+    input  wire logic        status_ready,
+    output logic             status_error,
+    output logic [7:0]       status_error_code,
+    output logic [63:0]      row_count
+);
+endmodule
+"""
+
+_VECTORED = """
+module fanout_tile #(parameter int N = 4) (
+    input  wire logic          clk,
+    input  wire logic          rst,
+    input  wire logic          input_valid,
+    output logic               input_ready,
+    input  wire logic [63:0]   input_data,
+    input  wire logic          input_last,
+    output logic [N-1:0]       output_valid,
+    input  wire logic [N-1:0]  output_ready,
+    output logic [N*64-1:0]    output_data,
+    output logic [N-1:0]       output_last,
+    output logic [N-1:0]       status_valid,
+    input  wire logic [N-1:0]  status_ready,
+    output logic [N-1:0]       status_error,
+    output logic [N*8-1:0]     status_error_code
+);
+endmodule
+"""
+
+_BROKEN = """
+module bad_tile (
+    input  wire logic        clk,
+    input  wire logic        rst,
+    input  wire logic        input_valid,
+    input  wire logic        input_ready,
+    input  wire logic [63:0] input_data,
+    input  wire logic        input_last,
+    output logic             output_valid,
+    input  wire logic        output_ready,
+    output logic [63:0]      output_data,
+    output logic             output_last,
+    output logic             status_valid,
+    input  wire logic        status_ready,
+    output logic             status_error
+);
+endmodule
+"""
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    path = tmp_path / "tile.sv"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_conforming_tile_passes(tmp_path: Path) -> None:
+    source = _write(tmp_path, _CONFORMING)
+    assert validate_stream_tile([source], "good_tile", count_port="row_count") == []
+
+
+def test_vectored_fanout_tile_passes(tmp_path: Path) -> None:
+    # per-lane vectored ports conform: names and directions are the contract
+    source = _write(tmp_path, _VECTORED)
+    assert validate_stream_tile([source], "fanout_tile") == []
+
+
+def test_violations_are_reported_individually(tmp_path: Path) -> None:
+    source = _write(tmp_path, _BROKEN)
+    violations = validate_stream_tile([source], "bad_tile")
+    assert "port 'input_ready' must be an output, is 'input'" in violations
+    assert "missing output port 'status_error_code'" in violations
+
+
+def test_missing_count_port_is_a_violation(tmp_path: Path) -> None:
+    source = _write(tmp_path, _CONFORMING)
+    violations = validate_stream_tile([source], "good_tile", count_port="bar_count")
+    assert violations == ["missing declared count port 'bar_count'"]
+
+
+def test_unknown_module_raises(tmp_path: Path) -> None:
+    source = _write(tmp_path, _CONFORMING)
+    with pytest.raises(StreamContractError, match="not found"):
+        module_ports([source], "nope")


### PR DESCRIPTION
Step 1 of the generator-architecture migration (ROADMAP carry-over debt: *NoC assembly belongs in dau-build via slang*).

`dau_build.sv_contract.validate_stream_tile(sources, module, count_port=...)` parses the module's real ANSI port interface with pyslang and returns every stream+status contract violation — missing ports, wrong directions, missing declared count port — at test/codegen time instead of deep inside a Vivado build. Names+directions come straight from the syntax tree (no dimension evaluation), so parameterized widths don't block validation and vectored fan-out tiles (the range partitioner) conform by name+direction.

Validated against the private core palette: 11/12 operators conform; the 12th (`int32-stream-aggregation`) is genuinely descriptor-driven (Arrow-lite protocol), not drift — its consumer-side conformance test exempts it explicitly.

Discovered en route and filed as roadmap debt: svparser's `Module` dimension evaluator cannot parse modules whose dimensions use localparams, `$clog2`, or SV ternaries (both newest cores fail) — the slang path was never exercised against the real palette, which is exactly the audit's thesis.

Tests: conforming tile, vectored fan-out tile, per-violation reporting, missing count port, unknown module. 229 passed, ruff clean.