### PR TITLE
Compose hardware access and host checkout roots from configuration

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from ccflow import BaseModel
 from pydantic import field_validator
 
@@ -10,6 +12,20 @@ class BoardConfig(BaseModel):
     name: str
     platform: str
     shell: str
+
+
+class HostConfig(BaseModel):
+    """Where the build host keeps its source checkouts — the ``host`` hydra
+    config group. Tasks and plans that need a checkout root interpolate from
+    the composed host (``host=hosts/<name>``, registered from a search-path
+    package or ``--config-dir`` overlay) instead of demanding the paths as
+    first-class required fields; a direct ``<field>=...`` override still
+    wins."""
+
+    name: str = "local"
+    dau_core_root: Path | None = None
+    dau_driver_root: Path | None = None
+    dau_utils_root: Path | None = None
 
 
 class BackendConfig(BaseModel):

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1062,6 +1062,11 @@ class HardwarePlanTask(BuildCallableModel):
             from dau_build.platforms import require_measured
 
             require_measured(self.platform)
+            if getattr(self.platform, "host_access", None) is None:
+                raise BuildStepError(
+                    f"platform {self.platform.name!r} declares no host_access; add the board's measured "
+                    "access facts to its platform config (or run without platform=) before executing hardware plans"
+                )
         config = HardwareToolchainConfig.for_platform(
             self.platform,
             work_root=self.work_root,

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -748,7 +748,9 @@ class VivadoOverlayStageTask(OverlayStageTask):
     vivado: str = "vivado"
     vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
-    dau_core_root: Path
+    # sourced from the composed host group (host=hosts/<name>) by the task
+    # config; a direct dau_core_root=... override wins
+    dau_core_root: Path | None = None
     dau_artifact_bundle: Path | None = None
     overlay_tcl: Path = Path("scripts/dau_overlay.tcl")
     artifact_stem: str = "dau-vivado"
@@ -768,7 +770,7 @@ class VivadoOverlayStageTask(OverlayStageTask):
     def stage_steps(self):
         return stage_vivado_overlay_plan(
             self._toolchain_config(),
-            dau_core_root=self.dau_core_root,
+            dau_core_root=self._required_root("dau_core_root"),
             source_shell_root=self.source_shell_root,
             dau_artifact_bundle=self.dau_artifact_bundle,
             artifact_stem=self.artifact_stem,
@@ -801,20 +803,30 @@ class VivadoOverlayStageTask(OverlayStageTask):
             return ("identity",)
         return tuple(operator for operator in self.operator.split(",") if operator) or ("identity",)
 
+    def _required_root(self, field_name: str) -> Path:
+        value = getattr(self, field_name)
+        if value is None:
+            raise BuildStepError(f"{field_name} is required: select host=hosts/<name> (a host config group entry) or set {field_name}=...")
+        return value
+
 
 class VivadoProjectStageTask(VivadoOverlayStageTask):
     task_name: ClassVar[str] = "stage-vivado-project"
     source_shell_root: Path
-    dau_driver_root: Path
+    dau_driver_root: Path | None = None
     dau_utils_root: Path | None = None
     project_manifest_path: Path | None = None
+    # the task name the manifest's replayable stage_command records; callers
+    # whose own task overlay composes an injected overlay definition set
+    # their task's name so replay re-composes the injection
+    stage_task_name: str | None = None
 
     def stage_steps(self):
         return stage_vivado_project_plan(
             self._toolchain_config(),
             source_shell_root=self.source_shell_root,
-            dau_core_root=self.dau_core_root,
-            dau_driver_root=self.dau_driver_root,
+            dau_core_root=self._required_root("dau_core_root"),
+            dau_driver_root=self._required_root("dau_driver_root"),
             dau_utils_root=self.dau_utils_root,
             dau_artifact_bundle=self.dau_artifact_bundle,
             artifact_stem=self.artifact_stem,
@@ -832,6 +844,7 @@ class VivadoProjectStageTask(VivadoOverlayStageTask):
             vivado_log_path=self.vivado_log_path,
             vivado_settings=self.vivado_settings,
             overlay_definition=self.overlay_definition,
+            stage_task_name=self.stage_task_name,
         )
 
 
@@ -1021,22 +1034,36 @@ class BuildVivadoArtifactsTask(BuildOverlayArtifactsTask):
 
 class HardwarePlanTask(BuildCallableModel):
     # the plan is the composed `plan` group option (a HardwarePlan model that
-    # owns its own required fields); the task holds the shared toolchain config
+    # owns its own required fields); the task holds the shared toolchain
+    # config. Hardware access (endpoint identity, BDFs, runtime-PM patterns,
+    # JTAG cable) composes from the `platform=` group's host_access when
+    # given; explicit task fields override it; with neither, the model
+    # defaults (the proven dpv1 bench values) apply.
     plan: Any = None
+    platform: Any = None
     work_root: Path
     bitstream: Path | None = None
     vivado: str = "vivado"
     vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
     openfpgaloader: str = "openFPGALoader"
-    jtag_cable: str = "digilent_hs2"
-    endpoint_bdf: str = "0000:04:00.0"
+    jtag_cable: str | None = None
+    endpoint_bdf: str | None = None
+    expected_endpoint_id: str | None = None
+    runtime_pm_executable: str | None = None
+    runtime_pm_patterns: tuple[str, ...] | None = None
+    rescan_bdfs: tuple[str, ...] | None = None
     execute: bool = False
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
         plan = self._plan()
-        config = HardwareToolchainConfig(
+        if self.execute and self.platform is not None:
+            from dau_build.platforms import require_measured
+
+            require_measured(self.platform)
+        config = HardwareToolchainConfig.for_platform(
+            self.platform,
             work_root=self.work_root,
             vivado_executable=self.vivado,
             vivado_invocation=self.vivado_invocation,
@@ -1045,6 +1072,10 @@ class HardwarePlanTask(BuildCallableModel):
             openfpgaloader_executable=self.openfpgaloader,
             jtag_cable=self.jtag_cable,
             endpoint_bdf=self.endpoint_bdf,
+            expected_endpoint_id=self.expected_endpoint_id,
+            runtime_pm_executable=self.runtime_pm_executable,
+            runtime_pm_patterns=self.runtime_pm_patterns,
+            rescan_bdfs=self.rescan_bdfs,
         )
         plan_result = plan.compose(config)
         if self.execute:

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -6,6 +6,7 @@ defaults:
   - optional step: null
   - optional platform: null
   - optional board: null
+  - optional host: null
   - optional backend: null
   - optional driver: null
   - optional memory: null

--- a/dau_build/config/plan/plans/flash.yaml
+++ b/dau_build/config/plan/plans/flash.yaml
@@ -1,6 +1,6 @@
 # @package plan
 _target_: dau_build.hardware_plan.FlashPlan
 name: flash
-dau_utils_root: null
+dau_utils_root: ${oc.select:host.dau_utils_root,null}
 python: python3
 vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh

--- a/dau_build/config/plan/plans/local-build-and-program.yaml
+++ b/dau_build/config/plan/plans/local-build-and-program.yaml
@@ -1,9 +1,11 @@
 # @package plan
 _target_: dau_build.hardware_plan.LocalBuildAndProgramPlan
 name: local-build-and-program
-dau_core_root: ???
+# sourced from the composed host group (host=hosts/<name>); direct
+# plan.<field>=... overrides win
+dau_core_root: ${oc.select:host.dau_core_root,null}
 source_shell_root: null
-dau_utils_root: null
+dau_utils_root: ${oc.select:host.dau_utils_root,null}
 overlay_tcl: scripts/dau_overlay.tcl
 smoke_command: null
 python: python3

--- a/dau_build/config/plan/plans/validate-bitstream.yaml
+++ b/dau_build/config/plan/plans/validate-bitstream.yaml
@@ -2,5 +2,5 @@
 _target_: dau_build.hardware_plan.ValidateBitstreamPlan
 name: validate-bitstream
 smoke_command: null
-dau_utils_root: null
+dau_utils_root: ${oc.select:host.dau_utils_root,null}
 python: python3

--- a/dau_build/config/platform/platforms/dau/dpv1.yaml
+++ b/dau_build/config/platform/platforms/dau/dpv1.yaml
@@ -75,6 +75,28 @@ budget:
   ff: 242600
   bram36: 335
   dsp: 740
+# how the bench host reaches the board: the proven endpoint identity,
+# the Thunderbolt bridge chain rescanned bottom-up after reprogramming, the
+# runtime-PM device patterns held during hardware sessions, and the JTAG cable
+host_access:
+  _target_: dau_build.platforms.HostAccess
+  pci_id: "10ee:7011"
+  endpoint_bdf: "0000:04:00.0"
+  rescan_bdfs:
+    - "0000:03:01.0"
+    - "0000:02:00.0"
+    - "0000:00:0d.3"
+    - "0000:00:0d.2"
+    - "0000:00:0d.0"
+    - "0000:00:07.2"
+    - "0000:00:07.0"
+  runtime_pm_patterns:
+    - Thunderbolt
+    - JHL
+    - "10ee:7011"
+    - Xilinx
+  runtime_pm_executable: dau-utils-pci-runtime-pm
+  jtag_cable: digilent_hs2
 memory:
   _target_: dau_build.platforms.PlatformMemory
   kind: ddr3

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -4,12 +4,20 @@ _target_: dau_build.build_steps.HardwarePlanTask
 # the plan is the composed plan group; select+configure with
 # plan=plans/local-build-and-program plan.dau_core_root=... plan.smoke_command=...
 plan: ${oc.select:plan,null}
+# hardware access composes from the platform group's host_access
+# (platform=platforms/<vendor>/<board>); the explicit fields below override
+# it, and with neither the model defaults (the proven dpv1 bench values) apply
+platform: ${oc.select:platform,null}
 work_root: ???
 bitstream: null
 vivado: vivado
 vivado_invocation: standard
 vivado_mount_root: null
 openfpgaloader: openFPGALoader
-jtag_cable: digilent_hs2
-endpoint_bdf: "0000:04:00.0"
+jtag_cable: null
+endpoint_bdf: null
+expected_endpoint_id: null
+runtime_pm_executable: null
+runtime_pm_patterns: null
+rescan_bdfs: null
 execute: false

--- a/dau_build/config/task/tasks/stage/stage-vivado-overlay.yaml
+++ b/dau_build/config/task/tasks/stage/stage-vivado-overlay.yaml
@@ -8,7 +8,9 @@ bitstream: null
 vivado: vivado
 vivado_invocation: standard
 vivado_mount_root: null
-dau_core_root: ???
+# sourced from the composed host group (host=hosts/<name>); a direct
+# dau_core_root=... override wins
+dau_core_root: ${oc.select:host.dau_core_root,null}
 dau_artifact_bundle: null
 overlay_tcl: scripts/dau_overlay.tcl
 artifact_stem: dau-vivado

--- a/dau_build/config/task/tasks/stage/stage-vivado-project.yaml
+++ b/dau_build/config/task/tasks/stage/stage-vivado-project.yaml
@@ -8,9 +8,11 @@ bitstream: null
 vivado: vivado
 vivado_invocation: standard
 vivado_mount_root: null
-dau_core_root: ???
-dau_driver_root: ???
-dau_utils_root: null
+# sourced from the composed host group (host=hosts/<name>); direct
+# <field>=... overrides win
+dau_core_root: ${oc.select:host.dau_core_root,null}
+dau_driver_root: ${oc.select:host.dau_driver_root,null}
+dau_utils_root: ${oc.select:host.dau_utils_root,null}
 dau_artifact_bundle: null
 overlay_tcl: scripts/dau_overlay.tcl
 artifact_stem: dau-vivado
@@ -27,4 +29,7 @@ timing_summary_path: reports/dau_timing_summary.rpt
 vivado_log_path: vivado.log
 vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh
 overlay_definition: null
+# the task name the recorded stage_command replays; set to the caller's
+# injecting task overlay when overlay_definition is composed by it
+stage_task_name: null
 execute: false

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -78,6 +78,29 @@ class HardwareToolchainConfig(BaseModel):
     jtag_cable: str = "digilent_hs2"
     endpoint_bdf: str = "0000:04:00.0"
     expected_endpoint_id: str = DPV1_PCI_ID
+    rescan_bdfs: tuple[str, ...] = PCI_RESCAN_BDFS
+
+    @classmethod
+    def for_platform(cls, platform, *, work_root: Path, **overrides) -> "HardwareToolchainConfig":
+        """Compose the toolchain config from a registered platform's
+        ``host_access`` (board/host config, not code defaults). Explicit
+        keyword overrides win; a platform without ``host_access`` keeps the
+        model defaults."""
+        access = getattr(platform, "host_access", None)
+        values: dict = {}
+        if access is not None:
+            values = {
+                "expected_endpoint_id": access.pci_id,
+                "endpoint_bdf": access.endpoint_bdf,
+                "jtag_cable": access.jtag_cable,
+                "runtime_pm_executable": access.runtime_pm_executable,
+            }
+            if access.rescan_bdfs:
+                values["rescan_bdfs"] = access.rescan_bdfs
+            if access.runtime_pm_patterns:
+                values["runtime_pm_patterns"] = access.runtime_pm_patterns
+        values.update({key: value for key, value in overrides.items() if value is not None})
+        return cls(work_root=work_root, **values)
 
     @property
     def project_tcl(self) -> Path:
@@ -108,7 +131,7 @@ def build_and_program_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, .
         vivado_build_step(config),
         jtag_detect_step(config),
         program_volatile_step(config),
-        pci_rescan_step(),
+        pci_rescan_step(config.rescan_bdfs),
         lspci_endpoint_step(config),
     )
 
@@ -118,7 +141,7 @@ def recovery_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, ...]:
         thunderbolt_hold_step(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
-        pci_rescan_step(),
+        pci_rescan_step(config.rescan_bdfs),
         lspci_endpoint_step(config),
     )
 
@@ -152,7 +175,7 @@ def local_build_and_program_plan(
         jtag_detect_step(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
-        pci_rescan_step(),
+        pci_rescan_step(config.rescan_bdfs),
         lspci_endpoint_step(config),
         *_smoke_steps(smoke_command),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
@@ -239,6 +262,7 @@ def stage_vivado_project_plan(
     vivado_log_path: Path = Path("vivado.log"),
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"),
     overlay_definition: VivadoOverlayDefinition | None = None,
+    stage_task_name: str | None = None,
 ) -> tuple[ToolStep, ...]:
     artifacts = generate_vivado_project_generation_artifacts(
         VivadoProjectGenerationRequest(
@@ -267,6 +291,7 @@ def stage_vivado_project_plan(
             vivado_invocation=config.vivado_invocation,
             vivado_mount_root=config.vivado_mount_root,
             overlay_definition=overlay_definition,
+            **({} if stage_task_name is None else {"stage_task_name": stage_task_name}),
         )
     )
     backend_artifacts = artifacts.backend_artifacts
@@ -301,7 +326,7 @@ def validate_bitstream_plan(
         jtag_detect_step(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
-        pci_rescan_step(),
+        pci_rescan_step(config.rescan_bdfs),
         lspci_endpoint_step(config),
         *_smoke_steps(smoke_command),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
@@ -527,7 +552,9 @@ def _runtime_pm_argv(config: HardwareToolchainConfig, mode: str) -> tuple[str, .
     return tuple(argv)
 
 
-def _lspci_endpoint_script(config: HardwareToolchainConfig, bridge_bdfs: Sequence[str] = PCI_RESCAN_BDFS) -> str:
+def _lspci_endpoint_script(config: HardwareToolchainConfig, bridge_bdfs: Sequence[str] | None = None) -> str:
+    if bridge_bdfs is None:
+        bridge_bdfs = config.rescan_bdfs
     expected_id = shlex.quote(config.expected_endpoint_id.lower())
     expected_slot = shlex.quote(config.lspci_slot)
     retry_rescan = _pci_rescan_script(bridge_bdfs)
@@ -676,7 +703,9 @@ class ValidateBitstreamPlan(HardwarePlan):
 
 class LocalBuildAndProgramPlan(HardwarePlan):
     name: str = "local-build-and-program"
-    dau_core_root: Path
+    # sourced from the composed host group (host=hosts/<name>) by the plan
+    # config; a direct plan.dau_core_root=... override wins
+    dau_core_root: Path | None = None
     source_shell_root: Path | None = None
     dau_utils_root: Path | None = None
     overlay_tcl: Path = Path("scripts/dau_overlay.tcl")
@@ -686,6 +715,8 @@ class LocalBuildAndProgramPlan(HardwarePlan):
     overlay_definition: VivadoOverlayDefinition | None = None
 
     def compose(self, config):
+        if self.dau_core_root is None:
+            raise ValueError("dau_core_root is required: select host=hosts/<name> (a host config group entry) or set plan.dau_core_root=...")
         return local_build_and_program_plan(
             config,
             dau_core_root=self.dau_core_root,

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -94,11 +94,11 @@ class HardwareToolchainConfig(BaseModel):
                 "endpoint_bdf": access.endpoint_bdf,
                 "jtag_cable": access.jtag_cable,
                 "runtime_pm_executable": access.runtime_pm_executable,
+                # authoritative including empty (global rescan only / no
+                # runtime-PM holds) — never silently the dpv1 defaults
+                "rescan_bdfs": access.rescan_bdfs,
+                "runtime_pm_patterns": access.runtime_pm_patterns,
             }
-            if access.rescan_bdfs:
-                values["rescan_bdfs"] = access.rescan_bdfs
-            if access.runtime_pm_patterns:
-                values["runtime_pm_patterns"] = access.runtime_pm_patterns
         values.update({key: value for key, value in overrides.items() if value is not None})
         return cls(work_root=work_root, **values)
 

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -152,8 +152,10 @@ class HostAccess(BaseModel):
 
     pci_id: str
     endpoint_bdf: str
-    rescan_bdfs: tuple[str, ...] = ()
-    runtime_pm_patterns: tuple[str, ...] = ()
+    # explicit, not defaulted: an empty tuple is meaningful (global rescan
+    # only / no runtime-PM holds), so each board states its own values
+    rescan_bdfs: tuple[str, ...]
+    runtime_pm_patterns: tuple[str, ...]
     runtime_pm_executable: str = "dau-utils-pci-runtime-pm"
     jtag_cable: str = "digilent_hs2"
 

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -144,6 +144,27 @@ class PlatformMemory(BaseModel):
         return value
 
 
+class HostAccess(BaseModel):
+    """How the bench host reaches the board: the PCI identity/topology the
+    hardware plans probe and the programming cable. These are measured
+    bench facts (BDFs, bridge rescan order, runtime-PM device patterns) —
+    board/host configuration, not code defaults."""
+
+    pci_id: str
+    endpoint_bdf: str
+    rescan_bdfs: tuple[str, ...] = ()
+    runtime_pm_patterns: tuple[str, ...] = ()
+    runtime_pm_executable: str = "dau-utils-pci-runtime-pm"
+    jtag_cable: str = "digilent_hs2"
+
+    @field_validator("pci_id", "endpoint_bdf")
+    @classmethod
+    def _nonempty(cls, value: str, info) -> str:
+        if not value:
+            raise ValueError(f"host access {info.field_name} must be non-empty")
+        return value
+
+
 class PlatformDefinition(BaseModel):
     """One target board as data.
 
@@ -154,13 +175,16 @@ class PlatformDefinition(BaseModel):
     that have *not* been measured on the board yet (e.g.
     ``host_link.xdma_personality`` before the XCI delta is audited) —
     ``require_measured`` refuses such boards for real builds while config-only
-    generation stays open."""
+    generation stays open. ``host_access`` carries the bench host's measured
+    access facts (PCI identity, endpoint/bridge BDFs, runtime-PM patterns,
+    JTAG cable) that ``HardwareToolchainConfig.for_platform`` composes from."""
 
     name: str
     part: str
     budget: ResourceBudget
     host_link: HostLink
     memory: PlatformMemory
+    host_access: HostAccess | None = None
     constraints: tuple[str, ...] = ()
     constraints_xdc: str = ""
     lane_placements: tuple[tuple[int, str], ...] = ()

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -632,3 +632,18 @@ def test_host_group_supplies_checkout_roots(tmp_path: Path) -> None:
     )
     with pytest.raises(BuildStepError, match="host=hosts/<name>"):
         bare.stage_steps()
+
+
+def test_hardware_plan_task_refuses_execution_without_host_access() -> None:
+    from dau_build.build_steps import HardwarePlanTask
+    from dau_build.hardware_plan import RecoveryPlan
+    from dau_build.platforms import dpv1_platform
+
+    # a selected platform must state how the host reaches it; the dpv1
+    # defaults are never silently applied to another board
+    accessless = dpv1_platform().model_copy(update={"name": "probe", "host_access": None})
+    with pytest.raises(BuildStepError, match="declares no host_access"):
+        HardwarePlanTask(plan=RecoveryPlan(), work_root=Path("/w"), platform=accessless, execute=True)(None)
+    # plan-only composition stays open (it renders, it does not touch hardware)
+    planned = HardwarePlanTask(plan=RecoveryPlan(), work_root=Path("/w"), platform=accessless)(None)
+    assert "thunderbolt-hold" in planned.message

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -558,3 +558,77 @@ def _write_backend_artifacts(artifacts) -> None:
             continue
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(text, encoding="utf-8")
+
+
+def test_hardware_plan_task_composes_platform_host_access() -> None:
+    from dau_build.build_steps import HardwarePlanTask
+    from dau_build.hardware_plan import RecoveryPlan
+    from dau_build.platforms import PlaceholderPlatformError, dpv1_platform
+
+    default = HardwarePlanTask(plan=RecoveryPlan(), work_root=Path("/repo/projects/vivado-shell"))(None)
+    composed = HardwarePlanTask(plan=RecoveryPlan(), work_root=Path("/repo/projects/vivado-shell"), platform=dpv1_platform())(None)
+    # dpv1's host_access reproduces the default plan text byte-identically
+    assert composed == default
+
+    # explicit task fields override the platform's host_access
+    overridden = HardwarePlanTask(
+        plan=RecoveryPlan(),
+        work_root=Path("/repo/projects/vivado-shell"),
+        platform=dpv1_platform(),
+        jtag_cable="ft4232",
+    )(None)
+    assert "-c ft4232" in overridden.message
+
+    # a placeholder board is refused for hardware-affecting execution
+    placeholder = dpv1_platform().model_copy(update={"name": "probe", "placeholders": ("host_access",)})
+    with pytest.raises(PlaceholderPlatformError, match="host_access"):
+        HardwarePlanTask(plan=RecoveryPlan(), work_root=Path("/w"), platform=placeholder, execute=True)(None)
+
+
+def test_host_group_supplies_checkout_roots(tmp_path: Path) -> None:
+    from hydra.utils import instantiate
+
+    from dau_build.config import compose_config
+
+    overlay = tmp_path / "user-configs"
+    (overlay / "host" / "hosts").mkdir(parents=True)
+    (overlay / "host" / "hosts" / "bench.yaml").write_text(
+        "# @package host\n"
+        "_target_: dau_build.build_config.HostConfig\n"
+        "name: bench\n"
+        "dau_core_root: /repo/dau-core\n"
+        "dau_driver_root: /repo/dau-driver\n"
+        "dau_utils_root: /repo/dau-utils\n"
+    )
+    cfg = compose_config(
+        [
+            "task=tasks/stage/stage-vivado-project",
+            "host=hosts/bench",
+            "model.work_root=/repo/outputs/vivado",
+            "model.source_shell_root=/repo/reference/vivado-shell",
+        ],
+        config_dir=str(overlay),
+    )
+    model = instantiate(cfg.cfg.model)
+    assert model.dau_core_root == Path("/repo/dau-core")
+    assert model.dau_driver_root == Path("/repo/dau-driver")
+    assert model.dau_utils_root == Path("/repo/dau-utils")
+
+    # the composed host also feeds the hardware plans
+    plan_cfg = compose_config(["plan=plans/local-build-and-program", "host=hosts/bench"], config_dir=str(overlay))
+    plan = instantiate(plan_cfg.cfg.plan)
+    assert plan.dau_core_root == Path("/repo/dau-core")
+    assert plan.dau_utils_root == Path("/repo/dau-utils")
+
+    # without a host the roots stay unset and the task demands them at call time
+    bare = instantiate(
+        compose_config(
+            [
+                "task=tasks/stage/stage-vivado-project",
+                "model.work_root=/repo/outputs/vivado",
+                "model.source_shell_root=/repo/reference/vivado-shell",
+            ]
+        ).cfg.model
+    )
+    with pytest.raises(BuildStepError, match="host=hosts/<name>"):
+        bare.stage_steps()

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1352,3 +1352,79 @@ def test_project_command_validation_requires_the_injected_definition_marker(tmp_
         command_plan_path=command_plan_path,
     )
     assert any("overlay-definition" in error for error in stripped)
+
+
+def test_toolchain_config_composes_from_platform_host_access() -> None:
+    from dau_build.platforms import dpv1_platform
+
+    # dpv1's host_access config reproduces the code defaults exactly
+    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == HardwareToolchainConfig(work_root=Path("/w"))
+
+    # a board with different access data changes the plans through config alone
+    other = dpv1_platform().model_copy(deep=True)
+    other.host_access.pci_id = "10ee:9038"
+    other.host_access.endpoint_bdf = "0000:65:00.0"
+    other.host_access.rescan_bdfs = ("0000:64:00.0",)
+    other.host_access.runtime_pm_patterns = ("Acme",)
+    other.host_access.jtag_cable = "ft4232"
+    config = HardwareToolchainConfig.for_platform(other, work_root=Path("/w"))
+    steps = recovery_plan(config)
+    by_name = {step.name: step for step in steps}
+    assert by_name["thunderbolt-hold"].argv == ("dau-utils-pci-runtime-pm", "hold", "--pattern", "Acme")
+    assert "0000:65:00.0/remove" in by_name["remove-endpoint"].argv[2]
+    assert by_name["program-volatile"].argv[1:3] == ("-c", "ft4232")
+    assert "0000:64:00.0" in by_name["pci-rescan"].argv[2]
+    assert "0000:03:01.0" not in by_name["pci-rescan"].argv[2]
+    assert "lspci -Dnn -d 10ee:9038" in by_name["lspci-endpoint"].argv[2]
+    assert "0000:64:00.0" in by_name["lspci-endpoint"].argv[2]
+
+    # explicit overrides beat platform data
+    assert HardwareToolchainConfig.for_platform(other, work_root=Path("/w"), jtag_cable="digilent_hs2").jtag_cable == "digilent_hs2"
+
+
+def test_stage_command_records_the_callers_staging_task(tmp_path: Path) -> None:
+    definition = _acme_overlay_definition()
+    request = VivadoProjectGenerationRequest(
+        source_shell_root=Path("/repo/projects/nite"),
+        work_root=tmp_path,
+        dau_core_root=Path("/repo/dau-core"),
+        dau_driver_root=Path("/repo/dau-driver"),
+        overlay_definition=definition,
+        stage_task_name="tasks/stage/acme-stage-vivado-overlay",
+    )
+    manifest = dict(vivado_backend.vivado_project_generation_manifest(request))
+    manifest_path = request.backend_request.resolved_manifest_path
+    command_plan_path = request.backend_request.resolved_command_plan_path
+
+    # the recorded command replays the caller's (definition-composing) task,
+    # so no hydra-missing marker is needed
+    assert manifest["stage_task"] == "tasks/stage/acme-stage-vivado-overlay"
+    assert "task=tasks/stage/acme-stage-vivado-overlay" in manifest["stage_command"]
+    assert "overlay_definition=???" not in manifest["stage_command"]
+    assert (
+        vivado_backend._validate_project_manifest_commands(
+            project_manifest=manifest, manifest_path=manifest_path, command_plan_path=command_plan_path
+        )
+        == ()
+    )
+
+    # a stage_command rewritten to the packaged default task fails validation
+    tampered = dict(manifest)
+    tampered["stage_command"] = tampered["stage_command"].replace("task=tasks/stage/acme-stage-vivado-overlay", "task=stage-vivado-overlay")
+    errors = vivado_backend._validate_project_manifest_commands(
+        project_manifest=tampered, manifest_path=manifest_path, command_plan_path=command_plan_path
+    )
+    assert any("stage_command" in error for error in errors)
+
+    # the default task name records no stage_task key (byte-identity)
+    default = dict(
+        vivado_backend.vivado_project_generation_manifest(
+            VivadoProjectGenerationRequest(
+                source_shell_root=Path("/repo/projects/nite"),
+                work_root=tmp_path,
+                dau_core_root=Path("/repo/dau-core"),
+                dau_driver_root=Path("/repo/dau-driver"),
+            )
+        )
+    )
+    assert "stage_task" not in default

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1428,3 +1428,37 @@ def test_stage_command_records_the_callers_staging_task(tmp_path: Path) -> None:
         )
     )
     assert "stage_task" not in default
+
+
+def test_host_access_is_explicit_about_bdfs_and_patterns() -> None:
+    from pydantic import ValidationError
+
+    from dau_build.platforms import HostAccess, dpv1_platform
+
+    # rescan_bdfs / runtime_pm_patterns are required: a board must state its
+    # own values (empty is meaningful, silence is not)
+    with pytest.raises(ValidationError):
+        HostAccess(pci_id="10ee:9038", endpoint_bdf="0000:65:00.0")
+
+    # empty tuples are authoritative — never silently the dpv1 defaults
+    bare = dpv1_platform().model_copy(deep=True)
+    bare.host_access.rescan_bdfs = ()
+    bare.host_access.runtime_pm_patterns = ()
+    config = HardwareToolchainConfig.for_platform(bare, work_root=Path("/w"))
+    steps = recovery_plan(config)
+    by_name = {step.name: step for step in steps}
+    assert by_name["thunderbolt-hold"].argv == ("dau-utils-pci-runtime-pm", "hold")
+    assert by_name["pci-rescan"].argv[2] == "echo 1 > /sys/bus/pci/rescan"
+
+
+def test_stage_task_name_must_be_non_empty(tmp_path: Path) -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="stage_task_name"):
+        VivadoProjectGenerationRequest(
+            source_shell_root=Path("/repo/projects/nite"),
+            work_root=tmp_path,
+            dau_core_root=Path("/repo/dau-core"),
+            dau_driver_root=Path("/repo/dau-driver"),
+            stage_task_name="",
+        )

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -205,3 +205,20 @@ def _dpv1_with(**overrides: object) -> PlatformDefinition:
     )
     base.update(overrides)
     return PlatformDefinition(**base)  # type: ignore[arg-type]
+
+
+def test_dpv1_host_access_matches_the_hardware_plan_constants() -> None:
+    from pathlib import Path
+
+    from dau_build.hardware_plan import DPV1_PCI_ID, PCI_RESCAN_BDFS, HardwareToolchainConfig
+
+    access = dpv1_platform().host_access
+    assert access is not None
+    # the config is the composed source; the code constants must not drift
+    assert access.pci_id == DPV1_PCI_ID
+    assert access.rescan_bdfs == PCI_RESCAN_BDFS
+    defaults = HardwareToolchainConfig(work_root=Path("/w"))
+    assert access.endpoint_bdf == defaults.endpoint_bdf
+    assert access.runtime_pm_patterns == defaults.runtime_pm_patterns
+    assert access.runtime_pm_executable == defaults.runtime_pm_executable
+    assert access.jtag_cable == defaults.jtag_cable

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -30,6 +30,10 @@ class VivadoOverlayDefinition(BaseModel):
     lane_placements: tuple[tuple[str, str], ...] = ()
 
 
+# the packaged staging task a recorded stage_command replays by default
+DEFAULT_STAGE_TASK_NAME = "stage-vivado-overlay"
+
+
 class VivadoBackendRequest(BaseModel):
     dau_core_hdl_root: Path
     build_root: Path
@@ -112,6 +116,12 @@ class VivadoProjectGenerationRequest(BaseModel):
     vivado_mount_root: Path | None = None
     plan_executable: str = "dau-build"
     overlay_definition: VivadoOverlayDefinition | None = None
+    # the task name recorded in the replayable stage_command. Callers that
+    # inject an overlay definition through their own task overlay (e.g. a
+    # private dpv1-stage-vivado-overlay) pass that task's name so replaying
+    # the recorded command re-composes the injection instead of demanding a
+    # definition on a flat command line.
+    stage_task_name: str = DEFAULT_STAGE_TASK_NAME
 
     @property
     def dau_core_hdl_root(self) -> Path:
@@ -500,6 +510,11 @@ def vivado_project_generation_manifest(request: VivadoProjectGenerationRequest) 
         # stage_command (which demands the definition) needs the caller's
         # configuration to re-run
         items.append(("overlay_definition", "injected"))
+    if request.stage_task_name != DEFAULT_STAGE_TASK_NAME:
+        # the caller stages through its own task overlay (which composes the
+        # injected definition); record it so the stage_command replays the
+        # caller's task, not the packaged default
+        items.append(("stage_task", request.stage_task_name))
     items.extend(
         (
             ("stage_command", vivado_project_stage_command(request)),
@@ -537,13 +552,14 @@ def vivado_project_stage_command(request: VivadoProjectGenerationRequest) -> str
         overrides.append(("vivado_mount_root", request.vivado_mount_root.resolve(strict=False)))
     if request.dau_artifact_bundle_path is not None:
         overrides.append(("dau_artifact_bundle", request.dau_artifact_bundle_path))
-    if request.overlay_definition is not None:
-        # the injected definition cannot ride a flat command line; mark the
-        # field hydra-missing so replaying the recorded command refuses to
-        # silently re-stage the packaged default overlay instead
+    if request.overlay_definition is not None and request.stage_task_name == DEFAULT_STAGE_TASK_NAME:
+        # the injected definition cannot ride a flat command line; when the
+        # caller did not name its own (definition-composing) staging task,
+        # mark the field hydra-missing so replaying the recorded command
+        # refuses to silently re-stage the packaged default overlay instead
         overrides.append(("overlay_definition", "???"))
     overrides.append(("operator", ",".join(request.operator_set)))
-    return _task_command(request.plan_executable, "stage-vivado-overlay", tuple(overrides))
+    return _task_command(request.plan_executable, request.stage_task_name, tuple(overrides))
 
 
 def vivado_project_build_command(request: VivadoProjectGenerationRequest) -> str:
@@ -830,16 +846,19 @@ def _validate_project_manifest_commands(
         stage_required_options.append(("--vivado-invocation", vivado_invocation))
     if vivado_mount_root:
         stage_required_options.append(("--vivado-mount-root", vivado_mount_root))
-    if project_manifest.get("overlay_definition") == "injected":
-        # the artifacts came from a caller-injected overlay definition; the
-        # recorded stage_command must demand it (hydra-missing) rather than
-        # silently re-stage the packaged default overlay
+    stage_task = project_manifest.get("stage_task", "") or DEFAULT_STAGE_TASK_NAME
+    if project_manifest.get("overlay_definition") == "injected" and stage_task == DEFAULT_STAGE_TASK_NAME:
+        # the artifacts came from a caller-injected overlay definition and no
+        # caller staging task was recorded; the recorded stage_command must
+        # demand the definition (hydra-missing) rather than silently re-stage
+        # the packaged default overlay. A recorded caller task composes the
+        # injection itself, so no marker is required then.
         stage_required_options.append(("--overlay-definition", "???"))
     errors.extend(
         _validate_project_command(
             label="stage_command",
             command=project_manifest.get("stage_command", ""),
-            expected_plan="stage-vivado-overlay",
+            expected_plan=stage_task,
             required_options=tuple(stage_required_options),
         )
     )

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Literal
 
 from ccflow import BaseModel
+from pydantic import field_validator
 
 from dau_build.artifact_bundle import ArtifactBundle, ArtifactBundleError, load_artifact_bundle
 
@@ -122,6 +123,13 @@ class VivadoProjectGenerationRequest(BaseModel):
     # the recorded command re-composes the injection instead of demanding a
     # definition on a flat command line.
     stage_task_name: str = DEFAULT_STAGE_TASK_NAME
+
+    @field_validator("stage_task_name")
+    @classmethod
+    def _stage_task_name_nonempty(cls, value: str) -> str:
+        if not value:
+            raise ValueError("stage_task_name must be non-empty (default: the packaged stage-vivado-overlay task)")
+        return value
 
     @property
     def dau_core_hdl_root(self) -> Path:

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -27,7 +27,7 @@ defaults:
 
 Every group except `callable` is `optional … null`: nothing is selected unless
 overridden. A run selects exactly one of `task=` or `step=` to populate `model`,
-optionally augmented by `spec=`, `board=`, `backend=`, `driver=`, `memory=`, `simulator=`, `platform=`, and `plan=`.
+optionally augmented by `spec=`, `board=`, `backend=`, `driver=`, `memory=`, `simulator=`, `platform=`, `host=`, and `plan=`.
 
 Each option file begins with a `# @package <key>` directive that places its
 content under that top-level key. Tasks and steps use `# @package model`; the
@@ -45,6 +45,7 @@ other groups use their singular key (`# @package board`, etc.).
 | `simulator` | `simulator`    | a `Simulator` (e.g. `VerilatorSimulator`) | The simulator (used by `SimulateTask`).                          |
 | `platform`  | `platform`     | `dau_build.platforms.PlatformDefinition`  | The full physical platform definition.                           |
 | `plan`      | `plan`         | a `HardwarePlan` (e.g. `RecoveryPlan`)    | The hardware-session plan (`HardwarePlanTask`).                  |
+| `host`      | `host`         | `dau_build.build_config.HostConfig`       | The build host's source checkout roots (none packaged).          |
 | `design`    | `design`       | (none packaged)                           | Reserved; registered by extension packages.                      |
 | `callable`  | —              | ccflow registry pointer                   | Fixed evaluator wiring; not normally overridden.                 |
 
@@ -175,9 +176,22 @@ constraint text the shell project generators emit behind their banner),
 implementation hook; empty means the board needs none), and `placeholders`
 (names of hardware-derived values not yet measured on the board —
 `require_measured` refuses placeholder boards for real builds while
-config-only generation stays open). The shell project requests
+config-only generation stays open). `host_access` (`HostAccess`: `pci_id`,
+`endpoint_bdf`, `rescan_bdfs`, `runtime_pm_patterns`,
+`runtime_pm_executable`, `jtag_cable`) carries the bench host's measured
+access facts; `HardwarePlanTask` composes its toolchain config from it when
+`platform=` is selected (explicit task fields override). The shell project requests
 (`MmJobShellRequest`, `MmDdrJobShellRequest`) take a `platform` and default
 to dpv1; `part` defaults from the platform.
+
+## `host`
+
+`host=hosts/<name>` composes `dau_build.build_config.HostConfig` — where the
+build host keeps its source checkouts (`dau_core_root`, `dau_driver_root`,
+`dau_utils_root`). dau-build packages no host options (checkout layouts are
+site-specific); register them from a search-path package or a `--config-dir`
+overlay. The stage tasks and hardware plans interpolate their checkout roots
+from the composed host, and a direct `<field>=...` override always wins.
 
 ## `plan`
 
@@ -188,7 +202,7 @@ pydantic enforces them, rather than a runtime check).
 | Option                          | Model                      | Extra fields                                                                                                                |
 | ------------------------------- | -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `plans/build-and-program`       | `BuildAndProgramPlan`      | —                                                                                                                           |
-| `plans/local-build-and-program` | `LocalBuildAndProgramPlan` | `dau_core_root` (req), `source_shell_root`, `dau_utils_root`, `overlay_tcl`, `smoke_command`, `python`, `vivado_settings`   |
+| `plans/local-build-and-program` | `LocalBuildAndProgramPlan` | `dau_core_root` (from `host=` or `plan.dau_core_root=`), `source_shell_root`, `dau_utils_root`, `overlay_tcl`, `smoke_command`, `python`, `vivado_settings` |
 | `plans/validate-bitstream`      | `ValidateBitstreamPlan`    | `smoke_command`, `dau_utils_root`, `python`                                                                                 |
 | `plans/flash`                   | `FlashPlan`                | `dau_utils_root`, `python`, `vivado_settings`                                                                               |
 | `plans/recovery`                | `RecoveryPlan`             | —                                                                                                                           |


### PR DESCRIPTION
P0 boards-as-registered-configuration: the V5 hardware-access row and the V3-residue host-path/stage-replay rows.

Hardware access stops being dpv1 code defaults:
- `PlatformDefinition.host_access` (`HostAccess`: pci_id, endpoint BDF, bridge rescan BDFs, runtime-PM patterns/executable, JTAG cable); the dpv1 platform config carries the proven bench values, reconciliation-pinned against the code constants. `rescan_bdfs`/`runtime_pm_patterns` are required and copied verbatim - empty is meaningful (global rescan only / no holds), never silently the dpv1 defaults.
- `HardwareToolchainConfig` gains `rescan_bdfs` + `for_platform` (explicit overrides win); the plans thread `config.rescan_bdfs` through pci-rescan and the lspci retry.
- `HardwarePlanTask` composes from the `platform=` group, exposes the access fields as optional overrides, refuses placeholder boards for execution, and refuses executing a selected platform that declares no `host_access`. With neither platform nor overrides the plan texts stay byte-identical to the proven defaults (pinned).

Host checkout roots stop being first-class `???` fields:
- new `host` config group (`HostConfig`: dau_core_root/dau_driver_root/dau_utils_root; none packaged - hosts are site-specific, registered via search-path packages or `--config-dir`). Stage tasks and hardware plans interpolate their roots from the composed host; direct overrides win; a missing root fails at call time with `host=hosts/<name>` guidance.

Recorded stage commands can replay the caller's staging task:
- `VivadoProjectGenerationRequest.stage_task_name` (validated non-empty): a non-default name is recorded as `stage_task` in the project manifest and the recorded `stage_command` replays that task - which composes the injected overlay definition itself, so the hydra-missing marker is skipped; validation accepts the recorded task and still fails a command rewritten to the packaged default. Default-path manifests stay byte-identical.

Suite: 284 passed, 1 skipped (was 276/1 after #115).
