### PR TITLE
Add platform job_clock_mhz to clock-convert job logic behind the XDMA

### DIFF
--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -280,7 +280,8 @@ def _job_clock_domain_tcl(request) -> str:
     return f"""
 # job clock domain: job logic runs at {job_mhz} MHz behind the XDMA's
 # {axi_mhz} MHz axi_aclk (platform job_clock_mhz) — MMCM-derived job clock,
-# reset synchronized by proc_sys_reset, clock conversion in the smartconnects
+# reset synchronized by proc_sys_reset (its ext_reset_in polarity propagates
+# from axi_aresetn's ACTIVE_LOW), clock conversion in the smartconnects
 set job_clk [create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz job_clk]
 set_property -dict [list \\
     CONFIG.PRIM_SOURCE {{No_buffer}} \\
@@ -289,7 +290,6 @@ set_property -dict [list \\
     CONFIG.USE_RESET {{false}} \\
 ] $job_clk
 set job_rst [create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset job_rst]
-set_property CONFIG.C_EXT_RESET_HIGH {{0}} $job_rst
 connect_bd_net [get_bd_pins xdma_0/axi_aclk] [get_bd_pins job_clk/clk_in1]
 connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins job_rst/slowest_sync_clk]
 connect_bd_net [get_bd_pins job_clk/locked] [get_bd_pins job_rst/dcm_locked]
@@ -385,6 +385,9 @@ def mm_ddr_job_shell_project_tcl(request: MmDdrJobShellRequest) -> str:
     )
     convert = request.platform.job_clock_mhz is not None
     job_domain = _job_clock_domain_tcl(request) if convert else ""
+    # the XADC rides axi_aclk; its DCLK setting follows the personality
+    # (125 on dpv1, 250 on a Gen2 x8 personality)
+    xadc_dclk_mhz = request.platform.host_link.xdma_personality.axi_clock_mhz()
     smc_clocks = "3" if convert else "2"
     smc_lite_config = "CONFIG.NUM_SI {1} CONFIG.NUM_MI {2} CONFIG.NUM_CLKS {2}" if convert else "CONFIG.NUM_SI {1} CONFIG.NUM_MI {2}"
     top_clk_sink = "" if convert else f" \\\n    [get_bd_pins {request.top_module}_0/s_axi_aclk]"
@@ -425,7 +428,7 @@ set xadc_0 [create_bd_cell -type ip -vlnv xilinx.com:ip:xadc_wiz xadc_0]
 set_property -dict [list \\
     CONFIG.INTERFACE_SELECTION {{Enable_AXI}} \\
     CONFIG.ENABLE_TEMP_BUS {{true}} \\
-    CONFIG.DCLK_FREQUENCY {{125}} \\
+    CONFIG.DCLK_FREQUENCY {{{xadc_dclk_mhz}}} \\
     CONFIG.ADC_CONVERSION_RATE {{1000}} \\
     CONFIG.ENABLE_RESET {{false}} \\
 ] $xadc_0

--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -267,6 +267,36 @@ set dau_job [create_bd_cell -type module -reference {request.top_module} {reques
 """
 
 
+def _job_clock_domain_tcl(request) -> str:
+    """The job clock domain, emitted when the platform sets ``job_clock_mhz``:
+    an MMCM (clk_wiz) derives the job clock from the XDMA's ``axi_aclk`` (7-series
+    has no BUFGCE_DIV and the XDMA offers no divided user clock), and
+    proc_sys_reset synchronizes ``axi_aresetn`` into the job domain. The AXI
+    clock conversion itself happens inside the smartconnects (the structure the
+    dpv1 DDR shell already proves against the memory controller's ui_clk)."""
+    platform = request.platform
+    job_mhz = platform.job_clock_mhz
+    axi_mhz = platform.host_link.xdma_personality.axi_clock_mhz()
+    return f"""
+# job clock domain: job logic runs at {job_mhz} MHz behind the XDMA's
+# {axi_mhz} MHz axi_aclk (platform job_clock_mhz) — MMCM-derived job clock,
+# reset synchronized by proc_sys_reset, clock conversion in the smartconnects
+set job_clk [create_bd_cell -type ip -vlnv xilinx.com:ip:clk_wiz job_clk]
+set_property -dict [list \\
+    CONFIG.PRIM_SOURCE {{No_buffer}} \\
+    CONFIG.PRIM_IN_FREQ {{{axi_mhz}}} \\
+    CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {{{job_mhz}}} \\
+    CONFIG.USE_RESET {{false}} \\
+] $job_clk
+set job_rst [create_bd_cell -type ip -vlnv xilinx.com:ip:proc_sys_reset job_rst]
+set_property CONFIG.C_EXT_RESET_HIGH {{0}} $job_rst
+connect_bd_net [get_bd_pins xdma_0/axi_aclk] [get_bd_pins job_clk/clk_in1]
+connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins job_rst/slowest_sync_clk]
+connect_bd_net [get_bd_pins job_clk/locked] [get_bd_pins job_rst/dcm_locked]
+connect_bd_net [get_bd_pins xdma_0/axi_aresetn] [get_bd_pins job_rst/ext_reset_in]
+"""
+
+
 def _lane_swizzle_verify_tcl(lane_placements: tuple[tuple[int, str], ...]) -> str:
     """Post-route verification that every swizzled lane landed on its site."""
     swizzle_pairs = " ".join(f"{lane} {channel}" for lane, channel in lane_placements)
