### PR TITLE
Carry composed capability words through the scan-composition walker

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -237,7 +237,12 @@ def _axi_lite_decode_assigns_sv() -> str:
 
 def _identity_registers_instance_sv() -> str:
     """The read-only identity/capability register file that backs the
-    default read path (capability words parameterized at the top)."""
+    default read path (capability words parameterized at the top).
+
+    The caller-supplied ``dau_identity_registers`` module must accept the
+    four capability parameters (register map 0.2) — an older identity
+    block that only knows OPERATOR_BITMAP rejects the parameter override
+    at elaboration."""
     return """    dau_identity_registers #(
         .OPERATOR_BITMAP(OPERATOR_BITMAP),
         .LANE_COUNT(LANE_COUNT),

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -91,7 +91,14 @@ class ScanComposition(BaseModel):
     partitioner: TileInstance | None = None
     burst_beats: int = 32
     addr_width: int = 32
-    operator_bitmap: int = 0x0000_001E
+    # capability words the identity block advertises (register map 0.2).
+    # These are caller-computed data — the walker never guesses them: the
+    # bitmaps default to zero ("advertise nothing") so a composition only
+    # advertises what its composer declared, and the lane-count word is
+    # always the composed lane count.
+    operator_bitmap: int = 0x0000_0000
+    host_opcode_bitmap: int = 0x0000_0000
+    sort_capacity: int = 0
     registers: RegisterLayout = RegisterLayout()
 
     def model_post_init(self, context) -> None:
@@ -230,9 +237,12 @@ def _axi_lite_decode_assigns_sv() -> str:
 
 def _identity_registers_instance_sv() -> str:
     """The read-only identity/capability register file that backs the
-    default read path (OPERATOR_BITMAP parameterized at the top)."""
+    default read path (capability words parameterized at the top)."""
     return """    dau_identity_registers #(
