### PR TITLE
Price against placeable dpv1 capacity and require digested flash provenance

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -573,12 +573,15 @@ def _bitstream_from_shell_build_manifest(manifest_path: Path) -> Path:
     bitstream_path = bitstream.path if bitstream.path.is_absolute() else manifest_path.parent / bitstream.path
     if not bitstream_path.is_file():
         raise BuildStepError(f"bitstream does not exist: {bitstream_path.as_posix()}")
-    if bitstream.digest is not None:
-        actual = hashlib.new(bitstream.digest.algorithm, bitstream_path.read_bytes()).hexdigest()
-        if actual != bitstream.digest.value:
-            raise BuildStepError(
-                f"bitstream digest mismatch (manifest {bitstream.digest.value[:12]}..., file {actual[:12]}...): {bitstream_path.as_posix()}"
-            )
+    if bitstream.digest is None:
+        # digest is optional in the artlink model, but flash provenance is
+        # the digest: a manifest without one proves nothing about the file
+        raise BuildStepError(f"bitstream artifact carries no digest: {manifest_path.as_posix()}; flash requires digested provenance")
+    actual = hashlib.new(bitstream.digest.algorithm, bitstream_path.read_bytes()).hexdigest()
+    if actual != bitstream.digest.value:
+        raise BuildStepError(
+            f"bitstream digest mismatch (manifest {bitstream.digest.value[:12]}..., file {actual[:12]}...): {bitstream_path.as_posix()}"
+        )
     return bitstream_path
 
 

--- a/dau_build/config/platform/platforms/dau/dpv1.yaml
+++ b/dau_build/config/platform/platforms/dau/dpv1.yaml
@@ -10,11 +10,19 @@ _target_: dau_build.platforms.PlatformDefinition
 name: dpv1
 part: xc7a200tfbg484-2
 program_method: jtag
+# Placeable *datapath* capacity, not raw part capacity. Vivado reports
+# 133800 LUT / 267600 FF available on xc7a200tfbg484-2 (not the 134600 /
+# 269200 slice-math numbers), and the shell infrastructure a composition
+# never prices (XDMA + MIG DDR3 + interconnect) measures 21596 LUT /
+# 23905 FF / 29.5 BRAM36 / 0 DSP placed on the proven bring-up build
+# (~24.7K LUT derived on bar-noc). Budget = available minus a
+# 25K LUT / 25K FF / 30 BRAM36 shell reservation, so fits() checks what a
+# composition datapath may actually place.
 budget:
   _target_: dau_build.platforms.ResourceBudget
-  lut: 134600
-  ff: 269200
-  bram36: 365
+  lut: 108800
+  ff: 242600
+  bram36: 335
   dsp: 740
 memory:
   _target_: dau_build.platforms.PlatformMemory

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -234,6 +234,24 @@ def test_flash_refuses_backend_manifest_bitstream_digest_mismatch(tmp_path: Path
         execute_override_task(("task=tasks/flash/flash", f"manifest_path={manifest_path}"))
 
 
+def test_flash_refuses_packaged_manifest_without_bitstream_digest(tmp_path: Path) -> None:
+    # digest is optional in the artlink model: a packaged manifest whose
+    # bitstream artifact carries none must be refused, not silently trusted
+    import yaml
+
+    from dau_build.shell_build import write_overlay_build_manifest
+
+    manifest_path = _write_minimal_built_backend_manifest(tmp_path)
+    packaged = write_overlay_build_manifest(tmp_path, manifest_path, name="dau-vivado")
+    data = yaml.safe_load(packaged.read_text(encoding="utf-8"))
+    for artifact in data["artifacts"]:
+        artifact.pop("digest", None)
+    packaged.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(BuildStepError, match="no digest"):
+        execute_override_task(("task=tasks/flash/flash", f"manifest_path={manifest_path}"))
+
+
 def test_execute_override_task_plans_identity_smoke_test() -> None:
     result = execute_override_task(("task=tasks/flash/smoke-test", "test=identity"))
 

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -75,7 +75,7 @@ def test_fits_under_and_over_budget() -> None:
     platform = dpv1_platform()
     report = fits(_Use(lut=2000, ff=1500, bram36=4.0, dsp=8), platform)
     assert report.fits
-    assert report.headroom["lut"] == 134600 - 2000
+    assert report.headroom["lut"] == 108800 - 2000
     assert report.utilization["dsp"] == pytest.approx(8 / 740)
 
     over = fits(_Use(lut=200000, ff=1500, bram36=4.0, dsp=8), platform)


### PR DESCRIPTION
Two follow-ups from a post-merge audit of #112 and dau#35:

**dpv1 budget is now placeable datapath capacity.** The `ResourceBudget` carried raw slice-math part totals (134600 LUT / 269200 FF); Vivado reports 133800 / 267600 available on xc7a200tfbg484-2, and the shell infrastructure a composition never prices (XDMA + MIG DDR3 + interconnect) measures 21596 LUT / 23905 FF / 29.5 BRAM36 placed on the proven bring-up build (~24.7K LUT derived on bar-noc). The budget is now available capacity minus a 25K LUT / 25K FF / 30 BRAM36 shell reservation, so `Dpv1ShellTask` pricing (dau#35) gates against what a composition may actually place instead of passing near-limit designs that fail in Vivado. bar-noc prices at 6076 LUT (5.6% of the new budget) and still passes with room.

**Flash refuses digestless bitstream artifacts.** artlink's `Artifact.digest` is optional, so a packaged manifest whose bitstream artifact carried no digest passed the #112 provenance gate without any verification. `_bitstream_from_shell_build_manifest` now requires the digest; `write_overlay_build_manifest` always writes one, so no legitimate path changes.

Verified: 258 passed, 1 skipped (baseline 257 + the new digestless-refusal test); dau suite 58 green against the new budget; lint clean.