### PR TITLE
Close flash provenance, runtime-PM CLI, and invocation validation gaps

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -600,7 +600,16 @@ class FlashTask(BuildCallableModel):
             else:
                 manifest = _read_key_value_manifest(self.manifest_path)
                 _require_built_manifest(self.manifest_path, manifest)
-                bitstream = bitstream or _manifest_path(self.manifest_path.parent, manifest, "bitstream")
+                # a key=value backend manifest carries no digests: flash
+                # provenance comes from the packaged artlink manifest the
+                # validate step writes beside it (digest-verified below)
+                packaged = self.manifest_path.with_suffix(".artifacts.yaml")
+                if not packaged.is_file():
+                    raise BuildStepError(
+                        f"backend manifest has no packaged artlink manifest: {packaged.as_posix()}; "
+                        "run the validate step (execute=True) to package digested provenance before flashing"
+                    )
+                bitstream = bitstream or _bitstream_from_shell_build_manifest(packaged)
             manifest_segment = f" manifest={self.manifest_path}"
         if bitstream is None:
             raise BuildStepError("flash requires bitstream or manifest_path")

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Literal
 
 from ccflow import BaseModel
 
@@ -67,10 +68,11 @@ class HardwareToolchainConfig(BaseModel):
     work_root: Path
     bitstream_path: Path | None = None
     vivado_executable: str = "vivado"
-    vivado_invocation: str = "standard"
+    vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
     openfpgaloader_executable: str = "openFPGALoader"
-    runtime_pm_executable: str = "dau-pci-runtime-pm"
+    # the console script dau-utils actually installs (dau_utils.pci_runtime_pm)
+    runtime_pm_executable: str = "dau-utils-pci-runtime-pm"
     runtime_pm_patterns: tuple[str, ...] = ("Thunderbolt", "JHL", DPV1_PCI_ID, "Xilinx")
     jtag_cable: str = "digilent_hs2"
     endpoint_bdf: str = "0000:04:00.0"

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -197,6 +197,43 @@ def test_execute_override_task_plans_openfpgaloader_flash(tmp_path: Path) -> Non
     )
 
 
+def _write_minimal_built_backend_manifest(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "Top_wrapper.bit").write_bytes(b"bit")
+    for name in ("dau_utilization.rpt", "dau_timing_summary.rpt", "vivado.log"):
+        (root / name).write_text("built\n", encoding="utf-8")
+    manifest_path = root / "dau-vivado.manifest"
+    manifest_path.write_text(
+        "bitstream=Top_wrapper.bit\n"
+        "resource_summary=dau_utilization.rpt\n"
+        "timing_summary=dau_timing_summary.rpt\n"
+        "vivado_log=vivado.log\n"
+        "build_status=built\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def test_flash_refuses_backend_manifest_without_packaged_provenance(tmp_path: Path) -> None:
+    # a key=value backend manifest alone carries no digests: flash must
+    # demand the packaged artlink manifest the validate step writes
+    manifest_path = _write_minimal_built_backend_manifest(tmp_path)
+
+    with pytest.raises(BuildStepError, match="no packaged artlink manifest"):
+        execute_override_task(("task=tasks/flash/flash", f"manifest_path={manifest_path}"))
+
+
+def test_flash_refuses_backend_manifest_bitstream_digest_mismatch(tmp_path: Path) -> None:
+    from dau_build.shell_build import write_overlay_build_manifest
+
+    manifest_path = _write_minimal_built_backend_manifest(tmp_path)
+    write_overlay_build_manifest(tmp_path, manifest_path, name="dau-vivado")
+    (tmp_path / "Top_wrapper.bit").write_bytes(b"replaced-after-build")
+
+    with pytest.raises(BuildStepError, match="digest mismatch"):
+        execute_override_task(("task=tasks/flash/flash", f"manifest_path={manifest_path}"))
+
+
 def test_execute_override_task_plans_identity_smoke_test() -> None:
     result = execute_override_task(("task=tasks/flash/smoke-test", "test=identity"))
 
@@ -217,7 +254,7 @@ def test_hardware_plan_task_via_plan_group() -> None:
 
     assert result == BuildStepResult(
         step="hardware-plan",
-        message="thunderbolt-release\tdau-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx",
+        message="thunderbolt-release\tdau-utils-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx",
     )
 
 
@@ -391,7 +428,7 @@ def test_dau_build_cfg_dispatches_hardware_plan_via_group(capsys) -> None:
 
     assert exit_code == 0
     assert capsys.readouterr().out.splitlines() == [
-        "thunderbolt-release\tdau-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
+        "thunderbolt-release\tdau-utils-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
     ]
 
 
@@ -481,6 +518,11 @@ def _write_built_backend_outputs(build_root: Path, manifest_path: Path) -> Path:
         manifest_path.read_text(encoding="utf-8").replace("build_status=planned", "build_status=built"),
         encoding="utf-8",
     )
