### PR TITLE
Extract private driver smoke behind injectable smoke_command

### DIFF
--- a/dau_build/config/plan/plans/local-build-and-program.yaml
+++ b/dau_build/config/plan/plans/local-build-and-program.yaml
@@ -2,9 +2,9 @@
 _target_: dau_build.hardware_plan.LocalBuildAndProgramPlan
 name: local-build-and-program
 dau_core_root: ???
-dau_driver_root: ???
 source_shell_root: null
 dau_utils_root: null
 overlay_tcl: scripts/dau_overlay.tcl
+smoke_command: null
 python: python3
 vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh

--- a/dau_build/config/plan/plans/validate-bitstream.yaml
+++ b/dau_build/config/plan/plans/validate-bitstream.yaml
@@ -1,7 +1,6 @@
 # @package plan
 _target_: dau_build.hardware_plan.ValidateBitstreamPlan
 name: validate-bitstream
-dau_core_root: ???
-dau_driver_root: ???
+smoke_command: null
 dau_utils_root: null
 python: python3

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -2,7 +2,7 @@
 
 _target_: dau_build.build_steps.HardwarePlanTask
 # the plan is the composed plan group; select+configure with
-# plan=plans/local-build-and-program plan.dau_core_root=... plan.dau_driver_root=...
+# plan=plans/local-build-and-program plan.dau_core_root=... plan.smoke_command=...
 plan: ${oc.select:plan,null}
 work_root: ???
 bitstream: null

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -124,10 +124,10 @@ def local_build_and_program_plan(
     config: HardwareToolchainConfig,
     *,
     dau_core_root: Path,
-    dau_driver_root: Path,
     source_shell_root: Path | None = None,
     overlay_tcl: Path = Path("scripts/dau_overlay.tcl"),
     dau_utils_root: Path | None = None,
+    smoke_command: str | None = None,
     python: str = "python3",
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"),
 ) -> tuple[ToolStep, ...]:
@@ -149,7 +149,7 @@ def local_build_and_program_plan(
         program_volatile_step(config),
         pci_rescan_step(),
         lspci_endpoint_step(config),
-        driver_hardware_smoke_step(dau_core_root=dau_core_root, dau_driver_root=dau_driver_root, python=python),
+        *_smoke_steps(smoke_command),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
     )
 