@@ -353,7 +383,22 @@ def mm_ddr_job_shell_project_tcl(request: MmDdrJobShellRequest) -> str:
             "# (dpv1) PCIe personality) with DDR staging behind the memory controller."
         ),
     )
-    staging = f"""
+    convert = request.platform.job_clock_mhz is not None
+    job_domain = _job_clock_domain_tcl(request) if convert else ""
+    smc_clocks = "3" if convert else "2"
+    smc_lite_config = "CONFIG.NUM_SI {1} CONFIG.NUM_MI {2} CONFIG.NUM_CLKS {2}" if convert else "CONFIG.NUM_SI {1} CONFIG.NUM_MI {2}"
+    top_clk_sink = "" if convert else f" \\\n    [get_bd_pins {request.top_module}_0/s_axi_aclk]"
+    top_rst_sink = "" if convert else f" \\\n    [get_bd_pins {request.top_module}_0/s_axi_aresetn]"
+    job_wiring = (
+        (
+            f"connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc/aclk2] [get_bd_pins smc_lite/aclk1] "
+            f"[get_bd_pins {request.top_module}_0/s_axi_aclk]\n"
+            f"connect_bd_net [get_bd_pins job_rst/peripheral_aresetn] [get_bd_pins {request.top_module}_0/s_axi_aresetn]\n"
+        )
+        if convert
+        else ""
+    )
+    staging = f"""{job_domain}
 # memory controller from the vendored proven configuration; the .prj owns
 # the DDR3 and sys_clk pin placement
 set mig_0 [create_bd_cell -type ip -vlnv xilinx.com:ip:mig_7series mig_0]
@@ -389,7 +434,7 @@ connect_bd_net [get_bd_pins xadc_0/temp_out] [get_bd_pins mig_0/device_temp_i]
 # one memory-side smartconnect: XDMA (128-bit) and the job master (64-bit)
 # into the controller's 128-bit S_AXI, bridging 125 MHz -> ui_clk
 set smc [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smc]
-set_property -dict [list CONFIG.NUM_SI {{2}} CONFIG.NUM_MI {{1}} CONFIG.NUM_CLKS {{2}}] $smc
+set_property -dict [list CONFIG.NUM_SI {{2}} CONFIG.NUM_MI {{1}} CONFIG.NUM_CLKS {{{smc_clocks}}}] $smc
 connect_bd_intf_net [get_bd_intf_pins xdma_0/M_AXI] [get_bd_intf_pins smc/S00_AXI]
 connect_bd_intf_net [get_bd_intf_pins {request.top_module}_0/M_AXI] [get_bd_intf_pins smc/S01_AXI]
 connect_bd_intf_net [get_bd_intf_pins smc/M00_AXI] [get_bd_intf_pins mig_0/S_AXI]
