### PR TITLE
Make the Vivado overlay payload an injectable definition

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -479,6 +479,7 @@ class SynthesisEngine(BaseModel):
 
 class VivadoEngine(SynthesisEngine):
     name: str = "vivado"
+    overlay_definition: VivadoOverlayDefinition | None = None
 
     def synthesize(self, *, task: "SynthesizeTask", spec, artifacts, resolved) -> BuildStepResult:
         backend_artifacts = _write_vivado_backend_handoff(
@@ -489,6 +490,7 @@ class VivadoEngine(SynthesisEngine):
             platform=resolved.board.platform,
             shell=resolved.board.shell,
             operator_set=resolved.operators.names,
+            overlay_definition=self.overlay_definition,
         )
         return BuildStepResult(
             step="synthesize",
@@ -1274,6 +1276,7 @@ def _write_vivado_backend_handoff(
     platform: str,
     shell: str,
     operator_set: tuple[str, ...],
+    overlay_definition: VivadoOverlayDefinition | None = None,
 ) -> VivadoBackendArtifacts:
     try:
         backend_artifacts = generate_vivado_backend_artifacts(
@@ -1288,6 +1291,7 @@ def _write_vivado_backend_handoff(
                 selected_module=selected_module,
                 register_map_version=spec.register_map_version,
                 stream_protocol_version=spec.stream_protocol_version,
+                overlay_definition=overlay_definition,
             )
         )
     except ValueError as exc:

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -23,6 +23,7 @@ from dau_build.vivado_backend import (
     VivadoBackendArtifacts,
     VivadoBackendArtifactValidation,
     VivadoBackendRequest,
+    VivadoOverlayDefinition,
     VivadoProjectArtifactValidation,
     generate_vivado_backend_artifacts,
 )
@@ -752,6 +753,7 @@ class VivadoOverlayStageTask(OverlayStageTask):
     timing_summary_path: Path = Path("reports/dau_timing_summary.rpt")
     vivado_log_path: Path = Path("vivado.log")
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
+    overlay_definition: VivadoOverlayDefinition | None = None
 
     def stage_steps(self):
         return stage_vivado_overlay_plan(
@@ -772,6 +774,7 @@ class VivadoOverlayStageTask(OverlayStageTask):
             timing_summary_path=self.timing_summary_path,
             vivado_log_path=self.vivado_log_path,
             vivado_settings=self.vivado_settings,
+            overlay_definition=self.overlay_definition,
         )
 
     def _toolchain_config(self) -> HardwareToolchainConfig:
@@ -818,6 +821,7 @@ class VivadoProjectStageTask(VivadoOverlayStageTask):
             timing_summary_path=self.timing_summary_path,
             vivado_log_path=self.vivado_log_path,
             vivado_settings=self.vivado_settings,
+            overlay_definition=self.overlay_definition,
         )
 
 

--- a/dau_build/config/backend/backends/vivado.yaml
+++ b/dau_build/config/backend/backends/vivado.yaml
@@ -4,3 +4,4 @@
 _target_: dau_build.build_steps.VivadoEngine
 name: vivado
 invocation: standard
+overlay_definition: null

--- a/dau_build/config/plan/plans/local-build-and-program.yaml
+++ b/dau_build/config/plan/plans/local-build-and-program.yaml
@@ -8,3 +8,4 @@ overlay_tcl: scripts/dau_overlay.tcl
 smoke_command: null
 python: python3
 vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh
+overlay_definition: null

--- a/dau_build/config/task/tasks/stage/stage-vivado-overlay.yaml
+++ b/dau_build/config/task/tasks/stage/stage-vivado-overlay.yaml
@@ -23,4 +23,5 @@ resource_summary_path: reports/dau_utilization.rpt
 timing_summary_path: reports/dau_timing_summary.rpt
 vivado_log_path: vivado.log
 vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh
+overlay_definition: null
 execute: false

--- a/dau_build/config/task/tasks/stage/stage-vivado-project.yaml
+++ b/dau_build/config/task/tasks/stage/stage-vivado-project.yaml
@@ -26,4 +26,5 @@ resource_summary_path: reports/dau_utilization.rpt
 timing_summary_path: reports/dau_timing_summary.rpt
 vivado_log_path: vivado.log
 vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh
+overlay_definition: null
 execute: false

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -12,6 +12,7 @@ from ccflow import BaseModel
 from dau_build.vivado_backend import (
     VivadoBackendArtifactValidation,
     VivadoBackendRequest,
+    VivadoOverlayDefinition,
     VivadoProjectArtifactValidation,
     VivadoProjectGenerationRequest,
     dau_overlay_tcl,
@@ -132,18 +133,20 @@ def local_build_and_program_plan(
     smoke_command: str | None = None,
     python: str = "python3",
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"),
+    overlay_definition: VivadoOverlayDefinition | None = None,
 ) -> tuple[ToolStep, ...]:
     overlay_path = _work_path(config.work_root, overlay_tcl)
     build_tcl = Path("scripts/dau_build.tcl")
     build_tcl_path = _work_path(config.work_root, build_tcl)
     vivado_path_base = config.work_root.resolve(strict=False) if config.vivado_mount_root is not None else None
-    overlay_source = dau_overlay_tcl(dau_core_root / "dau_core" / "hdl", vivado_path_base=vivado_path_base)
+    overlay_source = dau_overlay_tcl(dau_core_root / "dau_core" / "hdl", vivado_path_base=vivado_path_base, overlay_definition=overlay_definition)
+    build_tcl_source = vivado_build_tcl(lane_placements=None if overlay_definition is None else overlay_definition.lane_placements)
     stage_steps = () if source_shell_root is None else stage_shell_plan(config, source_shell_root=source_shell_root)
     return (
         *stage_steps,
         thunderbolt_hold_step(config, dau_utils_root=dau_utils_root, python=python),
         write_dau_overlay_step(overlay_path=overlay_path, source=overlay_source),
-        write_vivado_build_script_step(build_tcl_path=build_tcl_path, source=vivado_build_tcl()),
+        write_vivado_build_script_step(build_tcl_path=build_tcl_path, source=build_tcl_source),
         *_local_vivado_driver_steps(config, overlay_tcl=overlay_tcl, build_tcl=build_tcl),
         vivado_overlay_build_step(config, overlay_tcl=overlay_tcl, build_tcl=build_tcl, vivado_settings=vivado_settings),
         jtag_detect_step(config),
@@ -175,6 +178,7 @@ def stage_vivado_overlay_plan(
     timing_summary_path: Path = Path("reports/dau_timing_summary.rpt"),
     vivado_log_path: Path = Path("vivado.log"),
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"),
+    overlay_definition: VivadoOverlayDefinition | None = None,
 ) -> tuple[ToolStep, ...]:
     artifacts = generate_vivado_backend_artifacts(
         VivadoBackendRequest(
@@ -198,6 +202,7 @@ def stage_vivado_overlay_plan(
             vivado_executable=config.vivado_executable,
             vivado_invocation=config.vivado_invocation,
             vivado_mount_root=config.vivado_mount_root,
+            overlay_definition=overlay_definition,
         )
     )
     stage_steps = () if source_shell_root is None else stage_shell_plan(config, source_shell_root=source_shell_root)
@@ -233,6 +238,7 @@ def stage_vivado_project_plan(
     timing_summary_path: Path = Path("reports/dau_timing_summary.rpt"),
     vivado_log_path: Path = Path("vivado.log"),
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"),
+    overlay_definition: VivadoOverlayDefinition | None = None,
 ) -> tuple[ToolStep, ...]:
     artifacts = generate_vivado_project_generation_artifacts(
         VivadoProjectGenerationRequest(
@@ -260,6 +266,7 @@ def stage_vivado_project_plan(
             vivado_executable=config.vivado_executable,
             vivado_invocation=config.vivado_invocation,
             vivado_mount_root=config.vivado_mount_root,
+            overlay_definition=overlay_definition,
         )
     )
     backend_artifacts = artifacts.backend_artifacts
@@ -676,6 +683,7 @@ class LocalBuildAndProgramPlan(HardwarePlan):
     smoke_command: str | None = None
     python: str = "python3"
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
+    overlay_definition: VivadoOverlayDefinition | None = None
 
     def compose(self, config):
         return local_build_and_program_plan(
@@ -687,6 +695,7 @@ class LocalBuildAndProgramPlan(HardwarePlan):
             smoke_command=self.smoke_command,
             python=self.python,
             vivado_settings=self.vivado_settings,
+            overlay_definition=self.overlay_definition,
         )
 
 

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -410,3 +410,39 @@ def test_task_dispatch_import_stays_light() -> None:
         capture_output=True,
     )
     assert completed.returncode == 0, completed.stderr.decode()
+
+
+def test_vivado_engine_threads_the_overlay_definition_into_the_handoff(tmp_path: Path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    import dau_build.build_steps as build_steps
+    from dau_build.vivado_backend import VivadoOverlayDefinition
+
+    captured = {}
+
+    def capture_request(request):
+        captured["request"] = request
+        raise ValueError("captured")
+
+    monkeypatch.setattr(build_steps, "generate_vivado_backend_artifacts", capture_request)
+    definition = VivadoOverlayDefinition(bd_overlay_tcl='puts "engine overlay"')
+    spec = SimpleNamespace(
+        sources=(str(tmp_path / "hdl" / "top.sv"),),
+        artifact_stem="dau-identity",
+        register_map_version="0.1",
+        stream_protocol_version="0.1",
+    )
+
+    with pytest.raises(BuildStepError, match="captured"):
+        build_steps._write_vivado_backend_handoff(
+            spec,
+            selected_module="dau_identity_top",
+            output_root=tmp_path / "out",
+            dau_artifact_bundle_path=tmp_path / "bundle.yaml",
+            platform="vivado-xdma",
+            shell="xdma-shell",
+            operator_set=("identity",),
+            overlay_definition=definition,
+        )
+
+    assert captured["request"].overlay_definition == definition

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1180,3 +1180,123 @@ def test_vivado_invocation_is_validated_at_model_construction(tmp_path: Path) ->
             dau_driver_root=tmp_path,
             vivado_invocation="bogus",
         )
+
+
+def _acme_overlay_definition() -> vivado_backend.VivadoOverlayDefinition:
+    return vivado_backend.VivadoOverlayDefinition(
+        hdl_source_vars=(("acme_registers_sv", "acme_registers.sv"),),
+        source_management_tcl="add_files -norecurse -fileset sources_1 $acme_registers_sv",
+        bd_overlay_tcl='puts "acme bd overlay"',
+        runtime_manifest_entries=(("acme_registers_sv", "$acme_registers_sv"),),
+        static_manifest_items=(("acme_cell", "acme_0"),),
+        lane_placements=(("Top_i/gt0", "GTPE2_CHANNEL_X0Y1"),),
+    )
+
+
+def test_default_overlay_definition_reproduces_the_undefined_texts() -> None:
+    # None and the packaged default must render identical scripts/manifests:
+    # callers that pin today's texts can inject an equal definition later
+    # without any byte drift
+    hdl_root = Path("/repo/dau-core/dau_core/hdl")
+    default = vivado_backend.DEFAULT_OVERLAY_DEFINITION
+
+    assert dau_overlay_tcl(hdl_root) == dau_overlay_tcl(hdl_root, overlay_definition=default)
+    assert dau_overlay_manifest(hdl_root) == dau_overlay_manifest(hdl_root, overlay_definition=default)
+    assert vivado_backend.vivado_build_tcl() == vivado_backend.vivado_build_tcl(lane_placements=default.lane_placements)
+
+
+def test_injected_overlay_definition_drives_overlay_tcl_and_manifest() -> None:
+    definition = _acme_overlay_definition()
+    hdl_root = Path("/repo/acme/hdl")
+
+    source = dau_overlay_tcl(hdl_root, overlay_definition=definition)
+
+    assert 'set acme_registers_sv [file normalize "/repo/acme/hdl/acme_registers.sv"]' in source
+    assert "add_files -norecurse -fileset sources_1 $acme_registers_sv" in source
+    assert 'puts "acme bd overlay"' in source
+    assert 'puts $manifest_file "acme_registers_sv=$acme_registers_sv"' in source
+    assert "open_project project.xpr" in source
+    assert "update_compile_order -fileset sources_1" in source
+    assert "dau_identity" not in source
+
+    manifest = dict(dau_overlay_manifest(hdl_root, overlay_definition=definition))
+
+    assert manifest["acme_registers_sv"] == "/repo/acme/hdl/acme_registers.sv"
+    assert manifest["acme_cell"] == "acme_0"
+    assert manifest["backend"] == "dau_build.vivado_backend.vivado_overlay"
+    assert "dau_identity_registers_sv" not in manifest
+
+
+def test_injected_lane_placements_drive_the_build_tcl_placement_block() -> None:
+    text = vivado_backend.vivado_build_tcl(lane_placements=(("Top_i/gt0", "GTPE2_CHANNEL_X0Y1"),))
+
+    assert "foreach lane [list     [list {Top_i/gt0} GTPE2_CHANNEL_X0Y1] ] {" in text
+    assert "pipe_lane" not in text
+
+
+def test_empty_lane_placements_omit_the_placement_block() -> None:
+    text = vivado_backend.vivado_build_tcl(lane_placements=())
+
+    assert "foreach lane" not in text
+    assert "open_run synth_1\n\nlaunch_runs impl_1" in text
+
+
+def test_backend_request_overlay_definition_threads_into_generated_artifacts(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    request = VivadoBackendRequest(dau_core_hdl_root=Path("/repo/acme/hdl"), build_root=tmp_path, overlay_definition=definition)
+
+    artifacts = generate_vivado_backend_artifacts(request)
+
+    assert 'set acme_registers_sv [file normalize "/repo/acme/hdl/acme_registers.sv"]' in artifacts.overlay_tcl_text
+    assert "[list {Top_i/gt0} GTPE2_CHANNEL_X0Y1]" in artifacts.build_tcl_text
+    assert "acme_cell=acme_0" in artifacts.manifest_text
+    assert "dau_identity" not in artifacts.overlay_tcl_text
+
+
+def test_project_request_forwards_the_overlay_definition_to_the_backend(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    request = VivadoProjectGenerationRequest(
+        source_shell_root=Path("/repo/projects/nite"),
+        work_root=tmp_path,
+        dau_core_root=Path("/repo/acme"),
+        dau_driver_root=Path("/repo/dau-driver"),
+        overlay_definition=definition,
+    )
+
+    assert request.backend_request.overlay_definition == definition
+
+
+def _decoded_write_step_payload(step) -> str:
+    tokens = shlex.split(step.argv[2])
+    payload = tokens[tokens.index("printf") + 2]
+    return base64.b64decode(payload).decode("utf-8")
+
+
+def test_stage_vivado_overlay_plan_stages_the_injected_definition(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    config = HardwareToolchainConfig(work_root=tmp_path)
+
+    steps = stage_vivado_overlay_plan(config, dau_core_root=Path("/repo/acme"), overlay_definition=definition)
+
+    overlay_source = _decoded_write_step_payload(next(step for step in steps if step.name == "write-dau-overlay"))
+    build_source = _decoded_write_step_payload(next(step for step in steps if step.name == "write-vivado-build-script"))
+    manifest_source = _decoded_write_step_payload(next(step for step in steps if step.name == "write-dau-manifest"))
+
+    assert 'puts "acme bd overlay"' in overlay_source
+    assert "[list {Top_i/gt0} GTPE2_CHANNEL_X0Y1]" in build_source
+    assert "acme_cell=acme_0" in manifest_source
+    assert "dau_identity" not in overlay_source
+
+
+def test_local_build_and_program_plan_honors_the_injected_definition(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    config = HardwareToolchainConfig(work_root=tmp_path)
+
+    steps = local_build_and_program_plan(config, dau_core_root=Path("/repo/acme"), overlay_definition=definition)
+
+    overlay_source = _decoded_write_step_payload(next(step for step in steps if step.name == "write-dau-overlay"))
+    build_source = _decoded_write_step_payload(next(step for step in steps if step.name == "write-vivado-build-script"))
+
+    assert 'set acme_registers_sv [file normalize "/repo/acme/dau_core/hdl/acme_registers.sv"]' in overlay_source
+    assert "[list {Top_i/gt0} GTPE2_CHANNEL_X0Y1]" in build_source
+    assert "pipe_lane" not in build_source

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1300,3 +1300,55 @@ def test_local_build_and_program_plan_honors_the_injected_definition(tmp_path: P
     assert 'set acme_registers_sv [file normalize "/repo/acme/dau_core/hdl/acme_registers.sv"]' in overlay_source
     assert "[list {Top_i/gt0} GTPE2_CHANNEL_X0Y1]" in build_source
     assert "pipe_lane" not in build_source
+
+
+def test_project_manifest_records_and_guards_an_injected_definition(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    request_kwargs = dict(
+        source_shell_root=Path("/repo/projects/nite"),
+        work_root=tmp_path,
+        dau_core_root=Path("/repo/acme"),
+        dau_driver_root=Path("/repo/dau-driver"),
+    )
+
+    injected = dict(
+        vivado_backend.vivado_project_generation_manifest(VivadoProjectGenerationRequest(**request_kwargs, overlay_definition=definition))
+    )
+    default = dict(vivado_backend.vivado_project_generation_manifest(VivadoProjectGenerationRequest(**request_kwargs)))
+
+    assert injected["overlay_definition"] == "injected"
+    # replaying the recorded command must demand the definition instead of
+    # silently re-staging the packaged default overlay
+    assert "overlay_definition=???" in injected["stage_command"]
+    assert "overlay_definition" not in default
+    assert "overlay_definition" not in default["stage_command"]
+
+
+def test_project_command_validation_requires_the_injected_definition_marker(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    request = VivadoProjectGenerationRequest(
+        source_shell_root=Path("/repo/projects/nite"),
+        work_root=tmp_path,
+        dau_core_root=Path("/repo/acme"),
+        dau_driver_root=Path("/repo/dau-driver"),
+        overlay_definition=definition,
+    )
+    project_manifest = dict(vivado_backend.vivado_project_generation_manifest(request))
+    manifest_path = request.backend_request.resolved_manifest_path
+    command_plan_path = request.backend_request.resolved_command_plan_path
+
+    marked = vivado_backend._validate_project_manifest_commands(
+        project_manifest=project_manifest,
+        manifest_path=manifest_path,
+        command_plan_path=command_plan_path,
+    )
+    assert marked == ()
+
+    # a stage_command silently rebuilt without the marker fails validation
+    project_manifest["stage_command"] = project_manifest["stage_command"].replace(" 'overlay_definition=???'", "")
+    stripped = vivado_backend._validate_project_manifest_commands(
+        project_manifest=project_manifest,
+        manifest_path=manifest_path,
+        command_plan_path=command_plan_path,
+    )
+    assert any("overlay-definition" in error for error in stripped)

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -493,10 +493,20 @@ def vivado_project_generation_manifest(request: VivadoProjectGenerationRequest) 
         ("vivado_executable", request.vivado_executable),
         ("vivado_invocation", request.vivado_invocation),
         ("vivado_mount_root", "" if request.vivado_mount_root is None else request.vivado_mount_root.resolve(strict=False).as_posix()),
-        ("stage_command", vivado_project_stage_command(request)),
-        ("build_command", vivado_project_build_command(request)),
-        ("validate_command", vivado_project_validate_command(request)),
     ]
+    if request.overlay_definition is not None:
+        # a caller-injected overlay definition cannot be reconstructed from a
+        # flat command line; record the fact so consumers know the recorded
+        # stage_command (which demands the definition) needs the caller's
+        # configuration to re-run
+        items.append(("overlay_definition", "injected"))
+    items.extend(
+        (
+            ("stage_command", vivado_project_stage_command(request)),
+            ("build_command", vivado_project_build_command(request)),
+            ("validate_command", vivado_project_validate_command(request)),
+        )
+    )
     return tuple(items)
 
 
@@ -527,6 +537,11 @@ def vivado_project_stage_command(request: VivadoProjectGenerationRequest) -> str
         overrides.append(("vivado_mount_root", request.vivado_mount_root.resolve(strict=False)))
     if request.dau_artifact_bundle_path is not None:
         overrides.append(("dau_artifact_bundle", request.dau_artifact_bundle_path))
+    if request.overlay_definition is not None:
+        # the injected definition cannot ride a flat command line; mark the
+        # field hydra-missing so replaying the recorded command refuses to
+        # silently re-stage the packaged default overlay instead
+        overrides.append(("overlay_definition", "???"))
     overrides.append(("operator", ",".join(request.operator_set)))
     return _task_command(request.plan_executable, "stage-vivado-overlay", tuple(overrides))
 
@@ -815,6 +830,11 @@ def _validate_project_manifest_commands(
         stage_required_options.append(("--vivado-invocation", vivado_invocation))
     if vivado_mount_root:
         stage_required_options.append(("--vivado-mount-root", vivado_mount_root))
+    if project_manifest.get("overlay_definition") == "injected":
+        # the artifacts came from a caller-injected overlay definition; the
+        # recorded stage_command must demand it (hydra-missing) rather than
+        # silently re-stage the packaged default overlay
+        stage_required_options.append(("--overlay-definition", "???"))
     errors.extend(
         _validate_project_command(
             label="stage_command",

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -10,6 +10,26 @@ from ccflow import BaseModel
 from dau_build.artifact_bundle import ArtifactBundle, ArtifactBundleError, load_artifact_bundle
 
 
+class VivadoOverlayDefinition(BaseModel):
+    """The design-specific payload of the Vivado overlay and build scripts:
+    which HDL sources to graft onto the staged shell (as Tcl-variable /
+    HDL-root-relative-path pairs), the source-management and block-design
+    edit Tcl those variables feed, the manifest entries they contribute, and
+    the placement fixups the build script applies after synthesis. dau-build's
+    machinery (path rendering, artifact bundles, manifest/command-plan
+    contracts) is generic; this payload is data so integration packages can
+    inject their own definition through the request/task ``overlay_definition``
+    fields. ``DEFAULT_OVERLAY_DEFINITION`` carries the historical XDMA
+    identity overlay for compatibility when no definition is injected."""
+
+    hdl_source_vars: tuple[tuple[str, str], ...] = ()
+    source_management_tcl: str = ""
+    bd_overlay_tcl: str = ""
+    runtime_manifest_entries: tuple[tuple[str, str], ...] = ()
+    static_manifest_items: tuple[tuple[str, str], ...] = ()
+    lane_placements: tuple[tuple[str, str], ...] = ()
+
+
 class VivadoBackendRequest(BaseModel):
     dau_core_hdl_root: Path
     build_root: Path
@@ -33,6 +53,7 @@ class VivadoBackendRequest(BaseModel):
     vivado_executable: str = "vivado"
     vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
+    overlay_definition: VivadoOverlayDefinition | None = None
 
     @property
     def resolved_manifest_path(self) -> Path:
@@ -90,6 +111,7 @@ class VivadoProjectGenerationRequest(BaseModel):
     vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
     plan_executable: str = "dau-build"
+    overlay_definition: VivadoOverlayDefinition | None = None
 
     @property
     def dau_core_hdl_root(self) -> Path:
@@ -124,6 +146,7 @@ class VivadoProjectGenerationRequest(BaseModel):
             vivado_executable=self.vivado_executable,
             vivado_invocation=self.vivado_invocation,
             vivado_mount_root=self.vivado_mount_root,
+            overlay_definition=self.overlay_definition,
         )
 
 
@@ -243,6 +266,7 @@ def generate_vivado_backend_artifacts(request: VivadoBackendRequest) -> VivadoBa
             dau_bundle_hdl_sources=_bundle_hdl_source_paths(artifact_bundle),
             selected_module=request.selected_module,
             vivado_path_base=vivado_path_base,
+            overlay_definition=request.overlay_definition,
         ),
         build_tcl_text=vivado_build_tcl(
             manifest_path=manifest_path,
@@ -250,6 +274,7 @@ def generate_vivado_backend_artifacts(request: VivadoBackendRequest) -> VivadoBa
             resource_summary_path=request.resource_summary_path,
             timing_summary_path=request.timing_summary_path,
             vivado_log_path=request.vivado_log_path,
+            lane_placements=None if request.overlay_definition is None else request.overlay_definition.lane_placements,
         ),
         overlay_driver_tcl_text=None
         if overlay_driver_tcl is None
@@ -405,6 +430,7 @@ def vivado_backend_manifest(request: VivadoBackendRequest, *, artifact_bundle: A
             dau_artifact_bundle_path=request.resolved_dau_artifact_bundle_path,
             artifact_bundle=artifact_bundle,
             vivado_path_base=vivado_path_base,
+            overlay_definition=request.overlay_definition,
         ),
         ("platform", request.platform),
         ("shell", request.shell),
@@ -1107,20 +1133,17 @@ def dau_overlay_manifest(
     dau_artifact_bundle_path: Path | None = None,
     artifact_bundle: ArtifactBundle | None = None,
     vivado_path_base: Path | None = None,
+    overlay_definition: VivadoOverlayDefinition | None = None,
 ) -> tuple[tuple[str, str], ...]:
-    identity_source = dau_core_hdl_root / "dau_identity_registers.sv"
-    identity_axil_source = dau_core_hdl_root / "dau_identity_axil.v"
-    legacy_identity_axil_source = dau_core_hdl_root / "dau_identity_axil.sv"
-    identity_source = _render_vivado_path(identity_source, vivado_path_base=vivado_path_base)
-    identity_axil_source = _render_vivado_path(identity_axil_source, vivado_path_base=vivado_path_base)
-    legacy_identity_axil_source = _render_vivado_path(legacy_identity_axil_source, vivado_path_base=vivado_path_base)
+    definition = overlay_definition if overlay_definition is not None else DEFAULT_OVERLAY_DEFINITION
+    hdl_source_items = tuple(
+        (variable, _render_vivado_path(dau_core_hdl_root / relative_path, vivado_path_base=vivado_path_base).as_posix())
+        for variable, relative_path in definition.hdl_source_vars
+    )
     return (
         ("backend", "dau_build.vivado_backend.vivado_overlay"),
-        ("dau_identity_registers_sv", identity_source.as_posix()),
-        ("dau_identity_axil_v", identity_axil_source.as_posix()),
-        ("dau_identity_axil_sv_legacy", legacy_identity_axil_source.as_posix()),
-        ("dau_identity_axil_cell", "dau_identity_axil_0"),
-        ("spi_ss_i_tieoff", "dau_spi_ss_i_tieoff"),
+        *hdl_source_items,
+        *definition.static_manifest_items,
         ("overlay", overlay_tcl.as_posix()),
         ("bitstream", bitstream_path.as_posix()),
         ("resource_summary", resource_summary_path.as_posix()),
@@ -1160,112 +1183,36 @@ def dau_overlay_tcl(
     dau_bundle_hdl_sources: tuple[Path, ...] = (),
     selected_module: str | None = None,
     vivado_path_base: Path | None = None,
+    overlay_definition: VivadoOverlayDefinition | None = None,
 ) -> str:
-    identity_source = _render_vivado_path(dau_core_hdl_root / "dau_identity_registers.sv", vivado_path_base=vivado_path_base)
-    identity_axil_source = _render_vivado_path(dau_core_hdl_root / "dau_identity_axil.v", vivado_path_base=vivado_path_base)
-    legacy_identity_axil_source = _render_vivado_path(dau_core_hdl_root / "dau_identity_axil.sv", vivado_path_base=vivado_path_base)
+    definition = overlay_definition if overlay_definition is not None else DEFAULT_OVERLAY_DEFINITION
+    hdl_source_sets = "\n".join(
+        f'set {variable} [file normalize "{_render_vivado_path(dau_core_hdl_root / relative_path, vivado_path_base=vivado_path_base).as_posix()}"]'
+        for variable, relative_path in definition.hdl_source_vars
+    )
+    runtime_manifest_puts = "\n".join(f'puts $manifest_file "{key}={value}"' for key, value in definition.runtime_manifest_entries)
     rendered_bundle_path = (
         None if dau_artifact_bundle_path is None else _render_vivado_path(dau_artifact_bundle_path, vivado_path_base=vivado_path_base)
     )
     rendered_generated_top = None if dau_generated_top is None else _render_vivado_path(dau_generated_top, vivado_path_base=vivado_path_base)
     rendered_bundle_sources = tuple(_render_vivado_path(path, vivado_path_base=vivado_path_base) for path in dau_bundle_hdl_sources)
     return f"""# Generated by dau-build; source before scripts/build.tcl.
-set dau_identity_registers_sv [file normalize \"{identity_source.as_posix()}\"]
-set dau_identity_axil_v [file normalize "{identity_axil_source.as_posix()}"]
-set dau_identity_axil_sv_legacy [file normalize "{legacy_identity_axil_source.as_posix()}"]
+{hdl_source_sets}
 if {{[llength [get_projects -quiet]] == 0}} {{
     if {{![file exists \"project.xpr\"]}} {{
         error \"project.xpr is missing; restore the Vivado project before this overlay\"
     }}
     open_project project.xpr
 }}
-set stale_dau_axil_source [get_files -quiet $dau_identity_axil_sv_legacy]
-if {{[llength $stale_dau_axil_source] != 0}} {{
-    remove_files $stale_dau_axil_source
-}}
-set locked_dau_ips [get_ips -quiet -filter {{IS_LOCKED == 1}}]
-if {{[llength $locked_dau_ips] != 0}} {{
-    upgrade_ip $locked_dau_ips
-}}
-foreach dau_hdl_source [list $dau_identity_registers_sv $dau_identity_axil_v] {{
-    if {{![file exists $dau_hdl_source]}} {{
-        error "missing DAU HDL source: $dau_hdl_source"
-    }}
-    if {{[llength [get_files -quiet $dau_hdl_source]] == 0}} {{
-        add_files -norecurse -fileset sources_1 $dau_hdl_source
-    }}
-    set_property library xil_defaultlib [get_files $dau_hdl_source]
-    set_property used_in {{synthesis implementation simulation}} [get_files $dau_hdl_source]
-}}
-set_property file_type SystemVerilog [get_files $dau_identity_registers_sv]
-set_property file_type Verilog [get_files $dau_identity_axil_v]
+{definition.source_management_tcl}
 {_bundle_hdl_sources_tcl(rendered_bundle_sources)}
 update_compile_order -fileset sources_1
-set top_bd [get_files -quiet project.srcs/sources_1/bd/Top/Top.bd]
-if {{[llength $top_bd] == 0}} {{
-    error "missing Top block design at project.srcs/sources_1/bd/Top/Top.bd"
-}}
-open_bd_design [get_files project.srcs/sources_1/bd/Top/Top.bd]
-foreach net_name {{axi_interconnect_0_M00_AXI Model_dout Version_dout}} {{
-    set old_net [get_bd_intf_nets -quiet $net_name]
-    if {{[llength $old_net] != 0}} {{
-        delete_bd_objs $old_net
-    }}
-    set old_net [get_bd_nets -quiet $net_name]
-    if {{[llength $old_net] != 0}} {{
-        delete_bd_objs $old_net
-    }}
-}}
-foreach cell_name {{dau_identity_axil_0 axi_gpio_0 Model Version}} {{
-    set old_cell [get_bd_cells -quiet $cell_name]
-    if {{[llength $old_cell] != 0}} {{
-        delete_bd_objs $old_cell
-    }}
-}}
-create_bd_cell -type module -reference dau_identity_axil dau_identity_axil_0
-connect_bd_intf_net -intf_net axi_interconnect_0_M00_AXI [get_bd_intf_pins axi_interconnect_0/M00_AXI] [get_bd_intf_pins dau_identity_axil_0/S_AXI]
-connect_bd_net -net S00_ACLK_1 [get_bd_pins xdma_0/axi_aclk] [get_bd_pins dau_identity_axil_0/s_axi_aclk]
-connect_bd_net -net S00_ARESETN_1 [get_bd_pins xdma_0/axi_aresetn] [get_bd_pins dau_identity_axil_0/s_axi_aresetn]
-set dau_identity_addr_seg [lindex [get_bd_addr_segs -quiet dau_identity_axil_0/S_AXI/*] 0]
-if {{$dau_identity_addr_seg eq ""}} {{
-    error "missing DAU AXI-Lite address segment for dau_identity_axil_0/S_AXI"
-}}
-assign_bd_address -offset 0x00001000 -range 0x00001000 -target_address_space [get_bd_addr_spaces xdma_0/M_AXI_LITE] $dau_identity_addr_seg -force
-set spi_ss_i_pin [get_bd_pins -quiet axi_quad_spi_0/ss_i]
-if {{[llength $spi_ss_i_pin] != 0}} {{
-    if {{[llength [get_bd_cells -quiet dau_spi_ss_i_tieoff]] == 0}} {{
-        create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 dau_spi_ss_i_tieoff
-    }}
-    set_property -dict [list CONFIG.CONST_WIDTH {{1}} CONFIG.CONST_VAL {{0}}] [get_bd_cells dau_spi_ss_i_tieoff]
-    set spi_ss_i_nets [get_bd_nets -quiet -of_objects $spi_ss_i_pin]
-    if {{[llength $spi_ss_i_nets] == 0}} {{
-        connect_bd_net -net dau_spi_ss_i_tieoff_dout [get_bd_pins dau_spi_ss_i_tieoff/dout] $spi_ss_i_pin
-    }} elseif {{[lsearch -exact $spi_ss_i_nets /dau_spi_ss_i_tieoff_dout] < 0}} {{
-        delete_bd_objs $spi_ss_i_nets
-        connect_bd_net -net dau_spi_ss_i_tieoff_dout [get_bd_pins dau_spi_ss_i_tieoff/dout] $spi_ss_i_pin
-    }}
-}}
-validate_bd_design
-save_bd_design
-set wrapper_path [make_wrapper -files [get_files project.srcs/sources_1/bd/Top/Top.bd] -top]
-if {{[llength [get_files -quiet $wrapper_path]] == 0}} {{
-    add_files -norecurse -fileset sources_1 $wrapper_path
-}}
-set_property -name "top" -value "Top_wrapper" -objects [get_filesets sources_1]
-update_compile_order -fileset sources_1
-set dau_identity_ooc_runs [get_runs -quiet *dau_identity_axil*]
-if {{[llength $dau_identity_ooc_runs] != 0}} {{
-    reset_run $dau_identity_ooc_runs
-}}
+{definition.bd_overlay_tcl}
 # The Python staging step writes the full structured manifest before Vivado
 # runs. Append runtime-discovered fields here so executing the command plan
 # does not clobber the typed backend contract.
 set manifest_file [open \"{manifest_path.as_posix()}\" a]
-puts $manifest_file \"dau_identity_registers_sv=$dau_identity_registers_sv\"
-puts $manifest_file "dau_identity_axil_v=$dau_identity_axil_v"
-puts $manifest_file "dau_identity_axil_cell=dau_identity_axil_0"
-puts $manifest_file "dau_identity_ooc_runs=$dau_identity_ooc_runs"
-puts $manifest_file "spi_ss_i_tieoff=dau_spi_ss_i_tieoff"
+{runtime_manifest_puts}
 puts $manifest_file "overlay={overlay_tcl.as_posix()}"
 puts $manifest_file "bitstream={bitstream_path.as_posix()}"
 puts $manifest_file "resource_summary={resource_summary_path.as_posix()}"
@@ -1314,6 +1261,27 @@ def project_build_script(
     )
 
 
+def _lane_placement_tcl(lane_placements: tuple[tuple[str, str], ...]) -> str:
+    if not lane_placements:
+        return ""
+    lane_entries = "".join(f"    [list {{{cell_path}}} {location}] " for cell_path, location in lane_placements)
+    return (
+        "foreach lane [list "
+        + lane_entries
+        + "] {\n"
+        + "    set cell_path [lindex $lane 0]\n"
+        + "    set lane_loc [lindex $lane 1]\n"
+        + "    set lane_cells [get_cells -quiet $cell_path]\n"
+        + "    if {[llength $lane_cells] == 0} {\n"
+        + '        puts "dau-build: skipping missing PCIe lane cell $cell_path"\n'
+        + "        continue\n"
+        + "    }\n"
+        + "    reset_property LOC $lane_cells\n"
+        + "    set_property LOC $lane_loc $lane_cells\n"
+        + "}\n\n"
+    )
+
+
 def vivado_build_tcl(
     *,
     manifest_path: Path = Path("dau-vivado.manifest"),
@@ -1321,7 +1289,9 @@ def vivado_build_tcl(
     resource_summary_path: Path = Path("reports/dau_utilization.rpt"),
     timing_summary_path: Path = Path("reports/dau_timing_summary.rpt"),
     vivado_log_path: Path = Path("vivado.log"),
+    lane_placements: tuple[tuple[str, str], ...] | None = None,
 ) -> str:
+    placements = lane_placements if lane_placements is not None else DEFAULT_OVERLAY_DEFINITION.lane_placements
     script = """# Generated by dau-build; source after scripts/dau_overlay.tcl.
 open_project project.xpr
 reset_run synth_1
@@ -1329,23 +1299,7 @@ launch_runs synth_1 -jobs 2
 wait_on_run synth_1
 open_run synth_1
 
-foreach lane [list \
-    [list {Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[3].gt_wrapper_i/gtp_channel.gtpe2_channel_i} GTPE2_CHANNEL_X0Y7] \
-    [list {Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[0].gt_wrapper_i/gtp_channel.gtpe2_channel_i} GTPE2_CHANNEL_X0Y6] \
-    [list {Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[2].gt_wrapper_i/gtp_channel.gtpe2_channel_i} GTPE2_CHANNEL_X0Y5] \
-    [list {Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[1].gt_wrapper_i/gtp_channel.gtpe2_channel_i} GTPE2_CHANNEL_X0Y4] \
-] {
-    set cell_path [lindex $lane 0]
-    set lane_loc [lindex $lane 1]
-    set lane_cells [get_cells -quiet $cell_path]
-    if {[llength $lane_cells] == 0} {
-        puts "dau-build: skipping missing PCIe lane cell $cell_path"
-        continue
-    }
-    reset_property LOC $lane_cells
-    set_property LOC $lane_loc $lane_cells
-}
-
+__LANE_PLACEMENT_TCL__
 launch_runs impl_1 -jobs 6 -to_step write_bitstream
 wait_on_run impl_1
 open_run impl_1
@@ -1380,7 +1334,8 @@ close_design
 puts "Implementation done!"
 """
     return (
-        script.replace("__MANIFEST_PATH__", manifest_path.as_posix())
+        script.replace("__LANE_PLACEMENT_TCL__\n", _lane_placement_tcl(placements))
+        .replace("__MANIFEST_PATH__", manifest_path.as_posix())
         .replace("__BITSTREAM_PATH__", bitstream_path.as_posix())
         .replace("__RESOURCE_SUMMARY_PATH__", resource_summary_path.as_posix())
         .replace("__TIMING_SUMMARY_PATH__", timing_summary_path.as_posix())
@@ -1455,6 +1410,130 @@ def _vivado_source_command(*, vivado_executable: str, tcl_path: Path, vivado_inv
     if vivado_invocation == "source-only":
         return shlex.join((vivado_executable, str(tcl_path)))
     return shlex.join((vivado_executable, "-mode", "batch", "-source", str(tcl_path)))
+
+
+# The historical XDMA identity overlay payload, kept as the default so the
+# staged scripts are unchanged when no definition is injected. Integration
+# packages own their design-specific payloads and inject them via the
+# request/task `overlay_definition` fields (the same extraction pattern as
+# the injectable `smoke_command`); this default is tracked for relocation
+# into caller configuration once the platform registry threads through.
+_DEFAULT_SOURCE_MANAGEMENT_TCL = """set stale_dau_axil_source [get_files -quiet $dau_identity_axil_sv_legacy]
+if {[llength $stale_dau_axil_source] != 0} {
+    remove_files $stale_dau_axil_source
+}
+set locked_dau_ips [get_ips -quiet -filter {IS_LOCKED == 1}]
+if {[llength $locked_dau_ips] != 0} {
+    upgrade_ip $locked_dau_ips
+}
+foreach dau_hdl_source [list $dau_identity_registers_sv $dau_identity_axil_v] {
+    if {![file exists $dau_hdl_source]} {
+        error "missing DAU HDL source: $dau_hdl_source"
+    }
+    if {[llength [get_files -quiet $dau_hdl_source]] == 0} {
+        add_files -norecurse -fileset sources_1 $dau_hdl_source
+    }
+    set_property library xil_defaultlib [get_files $dau_hdl_source]
+    set_property used_in {synthesis implementation simulation} [get_files $dau_hdl_source]
+}
+set_property file_type SystemVerilog [get_files $dau_identity_registers_sv]
+set_property file_type Verilog [get_files $dau_identity_axil_v]"""
+
+_DEFAULT_BD_OVERLAY_TCL = """set top_bd [get_files -quiet project.srcs/sources_1/bd/Top/Top.bd]
+if {[llength $top_bd] == 0} {
+    error "missing Top block design at project.srcs/sources_1/bd/Top/Top.bd"
+}
+open_bd_design [get_files project.srcs/sources_1/bd/Top/Top.bd]
+foreach net_name {axi_interconnect_0_M00_AXI Model_dout Version_dout} {
+    set old_net [get_bd_intf_nets -quiet $net_name]
+    if {[llength $old_net] != 0} {
+        delete_bd_objs $old_net
+    }
+    set old_net [get_bd_nets -quiet $net_name]
+    if {[llength $old_net] != 0} {
+        delete_bd_objs $old_net
+    }
+}
+foreach cell_name {dau_identity_axil_0 axi_gpio_0 Model Version} {
+    set old_cell [get_bd_cells -quiet $cell_name]
+    if {[llength $old_cell] != 0} {
+        delete_bd_objs $old_cell
+    }
+}
+create_bd_cell -type module -reference dau_identity_axil dau_identity_axil_0
+connect_bd_intf_net -intf_net axi_interconnect_0_M00_AXI [get_bd_intf_pins axi_interconnect_0/M00_AXI] [get_bd_intf_pins dau_identity_axil_0/S_AXI]
+connect_bd_net -net S00_ACLK_1 [get_bd_pins xdma_0/axi_aclk] [get_bd_pins dau_identity_axil_0/s_axi_aclk]
+connect_bd_net -net S00_ARESETN_1 [get_bd_pins xdma_0/axi_aresetn] [get_bd_pins dau_identity_axil_0/s_axi_aresetn]
+set dau_identity_addr_seg [lindex [get_bd_addr_segs -quiet dau_identity_axil_0/S_AXI/*] 0]
+if {$dau_identity_addr_seg eq ""} {
+    error "missing DAU AXI-Lite address segment for dau_identity_axil_0/S_AXI"
+}
+assign_bd_address -offset 0x00001000 -range 0x00001000 -target_address_space [get_bd_addr_spaces xdma_0/M_AXI_LITE] $dau_identity_addr_seg -force
+set spi_ss_i_pin [get_bd_pins -quiet axi_quad_spi_0/ss_i]
+if {[llength $spi_ss_i_pin] != 0} {
+    if {[llength [get_bd_cells -quiet dau_spi_ss_i_tieoff]] == 0} {
+        create_bd_cell -type ip -vlnv xilinx.com:ip:xlconstant:1.1 dau_spi_ss_i_tieoff
+    }
+    set_property -dict [list CONFIG.CONST_WIDTH {1} CONFIG.CONST_VAL {0}] [get_bd_cells dau_spi_ss_i_tieoff]
+    set spi_ss_i_nets [get_bd_nets -quiet -of_objects $spi_ss_i_pin]
+    if {[llength $spi_ss_i_nets] == 0} {
+        connect_bd_net -net dau_spi_ss_i_tieoff_dout [get_bd_pins dau_spi_ss_i_tieoff/dout] $spi_ss_i_pin
+    } elseif {[lsearch -exact $spi_ss_i_nets /dau_spi_ss_i_tieoff_dout] < 0} {
+        delete_bd_objs $spi_ss_i_nets
+        connect_bd_net -net dau_spi_ss_i_tieoff_dout [get_bd_pins dau_spi_ss_i_tieoff/dout] $spi_ss_i_pin
+    }
+}
+validate_bd_design
+save_bd_design
+set wrapper_path [make_wrapper -files [get_files project.srcs/sources_1/bd/Top/Top.bd] -top]
+if {[llength [get_files -quiet $wrapper_path]] == 0} {
+    add_files -norecurse -fileset sources_1 $wrapper_path
+}
+set_property -name "top" -value "Top_wrapper" -objects [get_filesets sources_1]
+update_compile_order -fileset sources_1
+set dau_identity_ooc_runs [get_runs -quiet *dau_identity_axil*]
+if {[llength $dau_identity_ooc_runs] != 0} {
+    reset_run $dau_identity_ooc_runs
+}"""
+
+DEFAULT_OVERLAY_DEFINITION = VivadoOverlayDefinition(
+    hdl_source_vars=(
+        ("dau_identity_registers_sv", "dau_identity_registers.sv"),
+        ("dau_identity_axil_v", "dau_identity_axil.v"),
+        ("dau_identity_axil_sv_legacy", "dau_identity_axil.sv"),
+    ),
+    source_management_tcl=_DEFAULT_SOURCE_MANAGEMENT_TCL,
+    bd_overlay_tcl=_DEFAULT_BD_OVERLAY_TCL,
+    runtime_manifest_entries=(
+        ("dau_identity_registers_sv", "$dau_identity_registers_sv"),
+        ("dau_identity_axil_v", "$dau_identity_axil_v"),
+        ("dau_identity_axil_cell", "dau_identity_axil_0"),
+        ("dau_identity_ooc_runs", "$dau_identity_ooc_runs"),
+        ("spi_ss_i_tieoff", "dau_spi_ss_i_tieoff"),
+    ),
+    static_manifest_items=(
+        ("dau_identity_axil_cell", "dau_identity_axil_0"),
+        ("spi_ss_i_tieoff", "dau_spi_ss_i_tieoff"),
+    ),
+    lane_placements=(
+        (
+            "Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[3].gt_wrapper_i/gtp_channel.gtpe2_channel_i",
+            "GTPE2_CHANNEL_X0Y7",
+        ),
+        (
+            "Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[0].gt_wrapper_i/gtp_channel.gtpe2_channel_i",
+            "GTPE2_CHANNEL_X0Y6",
+        ),
+        (
+            "Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[2].gt_wrapper_i/gtp_channel.gtpe2_channel_i",
+            "GTPE2_CHANNEL_X0Y5",
+        ),
+        (
+            "Top_i/xdma_0/inst/Top_xdma_0_0_pcie2_to_pcie3_wrapper_i/pcie2_ip_i/inst/inst/gt_top_i/pipe_wrapper_i/pipe_lane[1].gt_wrapper_i/gtp_channel.gtpe2_channel_i",
+            "GTPE2_CHANNEL_X0Y4",
+        ),
+    ),
+)
 
 
 # Generic stream-job contract manifest values. dau-build is public and


### PR DESCRIPTION
The overlay/build scripts hardcoded one design's payload: the identity HDL sources grafted onto the staged shell, the block-design edit Tcl, the manifest entries they contribute, and the post-synthesis PCIe lane placements. This extracts that payload into a `VivadoOverlayDefinition` data model threaded through the backend/project requests, the hardware plans, the stage tasks, and the Vivado synthesis engine (`overlay_definition` field — the same extraction pattern as the injectable `smoke_command`), so integration packages can supply their own definition from configuration.

- The packaged default carries the historical payload: with no definition injected, every staged text (overlay tcl, backend/project manifests, build tcl, plans) is byte-identical to main — verified by test and by direct comparison against the main module.
- A caller-injected definition cannot be reconstructed from a flat command line, so the project manifest records `overlay_definition=injected` and the recorded `stage_command` marks the field hydra-missing; validation requires the marker, so replaying the command demands the caller's definition instead of silently re-staging the default overlay.
- Relocating the default payload out of dau-build entirely rides the platform-registry work (boards-as-configuration).