@@ -283,8 +283,7 @@ def stage_shell_plan(
 def validate_bitstream_plan(
     config: HardwareToolchainConfig,
     *,
-    dau_core_root: Path,
-    dau_driver_root: Path,
+    smoke_command: str | None = None,
     dau_utils_root: Path | None = None,
     python: str = "python3",
 ) -> tuple[ToolStep, ...]:
@@ -295,7 +294,7 @@ def validate_bitstream_plan(
         program_volatile_step(config),
         pci_rescan_step(),
         lspci_endpoint_step(config),
-        driver_hardware_smoke_step(dau_core_root=dau_core_root, dau_driver_root=dau_driver_root, python=python),
+        *_smoke_steps(smoke_command),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
     )
 
@@ -447,10 +446,16 @@ def validate_vivado_artifacts_step(
     return ToolStep("validate-vivado-artifacts", tuple(argv))
 
 
-def driver_hardware_smoke_step(*, dau_core_root: Path, dau_driver_root: Path, python: str) -> ToolStep:
-    pythonpath = f"{dau_core_root}:{dau_driver_root}"
-    script = f"PYTHONPATH={shlex.quote(pythonpath)} {shlex.join((python, '-c', _driver_hardware_smoke_code()))}"
-    return ToolStep("driver-hardware-smoke", ("sh", "-c", script))
+def hardware_smoke_step(smoke_command: str) -> ToolStep:
+    """A post-programming smoke check supplied by the caller. dau-build is
+    public and never imports the private DAU packages, so it carries no smoke
+    payload of its own — inject one (e.g. from a private config overlay) via
+    the plan's ``smoke_command`` field."""
+    return ToolStep("driver-hardware-smoke", ("sh", "-c", smoke_command))
+
+
+def _smoke_steps(smoke_command: str | None) -> tuple[ToolStep, ...]:
+    return () if smoke_command is None else (hardware_smoke_step(smoke_command),)
 
 
 def flash_step(config: HardwareToolchainConfig, *, vivado_settings: Path) -> ToolStep:
@@ -511,23 +516,6 @@ def _runtime_pm_argv(config: HardwareToolchainConfig, mode: str) -> tuple[str, .
     for pattern in config.runtime_pm_patterns:
         argv.extend(("--pattern", pattern))
     return tuple(argv)
-
-
-def _driver_hardware_smoke_code() -> str:
-    return "; ".join(
-        (
-            "from pathlib import Path",
-            "from dau_core.registers import DAU_MAGIC_WORD, RegisterOffset",
-            "from dau_driver import discover_devices",
-            "devices = discover_devices(Path('/dev'))",
-            "assert devices, 'expected at least one DAU XDMA device'",
-            "device = devices[0]",
-            "assert device.read_register(RegisterOffset.MAGIC) == DAU_MAGIC_WORD",
-            "snapshot = device.read_register_block_snapshot()",
-            "assert snapshot.platform_id",
-            "print('DAU_SMOKE_OK', device.name, snapshot.platform_id)",
-        )
-    )
 
 
 def _lspci_endpoint_script(config: HardwareToolchainConfig, bridge_bdfs: Sequence[str] = PCI_RESCAN_BDFS) -> str:
@@ -664,16 +652,14 @@ class FlashPlan(HardwarePlan):
 
 class ValidateBitstreamPlan(HardwarePlan):
     name: str = "validate-bitstream"
-    dau_core_root: Path
-    dau_driver_root: Path
+    smoke_command: str | None = None
     dau_utils_root: Path | None = None
     python: str = "python3"
 
     def compose(self, config):
         return validate_bitstream_plan(
             config,
-            dau_core_root=self.dau_core_root,
-            dau_driver_root=self.dau_driver_root,
+            smoke_command=self.smoke_command,
             dau_utils_root=self.dau_utils_root,
             python=self.python,
         )
@@ -682,10 +668,10 @@ class ValidateBitstreamPlan(HardwarePlan):
 class LocalBuildAndProgramPlan(HardwarePlan):
     name: str = "local-build-and-program"
     dau_core_root: Path
-    dau_driver_root: Path
     source_shell_root: Path | None = None
     dau_utils_root: Path | None = None
     overlay_tcl: Path = Path("scripts/dau_overlay.tcl")
+    smoke_command: str | None = None
     python: str = "python3"
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
 
@@ -693,10 +679,10 @@ class LocalBuildAndProgramPlan(HardwarePlan):
         return local_build_and_program_plan(
             config,
             dau_core_root=self.dau_core_root,
-            dau_driver_root=self.dau_driver_root,
             source_shell_root=self.source_shell_root,
             dau_utils_root=self.dau_utils_root,
             overlay_tcl=self.overlay_tcl,
+            smoke_command=self.smoke_command,
             python=self.python,
             vivado_settings=self.vivado_settings,
         )

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -92,6 +92,14 @@ def test_hardware_plan_source_fixtures_do_not_embed_local_hardware_paths() -> No
     assert leaks == []
 
 
+def test_hardware_plan_module_emits_no_private_package_imports() -> None:
+    # dau-build is public: the smoke payload is injected via `smoke_command`,
+    # never hardcoded here as dau_core/dau_driver imports
+    source = Path(hardware_plan.__file__).read_text()
+    for fragment in ("from dau_core", "import dau_core", "from dau_driver", "import dau_driver"):
+        assert fragment not in source
+
+
 def _decode_write_text_step_source(step) -> str:
     tokens = shlex.split(step.argv[2])
     payload = tokens[tokens.index("%s") + 1]
@@ -700,13 +708,13 @@ def test_task_prints_thunderbolt_release_plan() -> None:
     assert lines[0] == "thunderbolt-release\tdau-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
 
 
-def test_local_build_and_program_plan_stages_overlay_programs_and_runs_hardware_smoke() -> None:
+def test_local_build_and_program_plan_stages_overlay_programs_and_runs_injected_smoke() -> None:
     config = HardwareToolchainConfig(work_root=Path("/repo/projects/vivado-shell"), vivado_executable="vivado")
 
     steps = local_build_and_program_plan(
         config,
         dau_core_root=Path("/repo/dau-core"),
-        dau_driver_root=Path("/repo/dau-driver"),
+        smoke_command="dau-smoke",
     )
 
     assert [step.name for step in steps] == [
@@ -734,10 +742,26 @@ def test_local_build_and_program_plan_stages_overlay_programs_and_runs_hardware_
     assert "scripts/build.tcl" not in steps[3].argv[2]
     assert EXPECTED_PCI_RESCAN_SCRIPT in steps[7].argv[2]
     assert EXPECTED_LSPCI_ENDPOINT_SNIPPET in steps[8].argv[2]
-    assert steps[9].argv[0] == "sh"
-    assert "PYTHONPATH=/repo/dau-core:/repo/dau-driver python3 -c" in steps[9].argv[2]
-    assert "discover_devices" in steps[9].argv[2]
-    assert "DAU_MAGIC_WORD" in steps[9].argv[2]
+    assert steps[9].argv == ("sh", "-c", "dau-smoke")
+
+
+def test_local_build_and_program_plan_omits_smoke_step_without_a_command() -> None:
+    config = HardwareToolchainConfig(work_root=Path("/repo/projects/vivado-shell"), vivado_executable="vivado")
+
+    steps = local_build_and_program_plan(config, dau_core_root=Path("/repo/dau-core"))
+
+    assert [step.name for step in steps] == [
+        "thunderbolt-hold",
+        "write-dau-overlay",
+        "write-vivado-build-script",
+        "vivado-overlay-build",
+        "jtag-detect",
+        "remove-endpoint",
+        "program-volatile",
+        "pci-rescan",
+        "lspci-endpoint",
+        "thunderbolt-release",
+    ]
 
 
 def test_local_build_and_program_plan_can_stage_shell_seed_before_overlay() -> None:
@@ -747,7 +771,6 @@ def test_local_build_and_program_plan_can_stage_shell_seed_before_overlay() -> N
         config,
         source_shell_root=Path("/repo/reference/vivado-shell"),
         dau_core_root=Path("/repo/dau-core"),
-        dau_driver_root=Path("/repo/dau-driver"),
     )
 
     assert [step.name for step in steps][0:5] == [
@@ -770,11 +793,7 @@ def test_validate_bitstream_plan_programs_existing_bitstream_without_vivado() ->
         vivado_executable="vivado",
     )
 
-    steps = validate_bitstream_plan(
-        config,
-        dau_core_root=Path("/repo/dau-core"),
-        dau_driver_root=Path("/repo/dau-driver"),
-    )
+    steps = validate_bitstream_plan(config, smoke_command="dau-smoke")
 
     assert [step.name for step in steps] == [
         "thunderbolt-hold",
@@ -787,9 +806,26 @@ def test_validate_bitstream_plan_programs_existing_bitstream_without_vivado() ->
         "thunderbolt-release",
     ]
     assert steps[3].argv == ("openFPGALoader", "-c", "digilent_hs2", "/repo/projects/vivado-shell/artifacts/candidate.bit")
+    assert steps[6].argv == ("sh", "-c", "dau-smoke")
     assert all(step.name != "vivado-overlay-build" for step in steps)
     assert all(step.argv[0] != "vivado" for step in steps)
     assert all("dau_overlay" not in step.command_line for step in steps)
+
+
+def test_validate_bitstream_plan_omits_smoke_step_without_a_command() -> None:
+    config = HardwareToolchainConfig(work_root=Path("/repo/projects/vivado-shell"))
+
+    steps = validate_bitstream_plan(config)
+
+    assert [step.name for step in steps] == [
+        "thunderbolt-hold",
+        "jtag-detect",
+        "remove-endpoint",
+        "program-volatile",
+        "pci-rescan",
+        "lspci-endpoint",
+        "thunderbolt-release",
+    ]
 
 
 def test_stage_vivado_overlay_plan_writes_backend_artifacts_without_running_vivado() -> None:
@@ -959,13 +995,12 @@ def test_task_local_build_can_stage_shell_before_overlay() -> None:
         plan_fields=[
             "plan.source_shell_root=/repo/reference/vivado-shell",
             "plan.dau_core_root=/repo/dau-core",
-            "plan.dau_driver_root=/repo/dau-driver",
         ],
         work_root="/repo/dau-build/outputs/vivado",
     )
 
     lines = result.message.splitlines()
-    assert len(lines) == 12
+    assert len(lines) == 11
     assert lines[0].startswith("stage-shell\tsh -c ")
     assert lines[2].startswith("write-dau-overlay\tsh -c ")
     assert lines[3].startswith("write-vivado-build-script\tsh -c ")
@@ -974,7 +1009,7 @@ def test_task_local_build_can_stage_shell_before_overlay() -> None:
 def test_task_prints_local_build_and_program_plan() -> None:
     result = _run_plan(
         "local-build-and-program",
-        plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.dau_driver_root=/repo/dau-driver"],
+        plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.smoke_command=dau-smoke"],
         work_root="/repo/projects/vivado-shell",
     )
 
@@ -984,14 +1019,14 @@ def test_task_prints_local_build_and_program_plan() -> None:
     assert lines[1].startswith("write-dau-overlay\tsh -c ")
     assert lines[2].startswith("write-vivado-build-script\tsh -c ")
     assert lines[3].startswith("vivado-overlay-build\tbash -lc ")
-    assert lines[9].startswith("driver-hardware-smoke\tsh -c ")
+    assert lines[9] == "driver-hardware-smoke\tsh -c dau-smoke"
     assert lines[10].startswith("thunderbolt-release\tdau-pci-runtime-pm release ")
 
 
 def test_task_prints_validate_bitstream_plan_without_vivado() -> None:
     result = _run_plan(
         "validate-bitstream",
-        plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.dau_driver_root=/repo/dau-driver"],
+        plan_fields=["plan.smoke_command=dau-smoke"],
         work_root="/repo/projects/vivado-shell",
         bitstream="/tmp/candidate.bit",
     )
@@ -1000,7 +1035,7 @@ def test_task_prints_validate_bitstream_plan_without_vivado() -> None:
     assert len(lines) == 8
     assert lines[0].startswith("thunderbolt-hold\tdau-pci-runtime-pm hold ")
     assert lines[3] == "program-volatile\topenFPGALoader -c digilent_hs2 /tmp/candidate.bit"
-    assert lines[6].startswith("driver-hardware-smoke\tsh -c ")
+    assert lines[6] == "driver-hardware-smoke\tsh -c dau-smoke"
     assert lines[7].startswith("thunderbolt-release\tdau-pci-runtime-pm release ")
     assert all("vivado" not in line.lower() for line in lines)
 
@@ -1052,7 +1087,7 @@ def test_cli_execute_releases_runtime_pm_after_failed_local_plan_step(monkeypatc
     with pytest.raises(BuildStepError, match="exit code 23"):
         _run_plan(
             "local-build-and-program",
-            plan_fields=["plan.dau_core_root=/repo/dau-core", "plan.dau_driver_root=/repo/dau-driver"],
+            plan_fields=["plan.dau_core_root=/repo/dau-core"],
             work_root="/repo/projects/vivado-shell",
             execute=True,
         )

--- a/docs/how-to/program-hardware.md
+++ b/docs/how-to/program-hardware.md
@@ -6,8 +6,8 @@ covers the three situations you hit most: programming a fresh build, validating
 an already-built bitstream, and recovering a device that a bad image has wedged.
 
 `hardware-plan` composes an ordered sequence of hardware-session steps — JTAG
-detect, endpoint remove, program, PCIe rescan, endpoint check, driver smoke — and
-runs them in the order the board actually needs. Like the build tasks it is
+detect, endpoint remove, program, PCIe rescan, endpoint check, optional injected
+smoke command — and runs them in the order the board actually needs. Like the build tasks it is
 plan-first: without `execute=true` it prints the plan; with it, it runs on the
 host. Run these on the machine physically attached to the board.
 
@@ -34,7 +34,6 @@ dau-build task=tasks/hardware/hardware-plan \
   plan=plans/local-build-and-program \
   plan.source_shell_root=/path/to/vivado-shell-seed \
   plan.dau_core_root=/path/to/dau-core \
-  plan.dau_driver_root=/path/to/dau-driver \
   plan.dau_utils_root=/path/to/dau-utils \
   model.work_root=outputs/vivado
 ```
@@ -52,7 +51,6 @@ dau-build task=tasks/hardware/hardware-plan \
   plan=plans/local-build-and-program \
   plan.source_shell_root=/path/to/vivado-shell-seed \
   plan.dau_core_root=/path/to/dau-core \
-  plan.dau_driver_root=/path/to/dau-driver \
   plan.dau_utils_root=/path/to/dau-utils \
   model.work_root=outputs/vivado \
   model.execute=true
@@ -61,9 +59,15 @@ dau-build task=tasks/hardware/hardware-plan \
 The plan holds runtime power management, writes the overlay/build Tcl, runs the
 Vivado build, detects the JTAG chain, removes the stale endpoint, programs the
 volatile bitstream, performs the ordered bridge-then-global PCIe rescan, retries
-the endpoint check, runs the dependency-free driver smoke (which asserts the DAU
-magic register and prints `DAU_SMOKE_OK`), and finally releases power management.
-If any step fails, the release step still runs.
+the endpoint check, runs the injected smoke command (if one is configured), and
+finally releases power management. If any step fails, the release step still
+runs.
+
+The smoke step is injectable: `plan.smoke_command=<command>` runs after the
+endpoint check, and the plan omits the step when no command is configured.
+dau-build itself ships no smoke payload — the DAU driver smoke (which asserts
+the DAU magic register and prints `DAU_SMOKE_OK`) is injected by the private
+`dau` package's config overlay.
 
 If you already have a bitstream and only want to program it, use
 `plan=plans/build-and-program` with `model.bitstream=<path>` instead — it skips
@@ -77,8 +81,6 @@ building anything, use `validate-bitstream`:
 ```bash
 dau-build task=tasks/hardware/hardware-plan \
   plan=plans/validate-bitstream \
-  plan.dau_core_root=/path/to/dau-core \
-  plan.dau_driver_root=/path/to/dau-driver \
   plan.dau_utils_root=/path/to/dau-utils \
   model.work_root=outputs/vivado \
   model.bitstream=/path/to/Top_wrapper.bit \

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -179,8 +179,8 @@ pydantic enforces them, rather than a runtime check).
 | Option                          | Model                      | Extra fields                                                                                                                |
 | ------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `plans/build-and-program`       | `BuildAndProgramPlan`      | —                                                                                                                           |
-| `plans/local-build-and-program` | `LocalBuildAndProgramPlan` | `dau_core_root`, `dau_driver_root` (req), `source_shell_root`, `dau_utils_root`, `overlay_tcl`, `python`, `vivado_settings` |
-| `plans/validate-bitstream`      | `ValidateBitstreamPlan`    | `dau_core_root`, `dau_driver_root` (req), `dau_utils_root`, `python`                                                        |
+| `plans/local-build-and-program` | `LocalBuildAndProgramPlan` | `dau_core_root` (req), `source_shell_root`, `dau_utils_root`, `overlay_tcl`, `smoke_command`, `python`, `vivado_settings`   |
+| `plans/validate-bitstream`      | `ValidateBitstreamPlan`    | `smoke_command`, `dau_utils_root`, `python`                                                                                 |
 | `plans/flash`                   | `FlashPlan`                | `dau_utils_root`, `python`, `vivado_settings`                                                                               |
 | `plans/recovery`                | `RecoveryPlan`             | —                                                                                                                           |
 | `plans/thunderbolt-hold`        | `ThunderboltHoldPlan`      | —                                                                                                                           |


### PR DESCRIPTION
## What

Removes the last private-package runtime hook from public dau-build (ROADMAP course-correction V2, P1): the hardware plans' smoke step hardcoded `dau_core.registers` + `dau_driver` imports behind `PYTHONPATH={dau_core_root}:{dau_driver_root}`.

- `validate_bitstream_plan` / `local_build_and_program_plan` (and their plan models + packaged yamls) take a generic `smoke_command` field instead of `dau_core_root`/`dau_driver_root` smoke roots; when no command is configured the smoke step is omitted.
- `local-build-and-program` keeps `dau_core_root` — it stages `dau_core/hdl` into the Vivado overlay, a path input, not an emitted import.
- `stage-vivado-project`'s `dau_driver_root` is untouched: it is recorded in the project manifest as a checkout-root path input.
- New guard test pins the policy: `dau_build/hardware_plan.py` may not contain `dau_core`/`dau_driver` import fragments.
- Docs updated (program-hardware how-to, plan config-group table).

The DAU-specific driver smoke payload moves to the private `dau` package's config overlay, which injects it as `plan.smoke_command`.

## Plan-text changes (deliberate)

- Injected smoke commands produce byte-identical plan text to the old hardcoded step (same `driver-hardware-smoke` step name, same `sh -c` wrapper).
- Plans composed without a smoke command drop the `driver-hardware-smoke` line entirely.

## Verification

- Full suite: 232 passed, 1 skipped.
- Wall proof: in a venv with only `pip install -e dau-build` (no dau-core/dau-driver), `import dau_build.hardware_plan` and all 42 hardware-plan tests pass.
- ruff check + format clean.