@@ -398,19 +443,17 @@ connect_bd_intf_net [get_bd_intf_pins smc/M00_AXI] [get_bd_intf_pins mig_0/S_AXI
 # into a register block; smc_lite mirrors that (pipelined, spec-strict
 # handshakes between the XDMA AXI-Lite master and the module reference)
 set smc_lite [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smc_lite]
-set_property -dict [list CONFIG.NUM_SI {{1}} CONFIG.NUM_MI {{2}}] $smc_lite
+set_property -dict [list {smc_lite_config}] $smc_lite
 connect_bd_intf_net [get_bd_intf_pins xdma_0/M_AXI_LITE] [get_bd_intf_pins smc_lite/S00_AXI]
 connect_bd_intf_net [get_bd_intf_pins smc_lite/M00_AXI] [get_bd_intf_pins {request.top_module}_0/S_AXI]
 connect_bd_intf_net [get_bd_intf_pins smc_lite/M01_AXI] [get_bd_intf_pins xadc_0/s_axi_lite]
 
 connect_bd_net [get_bd_pins xdma_0/axi_aclk] \\
-    [get_bd_pins smc/aclk] [get_bd_pins smc_lite/aclk] [get_bd_pins xadc_0/s_axi_aclk] \\
-    [get_bd_pins {request.top_module}_0/s_axi_aclk]
+    [get_bd_pins smc/aclk] [get_bd_pins smc_lite/aclk] [get_bd_pins xadc_0/s_axi_aclk]{top_clk_sink}
 connect_bd_net [get_bd_pins mig_0/ui_clk] [get_bd_pins smc/aclk1]
 connect_bd_net [get_bd_pins xdma_0/axi_aresetn] \\
-    [get_bd_pins smc/aresetn] [get_bd_pins smc_lite/aresetn] [get_bd_pins xadc_0/s_axi_aresetn] \\
-    [get_bd_pins {request.top_module}_0/s_axi_aresetn]
-
+    [get_bd_pins smc/aresetn] [get_bd_pins smc_lite/aresetn] [get_bd_pins xadc_0/s_axi_aresetn]{top_rst_sink}
+{job_wiring}
 assign_bd_address -offset 0x00000000 -range 0x{request.ddr_bytes:08X} -target_address_space [get_bd_addr_spaces xdma_0/M_AXI] [get_bd_addr_segs mig_0/memmap/memaddr] -force
 assign_bd_address -offset 0x00000000 -range 0x{request.ddr_bytes:08X} -target_address_space [get_bd_addr_spaces {request.top_module}_0/M_AXI] [get_bd_addr_segs mig_0/memmap/memaddr] -force
 assign_bd_address -offset 0x{request.register_window_offset:08X} -range 0x00001000 -target_address_space [get_bd_addr_spaces xdma_0/M_AXI_LITE] [get_bd_addr_segs {request.top_module}_0/S_AXI/*] -force
@@ -464,7 +507,20 @@ def mm_job_shell_project_tcl(request: MmJobShellRequest) -> str:
             "# with BRAM staging at the stream-job contract addresses."
         ),
     )
-    staging = f"""
+    convert = request.platform.job_clock_mhz is not None
+    job_domain = _job_clock_domain_tcl(request) if convert else ""
+    smc_lite_config = "CONFIG.NUM_SI {1} CONFIG.NUM_MI {1} CONFIG.NUM_CLKS {2}" if convert else "CONFIG.NUM_SI {1} CONFIG.NUM_MI {1}"
+    top_clk_sink = "" if convert else f" \\\n    [get_bd_pins {request.top_module}_0/s_axi_aclk]"
+    top_rst_sink = "" if convert else f" \\\n    [get_bd_pins {request.top_module}_0/s_axi_aresetn]"
+    job_wiring = (
+        (
+            f"connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc_lite/aclk1] [get_bd_pins {request.top_module}_0/s_axi_aclk]\n"
+            f"connect_bd_net [get_bd_pins job_rst/peripheral_aresetn] [get_bd_pins {request.top_module}_0/s_axi_aresetn]\n"
+        )
+        if convert
+        else ""
+    )
+    staging = f"""{job_domain}
 set bram_ctrl_in [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl bram_ctrl_in]
 set_property -dict [list CONFIG.DATA_WIDTH {{64}} CONFIG.SINGLE_PORT_BRAM {{1}}] $bram_ctrl_in
 set bram_ctrl_out [create_bd_cell -type ip -vlnv xilinx.com:ip:axi_bram_ctrl bram_ctrl_out]
@@ -495,19 +551,17 @@ connect_bd_intf_net [get_bd_intf_pins dw_out/M_AXI] [get_bd_intf_pins bram_ctrl_
 # into a register block; smc_lite mirrors that (pipelined, spec-strict
 # handshakes between the XDMA AXI-Lite master and the module reference)
 set smc_lite [create_bd_cell -type ip -vlnv xilinx.com:ip:smartconnect smc_lite]
-set_property -dict [list CONFIG.NUM_SI {{1}} CONFIG.NUM_MI {{1}}] $smc_lite
+set_property -dict [list {smc_lite_config}] $smc_lite
 connect_bd_intf_net [get_bd_intf_pins xdma_0/M_AXI_LITE] [get_bd_intf_pins smc_lite/S00_AXI]
 connect_bd_intf_net [get_bd_intf_pins smc_lite/M00_AXI] [get_bd_intf_pins {request.top_module}_0/S_AXI]
 
 connect_bd_net [get_bd_pins xdma_0/axi_aclk] \\
     [get_bd_pins smc/aclk] [get_bd_pins smc_lite/aclk] [get_bd_pins bram_ctrl_in/s_axi_aclk] [get_bd_pins bram_ctrl_out/s_axi_aclk] \\
-    [get_bd_pins dw_in/s_axi_aclk] [get_bd_pins dw_out/s_axi_aclk] \\
-    [get_bd_pins {request.top_module}_0/s_axi_aclk]
+    [get_bd_pins dw_in/s_axi_aclk] [get_bd_pins dw_out/s_axi_aclk]{top_clk_sink}
 connect_bd_net [get_bd_pins xdma_0/axi_aresetn] \\
     [get_bd_pins smc/aresetn] [get_bd_pins smc_lite/aresetn] [get_bd_pins bram_ctrl_in/s_axi_aresetn] [get_bd_pins bram_ctrl_out/s_axi_aresetn] \\
-    [get_bd_pins dw_in/s_axi_aresetn] [get_bd_pins dw_out/s_axi_aresetn] \\
-    [get_bd_pins {request.top_module}_0/s_axi_aresetn]
-
+    [get_bd_pins dw_in/s_axi_aresetn] [get_bd_pins dw_out/s_axi_aresetn]{top_rst_sink}
+{job_wiring}
 assign_bd_address -offset 0x{request.input_buffer_address:08X} -range 0x{request.input_bram_bytes:08X} -target_address_space [get_bd_addr_spaces xdma_0/M_AXI] [get_bd_addr_segs bram_ctrl_in/S_AXI/*] -force
 assign_bd_address -offset 0x{request.output_buffer_address:08X} -range 0x{request.output_bram_bytes:08X} -target_address_space [get_bd_addr_spaces xdma_0/M_AXI] [get_bd_addr_segs bram_ctrl_out/S_AXI/*] -force
 assign_bd_address -offset 0x{request.register_window_offset:08X} -range 0x00001000 -target_address_space [get_bd_addr_spaces xdma_0/M_AXI_LITE] [get_bd_addr_segs {request.top_module}_0/S_AXI/*] -force

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -49,6 +49,15 @@ class XdmaPersonality(BaseModel):
             raise ValueError(f"cannot parse pcie lane width from personality: {width!r}")
         return int(width[1:])
 
+    def axi_clock_mhz(self) -> int:
+        """The XDMA ``axi_aclk`` frequency in MHz from ``axisten_freq`` —
+        the clock the endpoint presents its AXI interfaces on (125 on dpv1's
+        Gen2 x4 personality; the IP forces 250 at Gen2 x8/128-bit)."""
+        freq = self.params.get("axisten_freq", "")
+        if not freq.isdigit():
+            raise ValueError(f"cannot parse axi clock from personality axisten_freq: {freq!r}")
+        return int(freq)
+
 
 class ResourceBudget(BaseModel):
     """Placeable capacity of a platform, in ``ResourceEnvelope`` units."""
@@ -179,7 +188,15 @@ class PlatformDefinition(BaseModel):
     ``require_measured`` refuses such boards for real builds while config-only
     generation stays open. ``host_access`` carries the bench host's measured
     access facts (PCI identity, endpoint/bridge BDFs, runtime-PM patterns,
-    JTAG cable) that ``HardwareToolchainConfig.for_platform`` composes from."""
+    JTAG cable) that ``HardwareToolchainConfig.for_platform`` composes from.
+
+    ``job_clock_mhz`` decouples the job logic's clock from the XDMA's
+    ``axi_aclk``: when set, the shell generators derive a job clock at that
+    frequency from ``axi_aclk`` (MMCM) and clock-convert both the register
+    aperture and the memory path in the smartconnects, so a personality
+    that forces a faster ``axi_aclk`` (250 MHz at Gen2 x8) never drags the
+    proven job-logic timing closure with it. ``None`` (the dpv1 default)
+    keeps the job logic on ``axi_aclk`` unchanged."""
 
     name: str
     part: str
@@ -191,6 +208,7 @@ class PlatformDefinition(BaseModel):
     constraints_xdc: str = ""
     lane_placements: tuple[tuple[int, str], ...] = ()
     program_method: str = "jtag"
+    job_clock_mhz: int | None = None
     placeholders: tuple[str, ...] = ()
 
     @field_validator("name", "part")
@@ -205,6 +223,13 @@ class PlatformDefinition(BaseModel):
     def _valid_program_method(cls, value: str) -> str:
         if value not in ("jtag", "flash"):
             raise ValueError(f"program_method must be 'jtag' or 'flash', got {value!r}")
+        return value
+
+    @field_validator("job_clock_mhz")
+    @classmethod
+    def _valid_job_clock(cls, value: int | None) -> int | None:
+        if value is not None and value <= 0:
+            raise ValueError("job_clock_mhz must be positive when set")
         return value
 
 

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -292,6 +292,7 @@ def test_job_clock_convert_wraps_the_ddr_shell(tmp_path: Path) -> None:
     assert "connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc/aclk2] [get_bd_pins smc_lite/aclk1] [get_bd_pins my_ddr_top_0/s_axi_aclk]" in text
     assert "connect_bd_net [get_bd_pins job_rst/peripheral_aresetn] [get_bd_pins my_ddr_top_0/s_axi_aresetn]" in text
     assert "[get_bd_pins xadc_0/s_axi_aclk]\n" in text  # XADC stays on axi_aclk
+    assert "CONFIG.DCLK_FREQUENCY {250}" in text  # XADC DCLK follows the personality
 
 
 def test_no_job_clock_means_no_conversion(tmp_path: Path) -> None:

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -257,6 +257,64 @@ def test_placeholder_platform_projects_refuse_to_build(tmp_path: Path) -> None:
     assert "placeholder-platform" not in mm_ddr_job_shell_project_tcl(_ddr_request(tmp_path))
 
 
+def test_job_clock_convert_wraps_the_bram_shell(tmp_path: Path) -> None:
+    """A platform with ``job_clock_mhz`` runs the job top in its own MMCM-derived
+    clock domain: the register aperture crosses inside smc_lite (NUM_CLKS 2) and
+    the staging BRAMs stay on axi_aclk (the true-dual-port RAM is the crossing)."""
+    platform = _probe_platform(job_clock_mhz=125)
+    platform.host_link.xdma_personality.params["axisten_freq"] = "250"
+    request = _request(tmp_path).model_copy(update={"platform": platform})
+    text = mm_job_shell_project_tcl(request)
+    # the job clock domain: MMCM from axi_aclk, synchronized reset
+    assert "CONFIG.PRIM_IN_FREQ {250}" in text
+    assert "CONFIG.CLKOUT1_REQUESTED_OUT_FREQ {125}" in text
+    assert "connect_bd_net [get_bd_pins xdma_0/axi_aclk] [get_bd_pins job_clk/clk_in1]" in text
+    assert "[get_bd_pins job_clk/locked] [get_bd_pins job_rst/dcm_locked]" in text
+    # the register aperture crosses in smc_lite; the job top leaves axi_aclk
+    assert "CONFIG.NUM_SI {1} CONFIG.NUM_MI {1} CONFIG.NUM_CLKS {2}" in text
+    assert "connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc_lite/aclk1] [get_bd_pins my_mm_top_0/s_axi_aclk]" in text
+    assert "connect_bd_net [get_bd_pins job_rst/peripheral_aresetn] [get_bd_pins my_mm_top_0/s_axi_aresetn]" in text
+    assert "[get_bd_pins dw_out/s_axi_aclk] \\" not in text  # axi_aclk net no longer reaches the top
+    # the XDMA-side staging stays on axi_aclk
+    assert "[get_bd_pins bram_ctrl_in/s_axi_aclk]" in text
+
+
+def test_job_clock_convert_wraps_the_ddr_shell(tmp_path: Path) -> None:
+    """The DDR shell gains the job domain as a third smartconnect clock next
+    to the memory controller's ui_clk; the XADC stays on axi_aclk."""
+    platform = _probe_platform(job_clock_mhz=125)
+    platform.host_link.xdma_personality.params["axisten_freq"] = "250"
+    request = _ddr_request(tmp_path).model_copy(update={"platform": platform})
+    text = mm_ddr_job_shell_project_tcl(request)
+    assert "CONFIG.NUM_SI {2} CONFIG.NUM_MI {1} CONFIG.NUM_CLKS {3}" in text
+    assert "CONFIG.NUM_SI {1} CONFIG.NUM_MI {2} CONFIG.NUM_CLKS {2}" in text
+    assert "[get_bd_pins mig_0/ui_clk] [get_bd_pins smc/aclk1]" in text
+    assert "connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc/aclk2] [get_bd_pins smc_lite/aclk1] [get_bd_pins my_ddr_top_0/s_axi_aclk]" in text
+    assert "connect_bd_net [get_bd_pins job_rst/peripheral_aresetn] [get_bd_pins my_ddr_top_0/s_axi_aresetn]" in text
+    assert "[get_bd_pins xadc_0/s_axi_aclk]\n" in text  # XADC stays on axi_aclk
+
+
+def test_no_job_clock_means_no_conversion(tmp_path: Path) -> None:
+    """``job_clock_mhz`` unset (the dpv1 default) emits no clock-domain
+    machinery at all — the byte-identity goldens above pin the exact text."""
+    for text in (mm_job_shell_project_tcl(_request(tmp_path)), mm_ddr_job_shell_project_tcl(_ddr_request(tmp_path))):
+        assert "job_clk" not in text
+        assert "job_rst" not in text
+        assert "clk_wiz" not in text
+        assert "proc_sys_reset" not in text
+
+
+def test_personality_axi_clock_parses_axisten_freq() -> None:
+    import pytest
+
+    from dau_build.platforms import XdmaPersonality
+
+    assert dpv1_xdma_personality().axi_clock_mhz() == 125
+    assert XdmaPersonality(params={"axisten_freq": "250"}).axi_clock_mhz() == 250
+    with pytest.raises(ValueError, match="axisten_freq"):
+        XdmaPersonality(params={}).axi_clock_mhz()
+
+
 def test_project_tcl_matches_pre_fragment_goldens() -> None:
     """The fragment refactor (shared preamble/postamble emitters) must not
     change a byte of the generated scripts — these fixtures were captured

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -289,7 +289,10 @@ def test_job_clock_convert_wraps_the_ddr_shell(tmp_path: Path) -> None:
     assert "CONFIG.NUM_SI {2} CONFIG.NUM_MI {1} CONFIG.NUM_CLKS {3}" in text
     assert "CONFIG.NUM_SI {1} CONFIG.NUM_MI {2} CONFIG.NUM_CLKS {2}" in text
     assert "[get_bd_pins mig_0/ui_clk] [get_bd_pins smc/aclk1]" in text
-    assert "connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc/aclk2] [get_bd_pins smc_lite/aclk1] [get_bd_pins my_ddr_top_0/s_axi_aclk]" in text
+    assert (
+        "connect_bd_net [get_bd_pins job_clk/clk_out1] [get_bd_pins smc/aclk2] [get_bd_pins smc_lite/aclk1] [get_bd_pins my_ddr_top_0/s_axi_aclk]"
+        in text
+    )
     assert "connect_bd_net [get_bd_pins job_rst/peripheral_aresetn] [get_bd_pins my_ddr_top_0/s_axi_aresetn]" in text
     assert "[get_bd_pins xadc_0/s_axi_aclk]\n" in text  # XADC stays on axi_aclk
     assert "CONFIG.DCLK_FREQUENCY {250}" in text  # XADC DCLK follows the personality


### PR DESCRIPTION
The dpv2 x8 XDMA personality forces axi_aclk to 250 MHz and the 2026-07-16 K7 build probe showed the DAU tile misses timing there (routed WNS -0.525, TNS -47.3, all endpoints in the tile; the XDMA core closes). This adds the strategic fix as platform data, not code:

- `PlatformDefinition.job_clock_mhz` (default `None` = no conversion): when set, the shell generators derive a job clock at that frequency from `axi_aclk` with an MMCM (clk_wiz — 7-series has no BUFGCE_DIV and the XDMA offers no divided user clock), synchronize the reset into the job domain with proc_sys_reset, and clock-convert inside the smartconnects: the register aperture crosses in `smc_lite` (NUM_CLKS 2) and, in the DDR shell, the job master crosses in `smc` as a third clock next to the controller's ui_clk — the same structure the dpv1 DDR shell already proves against a differing ui_clk. In the BRAM shell the staging true-dual-port RAMs are the crossing (port A stays on axi_aclk, port B follows the job top), so no unmeasured MIG fact is depended on.
- `XdmaPersonality.axi_clock_mhz()` reads `axisten_freq` — one source for the MMCM input frequency.
- `job_clock_mhz` unset emits byte-identical dpv1 texts, pinned by the existing goldens; new tests cover both converted shells and the parsing.

Proven by a full Vivado 2025.2 build of the dpv2 record-batch shell (scratch config, candidate refclk): see the follow-up BRINGUP entry.