+    # mirror the validate step: package the digested artlink manifest beside
+    # the key=value handoff (flash provenance consumes the packaged form)
+    from dau_build.shell_build import write_overlay_build_manifest
+
+    write_overlay_build_manifest(build_root, manifest_path, name="dau-vivado")
     return paths["bitstream"]
 
 

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -705,7 +705,9 @@ def test_task_prints_thunderbolt_release_plan() -> None:
 
     lines = result.message.splitlines()
     assert len(lines) == 1
-    assert lines[0] == "thunderbolt-release\tdau-utils-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
+    assert (
+        lines[0] == "thunderbolt-release\tdau-utils-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
+    )
 
 
 def test_local_build_and_program_plan_stages_overlay_programs_and_runs_injected_smoke() -> None:

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -636,7 +636,7 @@ def test_build_and_program_plan_names_vivado_jtag_and_pcie_steps() -> None:
         "lspci-endpoint",
     ]
     assert steps[0].argv == (
-        "dau-pci-runtime-pm",
+        "dau-utils-pci-runtime-pm",
         "hold",
         "--pattern",
         "Thunderbolt",
@@ -660,7 +660,7 @@ def test_thunderbolt_power_plans_hold_and_release_runtime_pm() -> None:
 
     assert hold_step.name == "thunderbolt-hold"
     assert hold_step.argv == (
-        "dau-pci-runtime-pm",
+        "dau-utils-pci-runtime-pm",
         "hold",
         "--pattern",
         "Thunderbolt",
@@ -673,7 +673,7 @@ def test_thunderbolt_power_plans_hold_and_release_runtime_pm() -> None:
     )
     assert release_step.name == "thunderbolt-release"
     assert release_step.argv == (
-        "dau-pci-runtime-pm",
+        "dau-utils-pci-runtime-pm",
         "release",
         "--pattern",
         "Thunderbolt",
@@ -690,7 +690,7 @@ def test_task_prints_recovery_plan_without_running_privileged_commands() -> None
     result = _run_plan("recovery", work_root="/repo/projects/vivado-shell")
 
     lines = result.message.splitlines()
-    assert lines[0] == "thunderbolt-hold\tdau-pci-runtime-pm hold --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
+    assert lines[0] == "thunderbolt-hold\tdau-utils-pci-runtime-pm hold --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
     assert lines[1:4] == [
         "remove-endpoint\tsh -c 'test ! -e /sys/bus/pci/devices/0000:04:00.0/remove || echo 1 > /sys/bus/pci/devices/0000:04:00.0/remove'",
         "program-volatile\topenFPGALoader -c digilent_hs2 /repo/projects/vivado-shell/project.runs/impl_1/Top_wrapper.bit",
@@ -705,7 +705,7 @@ def test_task_prints_thunderbolt_release_plan() -> None:
 
     lines = result.message.splitlines()
     assert len(lines) == 1
-    assert lines[0] == "thunderbolt-release\tdau-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
+    assert lines[0] == "thunderbolt-release\tdau-utils-pci-runtime-pm release --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
 
 
 def test_local_build_and_program_plan_stages_overlay_programs_and_runs_injected_smoke() -> None:
@@ -1015,12 +1015,12 @@ def test_task_prints_local_build_and_program_plan() -> None:
 
     lines = result.message.splitlines()
     assert len(lines) == 11
-    assert lines[0].startswith("thunderbolt-hold\tdau-pci-runtime-pm hold ")
+    assert lines[0].startswith("thunderbolt-hold\tdau-utils-pci-runtime-pm hold ")
     assert lines[1].startswith("write-dau-overlay\tsh -c ")
     assert lines[2].startswith("write-vivado-build-script\tsh -c ")
     assert lines[3].startswith("vivado-overlay-build\tbash -lc ")
     assert lines[9] == "driver-hardware-smoke\tsh -c dau-smoke"
-    assert lines[10].startswith("thunderbolt-release\tdau-pci-runtime-pm release ")
+    assert lines[10].startswith("thunderbolt-release\tdau-utils-pci-runtime-pm release ")
 
 
 def test_task_prints_validate_bitstream_plan_without_vivado() -> None:
@@ -1033,10 +1033,10 @@ def test_task_prints_validate_bitstream_plan_without_vivado() -> None:
 
     lines = result.message.splitlines()
     assert len(lines) == 8
-    assert lines[0].startswith("thunderbolt-hold\tdau-pci-runtime-pm hold ")
+    assert lines[0].startswith("thunderbolt-hold\tdau-utils-pci-runtime-pm hold ")
     assert lines[3] == "program-volatile\topenFPGALoader -c digilent_hs2 /tmp/candidate.bit"
     assert lines[6] == "driver-hardware-smoke\tsh -c dau-smoke"
-    assert lines[7].startswith("thunderbolt-release\tdau-pci-runtime-pm release ")
+    assert lines[7].startswith("thunderbolt-release\tdau-utils-pci-runtime-pm release ")
     assert all("vivado" not in line.lower() for line in lines)
 
 
@@ -1056,7 +1056,7 @@ def test_task_execute_runs_plan_steps_in_order(monkeypatch) -> None:
 
     assert calls == [
         (
-            "dau-pci-runtime-pm",
+            "dau-utils-pci-runtime-pm",
             "release",
             "--pattern",
             "Thunderbolt",
@@ -1157,3 +1157,24 @@ def test_dau_overlay_tcl_ties_off_upgraded_quad_spi_ss_input() -> None:
     assert "CONFIG.CONST_WIDTH {1} CONFIG.CONST_VAL {0}" in source
     assert "connect_bd_net -net dau_spi_ss_i_tieoff_dout" in source
     assert 'puts $manifest_file "spi_ss_i_tieoff=dau_spi_ss_i_tieoff"' in source
+
+
+def test_vivado_invocation_is_validated_at_model_construction(tmp_path: Path) -> None:
+    # config models are pydantic: an unsupported invocation must fail at
+    # construction, not survive into manifests/command plans
+    import pydantic
+
+    from dau_build.vivado_backend import VivadoProjectGenerationRequest
+
+    with pytest.raises(pydantic.ValidationError):
+        HardwareToolchainConfig(work_root=tmp_path, vivado_invocation="bogus")
+    with pytest.raises(pydantic.ValidationError):
+        VivadoBackendRequest(dau_core_hdl_root=tmp_path, build_root=tmp_path, vivado_invocation="bogus")
+    with pytest.raises(pydantic.ValidationError):
+        VivadoProjectGenerationRequest(
+            source_shell_root=tmp_path,
+            work_root=tmp_path,
+            dau_core_root=tmp_path,
+            dau_driver_root=tmp_path,
+            vivado_invocation="bogus",
+        )

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import os
 import shlex
 from pathlib import Path
+from typing import Literal
 
 from ccflow import BaseModel
 
 from dau_build.artifact_bundle import ArtifactBundle, ArtifactBundleError, load_artifact_bundle
-
-SUPPORTED_VIVADO_INVOCATIONS = frozenset(("standard", "source-only"))
 
 
 class VivadoBackendRequest(BaseModel):
@@ -32,12 +31,8 @@ class VivadoBackendRequest(BaseModel):
     vivado_log_path: Path = Path("vivado.log")
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
     vivado_executable: str = "vivado"
-    vivado_invocation: str = "standard"
+    vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
-
-    def __post_init__(self) -> None:
-        if self.vivado_invocation not in SUPPORTED_VIVADO_INVOCATIONS:
-            raise ValueError(f"unsupported Vivado invocation: {self.vivado_invocation}")
 
     @property
     def resolved_manifest_path(self) -> Path:
@@ -92,13 +87,9 @@ class VivadoProjectGenerationRequest(BaseModel):
     xdma_module_path: Path = Path("sw/xdma/xdma.ko")
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
     vivado_executable: str = "vivado"
-    vivado_invocation: str = "standard"
+    vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
     plan_executable: str = "dau-build"
-
-    def __post_init__(self) -> None:
-        if self.vivado_invocation not in SUPPORTED_VIVADO_INVOCATIONS:
-            raise ValueError(f"unsupported Vivado invocation: {self.vivado_invocation}")
 
     @property
     def dau_core_hdl_root(self) -> Path:


### PR DESCRIPTION
Three fixes from the second standards audit pass:

- **Flash provenance (P1)**: `task=tasks/flash/flash manifest_path=<backend.manifest>` previously planned a flash from a key=value backend manifest with only a `build_status=built` + file-existence check — no digest. Flash now requires the packaged artlink manifest (`*.artifacts.yaml`, written by the validate step) beside the key=value handoff and digest-verifies the bitstream through it. New tests: missing packaged manifest refused, digest mismatch refused.
- **Runtime-PM CLI (P1)**: `HardwareToolchainConfig.runtime_pm_executable` defaulted to `dau-pci-runtime-pm`, a console script `dau-utils` never installed (it installs `dau-utils-pci-runtime-pm`). An installed public workflow would fail before the safety hold. Default and pinned plan texts updated.
- **Invocation validation (P2)**: `VivadoBackendRequest`, `VivadoProjectGenerationRequest`, and `HardwareToolchainConfig` validated `vivado_invocation` in `__post_init__`, which pydantic models never call — `vivado_invocation="bogus"` survived construction. Now a `Literal["standard", "source-only"]` field (matching `ValidateVivadoArtifactsTask`), dead hooks removed, negative test added.

Suite: 257 passed, 1 skipped.