-        .OPERATOR_BITMAP(OPERATOR_BITMAP)
+        .OPERATOR_BITMAP(OPERATOR_BITMAP),
+        .LANE_COUNT(LANE_COUNT),
+        .HOST_OPCODE_BITMAP(HOST_OPCODE_BITMAP),
+        .SORT_CAPACITY(SORT_CAPACITY)
     ) identity_registers (
         .addr({4'h0, selected_addr[11:0]}),
         .wen(1'b0),
@@ -717,7 +727,10 @@ def generate_scan_composition_top_sv(
 // lane(s) behind the DAU stream-job register contract with the NoC lane
 // register block. Plain-Verilog top (BD module references require it).
 module {module_name} #(
-    parameter [31:0] OPERATOR_BITMAP = 32'h{composition.operator_bitmap:08X}
+    parameter [31:0] OPERATOR_BITMAP = 32'h{composition.operator_bitmap:08X},
+    parameter [31:0] LANE_COUNT = 32'd{num_lanes},
+    parameter [31:0] HOST_OPCODE_BITMAP = 32'h{composition.host_opcode_bitmap:08X},
+    parameter [31:0] SORT_CAPACITY = 32'd{composition.sort_capacity}
 ) (
     (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 s_axi_aclk CLK" *)
     (* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF S_AXI:M_AXI, ASSOCIATED_RESET s_axi_aresetn" *)

--- a/dau_build/tests/fixtures/scan_composition/bar_noc_4.v
+++ b/dau_build/tests/fixtures/scan_composition/bar_noc_4.v
@@ -5,7 +5,10 @@
 // lane(s) behind the DAU stream-job register contract with the NoC lane
 // register block. Plain-Verilog top (BD module references require it).
 module dau_mm_bar_noc_job #(
-    parameter [31:0] OPERATOR_BITMAP = 32'h0000001E
+    parameter [31:0] OPERATOR_BITMAP = 32'h00000000,
+    parameter [31:0] LANE_COUNT = 32'd4,
+    parameter [31:0] HOST_OPCODE_BITMAP = 32'h00000000,
+    parameter [31:0] SORT_CAPACITY = 32'd0
 ) (
     (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 s_axi_aclk CLK" *)
     (* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF S_AXI:M_AXI, ASSOCIATED_RESET s_axi_aresetn" *)
@@ -367,7 +370,10 @@ module dau_mm_bar_noc_job #(
     end
 
     dau_identity_registers #(
-        .OPERATOR_BITMAP(OPERATOR_BITMAP)
+        .OPERATOR_BITMAP(OPERATOR_BITMAP),
+        .LANE_COUNT(LANE_COUNT),
+        .HOST_OPCODE_BITMAP(HOST_OPCODE_BITMAP),
+        .SORT_CAPACITY(SORT_CAPACITY)
     ) identity_registers (
         .addr({4'h0, selected_addr[11:0]}),
         .wen(1'b0),

--- a/dau_build/tests/fixtures/scan_composition/sorted_scan.v
+++ b/dau_build/tests/fixtures/scan_composition/sorted_scan.v
@@ -5,7 +5,10 @@
 // lane(s) behind the DAU stream-job register contract with the NoC lane
 // register block. Plain-Verilog top (BD module references require it).
 module dau_mm_sorted_scan_job #(
-    parameter [31:0] OPERATOR_BITMAP = 32'h0000001E
+    parameter [31:0] OPERATOR_BITMAP = 32'h00000000,
+    parameter [31:0] LANE_COUNT = 32'd4,
+    parameter [31:0] HOST_OPCODE_BITMAP = 32'h00000000,
+    parameter [31:0] SORT_CAPACITY = 32'd16
 ) (
     (* X_INTERFACE_INFO = "xilinx.com:signal:clock:1.0 s_axi_aclk CLK" *)
     (* X_INTERFACE_PARAMETER = "ASSOCIATED_BUSIF S_AXI:M_AXI, ASSOCIATED_RESET s_axi_aresetn" *)
@@ -371,7 +374,10 @@ module dau_mm_sorted_scan_job #(
     end
 
     dau_identity_registers #(
-        .OPERATOR_BITMAP(OPERATOR_BITMAP)
+        .OPERATOR_BITMAP(OPERATOR_BITMAP),
+        .LANE_COUNT(LANE_COUNT),
+        .HOST_OPCODE_BITMAP(HOST_OPCODE_BITMAP),
+        .SORT_CAPACITY(SORT_CAPACITY)
     ) identity_registers (
         .addr({4'h0, selected_addr[11:0]}),
         .wen(1'b0),

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -50,6 +50,7 @@ def _sorted_scan_composition() -> ScanComposition:
             module="dau_int32_range_partitioner",
             config={"cfg_splitters": "{32'h0000001E, 32'h00000014, 32'h0000000A}"},
         ),
+        sort_capacity=16,  # caller-computed capability data (the sorter's batch row capacity)
     )
 
 
@@ -61,6 +62,27 @@ def test_bar_noc_top_matches_golden() -> None:
 
 def test_sorted_scan_top_matches_golden() -> None:
     assert generate_scan_composition_top_sv(_sorted_scan_composition()) == (_FIXTURES / "sorted_scan.v").read_text()
+
+
+def test_capability_words_are_caller_data_and_default_to_unadvertised() -> None:
+    """The identity block advertises exactly what the composer computed:
+    the bitmaps default to zero (never a static advertisement), the lane
+    count is always the composed lane count, and non-default words flow
+    into the top parameters and the identity instance."""
+    default = generate_scan_composition_top_sv(_bar_noc_composition())
+    assert "    parameter [31:0] OPERATOR_BITMAP = 32'h00000000,\n" in default
+    assert "    parameter [31:0] LANE_COUNT = 32'd4,\n" in default
+    assert "    parameter [31:0] HOST_OPCODE_BITMAP = 32'h00000000,\n" in default
+    assert "    parameter [31:0] SORT_CAPACITY = 32'd0\n" in default
+
+    composed = generate_scan_composition_top_sv(
+        _bar_noc_composition().model_copy(update={"operator_bitmap": 0x1E, "host_opcode_bitmap": 0x20, "sort_capacity": 16})
+    )
+    assert "    parameter [31:0] OPERATOR_BITMAP = 32'h0000001E,\n" in composed
+    assert "    parameter [31:0] HOST_OPCODE_BITMAP = 32'h00000020,\n" in composed
+    assert "    parameter [31:0] SORT_CAPACITY = 32'd16\n" in composed
+    for parameter in ("OPERATOR_BITMAP", "LANE_COUNT", "HOST_OPCODE_BITMAP", "SORT_CAPACITY"):
+        assert f"        .{parameter}({parameter}),\n" in composed or f"        .{parameter}({parameter})\n" in composed
 
 
 def test_generated_by_names_the_banner_only() -> None:


### PR DESCRIPTION
The public data surface for the V9+V10 capability-truth project (dau-core#62 carries the contract model; the wall holds — the walker consumes caller-computed words as plain data and imports nothing private).

## What

- `ScanComposition` gains `host_opcode_bitmap: int = 0` and `sort_capacity: int = 0` beside `operator_bitmap`.
- The generated top parameterizes and forwards `OPERATOR_BITMAP` / `LANE_COUNT` / `HOST_OPCODE_BITMAP` / `SORT_CAPACITY` into `dau_identity_registers` (register map 0.2 words at `0x0028` / `0x00C0` / `0x00C4` / `0x00C8`; they ride the existing default-read fallthrough to the identity block, no read-mux changes).
- **Default change, deliberate**: `operator_bitmap` flips `0x1E -> 0x0`. The static `0x1E` default was exactly the V9 over-advertisement — a composition now advertises only what its composer computed (dau computes the words from `dau_core.capability_contract` and passes them in). `LANE_COUNT` is always the composed lane count.

## Goldens (deliberate ABI-visible update, same commit)

`bar_noc_4.v` / `sorted_scan.v`: parameter block grows the three capability words, identity instance forwards them, `OPERATOR_BITMAP` default now `32'h00000000`; `sorted_scan.v` additionally pins a composer-declared `sort_capacity=16`.

## Downstream arming

dau CI runs the released 0.6.0 (old single-parameter emission). dau feature-detects `host_opcode_bitmap` in `ScanComposition.model_fields`; the composition-path capability emission and its goldens arm on the next dau-build release.

## Tests

288 passed / 1 skipped (was 287/1): +1 pinning caller-data words, zero-advertise defaults, and parameter/instance emission.
