### PR TITLE
Make the FPGA programmer a pluggable backend

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -596,8 +596,12 @@ class FlashTask(BuildCallableModel):
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        if self.tool.lower() != "openfpgaloader":
-            raise BuildStepError(f"unknown flash tool {self.tool!r}; expected openFPGAloader")
+        from dau_build.programmers import programmer_for_tool
+
+        try:
+            programmer_for_tool(self.tool)
+        except ValueError as exc:
+            raise BuildStepError(str(exc)) from exc
         bitstream = self.bitstream
         manifest_segment = ""
         if self.manifest_path is not None:
@@ -1042,6 +1046,9 @@ class HardwarePlanTask(BuildCallableModel):
     # no board defaults).
     plan: Any = None
     platform: Any = None
+    # the programmer is the composed `programmer` group option (a Programmer
+    # model); with none, the platform's program_method selects the default
+    programmer: Any = None
     work_root: Path
     bitstream: Path | None = None
     vivado: str = "vivado"
@@ -1071,6 +1078,7 @@ class HardwarePlanTask(BuildCallableModel):
         config = HardwareToolchainConfig.for_platform(
             self.platform,
             work_root=self.work_root,
+            programmer=self.programmer,
             vivado_executable=self.vivado,
             vivado_invocation=self.vivado_invocation,
             vivado_mount_root=self.vivado_mount_root,

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -589,19 +589,16 @@ def _bitstream_from_shell_build_manifest(manifest_path: Path) -> Path:
 
 
 class FlashTask(BuildCallableModel):
-    tool: str = "openFPGAloader"
+    # the programmer is the composed `programmer` group option (a Programmer
+    # model); defaults to openFPGALoader, symmetric to SynthesizeTask's backend
+    programmer: Any = None
     bitstream: Path | None = None
     manifest_path: Path | None = None
     mode: Literal["volatile", "persistent"] = "volatile"
 
     @Flow.call
     def __call__(self, context: NullContext) -> BuildStepResult:
-        from dau_build.programmers import programmer_for_tool
-
-        try:
-            programmer_for_tool(self.tool)
-        except ValueError as exc:
-            raise BuildStepError(str(exc)) from exc
+        programmer = self._programmer()
         bitstream = self.bitstream
         manifest_segment = ""
         if self.manifest_path is not None:
@@ -627,8 +624,18 @@ class FlashTask(BuildCallableModel):
             raise BuildStepError(f"bitstream does not exist: {bitstream}")
         return BuildStepResult(
             step="flash",
-            message=f"dau-build-flash\ttask=flash tool={self.tool} bitstream={bitstream}{manifest_segment} mode={self.mode} status=planned",
+            message=f"dau-build-flash\ttask=flash programmer={programmer.name} bitstream={bitstream}{manifest_segment} mode={self.mode} status=planned",
         )
+
+    def _programmer(self):
+        # the composed `programmer` group option; default to openFPGALoader
+        from dau_build.programmers import OpenFpgaLoaderProgrammer, Programmer
+
+        if isinstance(self.programmer, Programmer):
+            return self.programmer
+        if self.programmer is None:
+            return OpenFpgaLoaderProgrammer()
+        raise BuildStepError(f"programmer {getattr(self.programmer, 'name', self.programmer)!r} is not a Programmer")
 
 
 class SmokeTestTask(BuildCallableModel):

--- a/dau_build/config/base.yaml
+++ b/dau_build/config/base.yaml
@@ -13,6 +13,7 @@ defaults:
   - optional simulator: null
   - optional spec: null
   - optional plan: null
+  - optional programmer: null
   - optional design: null
   - callable: callable
 

--- a/dau_build/config/programmer/programmers/openfpgaloader.yaml
+++ b/dau_build/config/programmer/programmers/openfpgaloader.yaml
@@ -1,0 +1,10 @@
+# @package programmer
+
+# programmer=programmers/openfpgaloader — JTAG programming via openFPGALoader
+# (the dpv1 flow). executable/jtag_cable default to the composed toolchain
+# config (host_access cable, HardwarePlanTask.openfpgaloader); pin them here
+# to override.
+_target_: dau_build.programmers.OpenFpgaLoaderProgrammer
+name: openfpgaloader
+executable: openFPGALoader
+jtag_cable: null

--- a/dau_build/config/programmer/programmers/vivado-hwserver.yaml
+++ b/dau_build/config/programmer/programmers/vivado-hwserver.yaml
@@ -1,0 +1,7 @@
+# @package programmer
+
+# programmer=programmers/vivado-hwserver — programming through the Vivado
+# hw_server flash.tcl path (the flash plan).
+_target_: dau_build.programmers.VivadoHwServerProgrammer
+name: vivado-hwserver
+vivado_settings: /opt/Xilinx/2025.1/Vivado/settings64.sh

--- a/dau_build/config/task/tasks/flash/flash.yaml
+++ b/dau_build/config/task/tasks/flash/flash.yaml
@@ -1,7 +1,9 @@
 # @package model
 
 _target_: dau_build.build_steps.FlashTask
-tool: openFPGAloader
+# the programmer composes from the `programmer` group
+# (programmer=programmers/<name>); with none, FlashTask defaults to openFPGALoader
+programmer: ${oc.select:programmer,null}
 bitstream: null
 manifest_path: null
 mode: volatile

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -9,6 +9,10 @@ plan: ${oc.select:plan,null}
 # it, and with neither the facts stay unset — steps that need them fail
 # with guidance (dau-build carries no board defaults)
 platform: ${oc.select:platform,null}
+# the programmer composes from the `programmer` group
+# (programmer=programmers/<name>); with none, the platform's program_method
+# selects the default (jtag->openfpgaloader, flash->vivado-hwserver)
+programmer: ${oc.select:programmer,null}
 work_root: ???
 bitstream: null
 vivado: vivado

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -5,7 +5,7 @@ import shlex
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from ccflow import BaseModel
 
@@ -16,7 +16,6 @@ from dau_build.vivado_backend import (
     VivadoProjectArtifactValidation,
     VivadoProjectGenerationRequest,
     dau_overlay_tcl,
-    flash_script as vivado_flash_script,
     generate_vivado_backend_artifacts,
     generate_vivado_project_generation_artifacts,
     overlay_build_script as vivado_overlay_build_script,
@@ -70,13 +69,20 @@ class HardwareToolchainConfig(BaseModel):
     endpoint_bdf: str | None = None
     expected_endpoint_id: str | None = None
     rescan_bdfs: tuple[str, ...] | None = None
+    # the board's default programming method (PlatformDefinition.program_method:
+    # jtag->openFPGALoader, flash->vivado-hwserver); an explicit `programmer`
+    # (a Programmer model composed from the `programmer` group) wins.
+    program_method: str = "jtag"
+    programmer: Any = None
 
     @classmethod
-    def for_platform(cls, platform, *, work_root: Path, **overrides) -> "HardwareToolchainConfig":
+    def for_platform(cls, platform, *, work_root: Path, programmer=None, **overrides) -> "HardwareToolchainConfig":
         """Compose the toolchain config from a registered platform's
-        ``host_access`` (board/host config, not code defaults). Explicit
-        keyword overrides win; with neither, the host-access facts stay
-        unset and any step that needs them fails with guidance."""
+        ``host_access`` (board/host config, not code defaults) and its
+        ``program_method``. Explicit keyword overrides win; with neither, the
+        host-access facts stay unset and any step that needs them fails with
+        guidance. An explicit ``programmer`` model overrides the
+        ``program_method``-selected default."""
         access = getattr(platform, "host_access", None)
         values: dict = {}
         if access is not None:
@@ -90,8 +96,25 @@ class HardwareToolchainConfig(BaseModel):
                 "rescan_bdfs": access.rescan_bdfs,
                 "runtime_pm_patterns": access.runtime_pm_patterns,
             }
+        method = getattr(platform, "program_method", None)
+        if method is not None:
+            values["program_method"] = method
+        if programmer is not None:
+            values["programmer"] = programmer
         values.update({key: value for key, value in overrides.items() if value is not None})
         return cls(work_root=work_root, **values)
+
+    def resolve_programmer(self):
+        """The composed ``Programmer``: an explicit ``programmer`` override,
+        else the ``program_method`` default (``jtag`` openFPGALoader with this
+        config's executable/cable, ``flash`` the Vivado hw_server path)."""
+        from dau_build.programmers import OpenFpgaLoaderProgrammer, Programmer, VivadoHwServerProgrammer
+
+        if isinstance(self.programmer, Programmer):
+            return self.programmer
+        if self.program_method == "flash":
+            return VivadoHwServerProgrammer()
+        return OpenFpgaLoaderProgrammer(executable=self.openfpgaloader_executable)
 
     @property
     def project_tcl(self) -> Path:
@@ -495,13 +518,15 @@ def _smoke_steps(smoke_command: str | None) -> tuple[ToolStep, ...]:
 
 
 def flash_step(config: HardwareToolchainConfig, *, vivado_settings: Path) -> ToolStep:
-    script = vivado_flash_script(
-        work_root=config.work_root,
-        vivado_settings=vivado_settings,
-        vivado_executable=config.vivado_executable,
-        vivado_invocation=config.vivado_invocation,
+    # the flash plan programs through the Vivado hw_server path; honor an
+    # explicitly composed vivado-hwserver programmer, else compose one with
+    # the plan's vivado_settings
+    from dau_build.programmers import VivadoHwServerProgrammer
+
+    programmer = (
+        config.programmer if isinstance(config.programmer, VivadoHwServerProgrammer) else VivadoHwServerProgrammer(vivado_settings=vivado_settings)
     )
-    return ToolStep("flash", ("bash", "-lc", script))
+    return programmer.program_step(config)
 
 
 def thunderbolt_hold_step(config: HardwareToolchainConfig, *, dau_utils_root: Path | None = None, python: str = "python3") -> ToolStep:
@@ -523,11 +548,11 @@ def thunderbolt_release_step(config: HardwareToolchainConfig, *, dau_utils_root:
 
 
 def jtag_detect_step(config: HardwareToolchainConfig) -> ToolStep:
-    return ToolStep("jtag-detect", (config.openfpgaloader_executable, "-c", config.required_host_access("jtag_cable"), "--detect"))
+    return config.resolve_programmer().detect_step(config)
 
 
 def program_volatile_step(config: HardwareToolchainConfig) -> ToolStep:
-    return ToolStep("program-volatile", (config.openfpgaloader_executable, "-c", config.required_host_access("jtag_cable"), str(config.bitstream)))
+    return config.resolve_programmer().program_step(config)
 
 
 def remove_endpoint_step(config: HardwareToolchainConfig) -> ToolStep:

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -104,16 +104,18 @@ class HardwareToolchainConfig(BaseModel):
         values.update({key: value for key, value in overrides.items() if value is not None})
         return cls(work_root=work_root, **values)
 
-    def resolve_programmer(self):
+    def resolve_programmer(self, *, vivado_settings: Path | None = None):
         """The composed ``Programmer``: an explicit ``programmer`` override,
         else the ``program_method`` default (``jtag`` openFPGALoader with this
-        config's executable/cable, ``flash`` the Vivado hw_server path)."""
+        config's executable/cable, ``flash`` the Vivado hw_server path).
+        ``vivado_settings`` supplies the flash plan's settings path to the
+        default Vivado programmer (an explicit ``programmer`` carries its own)."""
         from dau_build.programmers import OpenFpgaLoaderProgrammer, Programmer, VivadoHwServerProgrammer
 
         if isinstance(self.programmer, Programmer):
             return self.programmer
         if self.program_method == "flash":
-            return VivadoHwServerProgrammer()
+            return VivadoHwServerProgrammer() if vivado_settings is None else VivadoHwServerProgrammer(vivado_settings=vivado_settings)
         return OpenFpgaLoaderProgrammer(executable=self.openfpgaloader_executable)
 
     @property
@@ -154,7 +156,7 @@ def build_and_program_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, .
     return (
         thunderbolt_hold_step(config),
         vivado_build_step(config),
-        jtag_detect_step(config),
+        *detect_steps(config),
         program_volatile_step(config),
         pci_rescan_step(config.required_host_access("rescan_bdfs")),
         lspci_endpoint_step(config),
@@ -197,7 +199,7 @@ def local_build_and_program_plan(
         write_vivado_build_script_step(build_tcl_path=build_tcl_path, source=build_tcl_source),
         *_local_vivado_driver_steps(config, overlay_tcl=overlay_tcl, build_tcl=build_tcl),
         vivado_overlay_build_step(config, overlay_tcl=overlay_tcl, build_tcl=build_tcl, vivado_settings=vivado_settings),
-        jtag_detect_step(config),
+        *detect_steps(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
         pci_rescan_step(config.required_host_access("rescan_bdfs")),
@@ -348,7 +350,7 @@ def validate_bitstream_plan(
 ) -> tuple[ToolStep, ...]:
     return (
         thunderbolt_hold_step(config, dau_utils_root=dau_utils_root, python=python),
-        jtag_detect_step(config),
+        *detect_steps(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
         pci_rescan_step(config.required_host_access("rescan_bdfs")),
@@ -518,15 +520,10 @@ def _smoke_steps(smoke_command: str | None) -> tuple[ToolStep, ...]:
 
 
 def flash_step(config: HardwareToolchainConfig, *, vivado_settings: Path) -> ToolStep:
-    # the flash plan programs through the Vivado hw_server path; honor an
-    # explicitly composed vivado-hwserver programmer, else compose one with
-    # the plan's vivado_settings
-    from dau_build.programmers import VivadoHwServerProgrammer
-
-    programmer = (
-        config.programmer if isinstance(config.programmer, VivadoHwServerProgrammer) else VivadoHwServerProgrammer(vivado_settings=vivado_settings)
-    )
-    return programmer.program_step(config)
+    # a persistent write through the composed programmer (Vivado hw_server for
+    # a flash board, openFPGALoader -f for a JTAG board) — the selector, not a
+    # hardcoded backend
+    return config.resolve_programmer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
 
 
 def thunderbolt_hold_step(config: HardwareToolchainConfig, *, dau_utils_root: Path | None = None, python: str = "python3") -> ToolStep:
@@ -547,8 +544,16 @@ def thunderbolt_release_step(config: HardwareToolchainConfig, *, dau_utils_root:
     )
 
 
-def jtag_detect_step(config: HardwareToolchainConfig) -> ToolStep:
+def jtag_detect_step(config: HardwareToolchainConfig) -> ToolStep | None:
+    # optional: None when the composed programmer has no separate detect step
     return config.resolve_programmer().detect_step(config)
+
+
+def detect_steps(config: HardwareToolchainConfig) -> tuple[ToolStep, ...]:
+    """The composed programmer's detect step, or ``()`` when it has none —
+    so a plan can splat it and skip a detect-less programmer (e.g. Vivado)."""
+    step = jtag_detect_step(config)
+    return () if step is None else (step,)
 
 
 def program_volatile_step(config: HardwareToolchainConfig) -> ToolStep:

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -1,0 +1,129 @@
+"""Board programmers: how a built bitstream reaches the FPGA.
+
+A ``Programmer`` is the FPGA-programming counterpart to the ``backend``
+group's ``SynthesisEngine`` — a polymorphic, fully hydra-configurable
+model selected from the ``programmer`` config group
+(``programmer=programmers/openfpgaloader``). The hardware-plan step helpers
+delegate to ``detect_step``/``program_step``; there is no programmer
+``Literal`` or dispatch ``if``.
+
+The default programmer follows a board's ``PlatformDefinition.program_method``
+(``jtag`` → ``OpenFpgaLoaderProgrammer``, ``flash`` →
+``VivadoHwServerProgrammer``); an explicit ``programmer=`` override wins.
+
+``ToolStep`` is imported lazily inside the step methods so this module and
+``hardware_plan`` do not import each other at module load.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from ccflow import BaseModel
+
+from dau_build.vivado_backend import flash_script as vivado_flash_script
+
+if TYPE_CHECKING:
+    from dau_build.hardware_plan import HardwareToolchainConfig, ToolStep
+
+
+class Programmer(BaseModel):
+    """A board-programming backend selected from the ``programmer`` config
+    group. ``detect_step`` produces the device-detection step;
+    ``program_step`` produces the configuration step (volatile by default,
+    ``mode="persistent"`` for a non-volatile write)."""
+
+    name: str
+
+    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
+        raise NotImplementedError
+
+    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+        raise NotImplementedError
+
+
+class OpenFpgaLoaderProgrammer(Programmer):
+    """JTAG programming via ``openFPGALoader``. ``executable``/``jtag_cable``
+    default to the composed toolchain config (so a board's ``host_access``
+    cable and a ``HardwarePlanTask.openfpgaloader`` override still flow
+    through); an explicitly composed programmer may pin them."""
+
+    name: str = "openfpgaloader"
+    executable: str = "openFPGALoader"
+    jtag_cable: str | None = None
+
+    def _cable(self, config: "HardwareToolchainConfig") -> str:
+        if self.jtag_cable is not None:
+            return self.jtag_cable
+        return config.required_host_access("jtag_cable")
+
+    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
+        from dau_build.hardware_plan import ToolStep
+
+        return ToolStep("jtag-detect", (self.executable, "-c", self._cable(config), "--detect"))
+
+    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+        from dau_build.hardware_plan import ToolStep
+
+        if mode == "persistent":
+            return ToolStep("program-persistent", (self.executable, "-c", self._cable(config), "-f", str(config.bitstream)))
+        return ToolStep("program-volatile", (self.executable, "-c", self._cable(config), str(config.bitstream)))
+
+
+class VivadoHwServerProgrammer(Programmer):
+    """Programming through the Vivado hw_server ``flash.tcl`` path (the
+    ``flash`` plan). Emits the same ``bash -lc`` step the flash plan has
+    always produced."""
+
+    name: str = "vivado-hwserver"
+    vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
+
+    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
+        raise NotImplementedError("vivado-hwserver programs through flash.tcl and has no separate JTAG detect step")
+
+    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+        from dau_build.hardware_plan import ToolStep
+
+        script = vivado_flash_script(
+            work_root=config.work_root,
+            vivado_settings=self.vivado_settings,
+            vivado_executable=config.vivado_executable,
+            vivado_invocation=config.vivado_invocation,
+        )
+        return ToolStep("flash", ("bash", "-lc", script))
+
+
+class XsctProgrammer(Programmer):
+    """Placeholder for Xilinx ``xsct``/hw_server programming — not yet
+    implemented."""
+
+    name: str = "xsct"
+
+    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
+        raise NotImplementedError("xsct programmer is not implemented")
+
+    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+        raise NotImplementedError("xsct programmer is not implemented")
+
+
+_PROGRAMMER_TOOLS: dict[str, type[Programmer]] = {
+    "openfpgaloader": OpenFpgaLoaderProgrammer,
+    "vivado": VivadoHwServerProgrammer,
+    "vivado-hwserver": VivadoHwServerProgrammer,
+    "xsct": XsctProgrammer,
+}
+
+
+def programmer_for_tool(tool: str) -> Programmer:
+    """The programmer a ``FlashTask.tool`` string selects. Raises
+    ``ValueError`` for an unrecognized tool (the pluggable replacement for the
+    old hardcoded openFPGALoader-only check)."""
+    programmer_type = _PROGRAMMER_TOOLS.get(tool.lower())
+    if programmer_type is None:
+        raise ValueError(f"unknown flash tool {tool!r}; expected one of {', '.join(sorted(_PROGRAMMER_TOOLS))}")
+    return programmer_type()
+
+
+for _programmer_cls in (Programmer, OpenFpgaLoaderProgrammer, VivadoHwServerProgrammer, XsctProgrammer):
+    _programmer_cls.model_rebuild()

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -4,12 +4,16 @@ A ``Programmer`` is the FPGA-programming counterpart to the ``backend``
 group's ``SynthesisEngine`` — a polymorphic, fully hydra-configurable
 model selected from the ``programmer`` config group
 (``programmer=programmers/openfpgaloader``). The hardware-plan step helpers
-delegate to ``detect_step``/``program_step``; there is no programmer
-``Literal`` or dispatch ``if``.
+and ``FlashTask`` delegate to ``detect_step``/``program_step``; there is no
+programmer ``Literal``, string→type table, or dispatch ``if``.
 
 The default programmer follows a board's ``PlatformDefinition.program_method``
 (``jtag`` → ``OpenFpgaLoaderProgrammer``, ``flash`` →
 ``VivadoHwServerProgrammer``); an explicit ``programmer=`` override wins.
+
+Detection is optional: ``detect_step`` returns ``None`` for a programmer with
+no separate detect step (e.g. the Vivado hw_server path), and every plan that
+emits a detect step skips a ``None`` rather than calling an unsupported one.
 
 ``ToolStep`` is imported lazily inside the step methods so this module and
 ``hardware_plan`` do not import each other at module load.
@@ -30,14 +34,15 @@ if TYPE_CHECKING:
 
 class Programmer(BaseModel):
     """A board-programming backend selected from the ``programmer`` config
-    group. ``detect_step`` produces the device-detection step;
-    ``program_step`` produces the configuration step (volatile by default,
-    ``mode="persistent"`` for a non-volatile write)."""
+    group. ``detect_step`` produces an optional device-detection step
+    (``None`` when the programmer has none); ``program_step`` produces the
+    configuration step (volatile by default, ``mode="persistent"`` for a
+    non-volatile write)."""
 
     name: str
 
-    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
-        raise NotImplementedError
+    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep | None":
+        return None
 
     def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
         raise NotImplementedError
@@ -73,14 +78,12 @@ class OpenFpgaLoaderProgrammer(Programmer):
 
 class VivadoHwServerProgrammer(Programmer):
     """Programming through the Vivado hw_server ``flash.tcl`` path (the
-    ``flash`` plan). Emits the same ``bash -lc`` step the flash plan has
-    always produced."""
+    ``flash`` plan). Has no separate JTAG detect step (``detect_step`` returns
+    ``None``); ``program_step`` emits the same ``bash -lc`` step the flash plan
+    has always produced."""
 
     name: str = "vivado-hwserver"
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
-
-    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
-        raise NotImplementedError("vivado-hwserver programs through flash.tcl and has no separate JTAG detect step")
 
     def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
         from dau_build.hardware_plan import ToolStep
@@ -94,36 +97,5 @@ class VivadoHwServerProgrammer(Programmer):
         return ToolStep("flash", ("bash", "-lc", script))
 
 
-class XsctProgrammer(Programmer):
-    """Placeholder for Xilinx ``xsct``/hw_server programming — not yet
-    implemented."""
-
-    name: str = "xsct"
-
-    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
-        raise NotImplementedError("xsct programmer is not implemented")
-
-    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
-        raise NotImplementedError("xsct programmer is not implemented")
-
-
-_PROGRAMMER_TOOLS: dict[str, type[Programmer]] = {
-    "openfpgaloader": OpenFpgaLoaderProgrammer,
-    "vivado": VivadoHwServerProgrammer,
-    "vivado-hwserver": VivadoHwServerProgrammer,
-    "xsct": XsctProgrammer,
-}
-
-
-def programmer_for_tool(tool: str) -> Programmer:
-    """The programmer a ``FlashTask.tool`` string selects. Raises
-    ``ValueError`` for an unrecognized tool (the pluggable replacement for the
-    old hardcoded openFPGALoader-only check)."""
-    programmer_type = _PROGRAMMER_TOOLS.get(tool.lower())
-    if programmer_type is None:
-        raise ValueError(f"unknown flash tool {tool!r}; expected one of {', '.join(sorted(_PROGRAMMER_TOOLS))}")
-    return programmer_type()
-
-
-for _programmer_cls in (Programmer, OpenFpgaLoaderProgrammer, VivadoHwServerProgrammer, XsctProgrammer):
+for _programmer_cls in (Programmer, OpenFpgaLoaderProgrammer, VivadoHwServerProgrammer):
     _programmer_cls.model_rebuild()

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -134,7 +134,7 @@ def test_synthesize_vivado_consumes_arrow_lite_aggregator_bundle_for_flash_and_s
 
     assert flash_result == BuildStepResult(
         step="flash",
-        message=f"dau-build-flash\ttask=flash tool=openFPGAloader bitstream={bitstream} manifest={backend_manifest_path} mode=volatile status=planned",
+        message=f"dau-build-flash\ttask=flash programmer=openfpgaloader bitstream={bitstream} manifest={backend_manifest_path} mode=volatile status=planned",
     )
     assert smoke_result == BuildStepResult(
         step="smoke-test",
@@ -189,11 +189,31 @@ def test_execute_override_task_plans_openfpgaloader_flash(tmp_path: Path) -> Non
     bitstream = tmp_path / "Top_wrapper.bit"
     bitstream.write_bytes(b"bit")
 
-    result = execute_override_task(("task=tasks/flash/flash", "tool=openFPGAloader", f"bitstream={bitstream}"))
+    # default programmer (openFPGALoader)
+    result = execute_override_task(("task=tasks/flash/flash", f"bitstream={bitstream}"))
 
     assert result == BuildStepResult(
         step="flash",
-        message=f"dau-build-flash\ttask=flash tool=openFPGAloader bitstream={bitstream} mode=volatile status=planned",
+        message=f"dau-build-flash\ttask=flash programmer=openfpgaloader bitstream={bitstream} mode=volatile status=planned",
+    )
+
+
+def test_flash_task_composes_the_programmer_group(tmp_path: Path) -> None:
+    from dau_build.config import run_request_config
+
+    bitstream = tmp_path / "Top_wrapper.bit"
+    bitstream.write_bytes(b"bit")
+
+    # programmer=programmers/<name> composes the adapter into the flash task
+    result = run_request_config(
+        "task",
+        "tasks/flash/flash",
+        overrides=["programmer=programmers/vivado-hwserver"],
+        model_values={"bitstream": bitstream},
+    )
+    assert result == BuildStepResult(
+        step="flash",
+        message=f"dau-build-flash\ttask=flash programmer=vivado-hwserver bitstream={bitstream} mode=volatile status=planned",
     )
 
 

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -197,6 +197,22 @@ def test_nested_board_and_backend_config_groups_compose() -> None:
     assert isinstance(backend, VivadoEngine) and backend.name == "vivado"
 
 
+def test_programmer_config_group_composes_the_adapter() -> None:
+    # programmer=programmers/<name> selects a Programmer model, symmetric to
+    # backend=backends/<name>; adding a group yaml is all it takes to select
+    # a programming adapter.
+    from hydra import compose, initialize_config_module
+    from hydra.utils import instantiate
+
+    from dau_build.programmers import OpenFpgaLoaderProgrammer, VivadoHwServerProgrammer
+
+    with initialize_config_module(config_module="dau_build.config", version_base=None):
+        jtag = instantiate(compose(config_name="base", overrides=["programmer=programmers/openfpgaloader"]).programmer)
+        flash = instantiate(compose(config_name="base", overrides=["programmer=programmers/vivado-hwserver"]).programmer)
+    assert isinstance(jtag, OpenFpgaLoaderProgrammer) and jtag.name == "openfpgaloader" and jtag.executable == "openFPGALoader"
+    assert isinstance(flash, VivadoHwServerProgrammer) and flash.name == "vivado-hwserver"
+
+
 def test_dau_build_registers_a_hydra_searchpath_entry_point() -> None:
     # the config tree is on the Hydra search path (lerna bridge) so packages
     # and users can extend it; dau-build must register itself

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1120,16 +1120,28 @@ def test_dau_overlay_manifest_records_backend_contract() -> None:
     assert dau_overlay_manifest_text(Path("/repo/dau-core/dau_core/hdl")).splitlines()[0] == "backend=dau_build.vivado_backend.vivado_overlay"
 
 
-def test_local_flash_plan_uses_vivado_flash_script_inside_runtime_pm_session() -> None:
-    config = _bench_config(work_root=Path("/repo/projects/vivado-shell"), vivado_executable="vivado")
-
-    steps = flash_plan(config)
-
+def test_flash_plan_routes_through_the_program_method_selector() -> None:
+    # a flash board flashes through the Vivado hw_server path (byte-identical
+    # to the pre-adapter flash step)
+    flash_config = _bench_config(work_root=Path("/repo/projects/vivado-shell"), vivado_executable="vivado", program_method="flash")
+    steps = flash_plan(flash_config)
     assert [step.name for step in steps] == ["thunderbolt-hold", "flash", "thunderbolt-release"]
     assert steps[1].argv[0:2] == ("bash", "-lc")
     assert "cd /repo/projects/vivado-shell" in steps[1].argv[2]
     assert ". /opt/Xilinx/2025.1/Vivado/settings64.sh" in steps[1].argv[2]
     assert "vivado -mode batch -source scripts/flash.tcl" in steps[1].argv[2]
+
+    # a JTAG board flashes persistently through openFPGALoader (-f)
+    jtag_config = _bench_config(work_root=Path("/repo/projects/vivado-shell"))
+    jtag_steps = flash_plan(jtag_config)
+    program = {step.name: step for step in jtag_steps}["program-persistent"]
+    assert program.argv == (
+        "openFPGALoader",
+        "-c",
+        "digilent_hs2",
+        "-f",
+        "/repo/projects/vivado-shell/project.runs/impl_1/Top_wrapper.bit",
+    )
 
 
 def test_task_local_build_can_stage_shell_before_overlay() -> None:
@@ -1576,6 +1588,17 @@ def test_explicit_programmer_override_beats_program_method() -> None:
     # an explicit backend= over the spec-derived default)
     config = _bench_config(work_root=Path("/w"), programmer=VivadoHwServerProgrammer())
     assert isinstance(config.resolve_programmer(), VivadoHwServerProgrammer)
+
+
+def test_detect_less_programmer_yields_a_plan_without_a_detect_step() -> None:
+    # detection is optional: a flash board (Vivado has no JTAG detect) composes
+    # a valid build-and-program plan that simply omits the detect step
+    config = _bench_config(work_root=Path("/w"), vivado_executable="vivado", program_method="flash")
+    assert config.resolve_programmer().detect_step(config) is None
+    step_names = [step.name for step in build_and_program_plan(config)]
+    assert "jtag-detect" not in step_names
+    # the program step is the Vivado flash step, and the plan is otherwise intact
+    assert step_names == ["thunderbolt-hold", "vivado-build", "flash", "pci-rescan", "lspci-endpoint"]
 
 
 def test_stage_command_records_the_callers_staging_task(tmp_path: Path) -> None:

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1538,6 +1538,46 @@ def test_toolchain_config_composes_from_platform_host_access() -> None:
     assert HardwareToolchainConfig.for_platform(other, work_root=Path("/w"), jtag_cable="digilent_hs2").jtag_cable == "digilent_hs2"
 
 
+def test_openfpgaloader_programmer_reproduces_prior_steps() -> None:
+    from dau_build.hardware_plan import jtag_detect_step, program_volatile_step
+    from dau_build.programmers import OpenFpgaLoaderProgrammer
+
+    config = _bench_config(work_root=Path("/repo/projects/vivado-shell"))
+    # the jtag default composes the openFPGALoader adapter
+    assert isinstance(config.resolve_programmer(), OpenFpgaLoaderProgrammer)
+    # byte-identical to the pre-adapter jtag-detect / program-volatile argv
+    assert jtag_detect_step(config).argv == ("openFPGALoader", "-c", "digilent_hs2", "--detect")
+    assert program_volatile_step(config).argv == (
+        "openFPGALoader",
+        "-c",
+        "digilent_hs2",
+        "/repo/projects/vivado-shell/project.runs/impl_1/Top_wrapper.bit",
+    )
+
+
+def test_program_method_flash_selects_the_vivado_programmer() -> None:
+    from dau_build.platforms import dpv1_platform
+    from dau_build.programmers import VivadoHwServerProgrammer
+
+    flash_board = dpv1_platform().model_copy(deep=True)
+    flash_board.program_method = "flash"
+    config = HardwareToolchainConfig.for_platform(flash_board, work_root=Path("/w"), vivado_executable="vivado")
+    programmer = config.resolve_programmer()
+    assert isinstance(programmer, VivadoHwServerProgrammer)
+    step = programmer.program_step(config)
+    assert step.name == "flash"
+    assert "vivado -mode batch -source scripts/flash.tcl" in step.argv[2]
+
+
+def test_explicit_programmer_override_beats_program_method() -> None:
+    from dau_build.programmers import VivadoHwServerProgrammer
+
+    # an explicit programmer wins over a jtag board's default (symmetric to
+    # an explicit backend= over the spec-derived default)
+    config = _bench_config(work_root=Path("/w"), programmer=VivadoHwServerProgrammer())
+    assert isinstance(config.resolve_programmer(), VivadoHwServerProgrammer)
+
+
 def test_stage_command_records_the_callers_staging_task(tmp_path: Path) -> None:
     definition = _acme_overlay_definition()
     request = VivadoProjectGenerationRequest(

--- a/dau_build/tests/test_shell_build.py
+++ b/dau_build/tests/test_shell_build.py
@@ -152,6 +152,17 @@ def test_flash_task_resolves_and_verifies_shell_build_manifest(tmp_path: Path) -
         FlashTask(manifest_path=manifest_path)(None)
 
 
+def test_flash_task_rejects_an_unknown_programmer_tool(tmp_path: Path) -> None:
+    # the programmer registry replaces the old hardcoded openFPGALoader-only
+    # check: an unrecognized tool is refused, a known one is accepted
+    output_root = _fake_shell_output(tmp_path)
+    manifest_path = write_shell_build_manifest(output_root, name="dpv1-test", metadata={"build_status": "built"})
+    with pytest.raises(BuildStepError, match="unknown flash tool"):
+        FlashTask(tool="nonesuch", manifest_path=manifest_path)(None)
+    # vivado-hwserver is now a recognized tool (no raise before bitstream checks)
+    assert "dau_mm_job.bit" in FlashTask(tool="vivado-hwserver", manifest_path=manifest_path)(None).message
+
+
 def test_flash_task_rejects_unbuilt_manifest(tmp_path: Path) -> None:
     output_root = _fake_shell_output(tmp_path)
     manifest_path = write_shell_build_manifest(output_root, name="dpv1-test", metadata={"build_status": "failed"})

--- a/dau_build/tests/test_shell_build.py
+++ b/dau_build/tests/test_shell_build.py
@@ -152,15 +152,19 @@ def test_flash_task_resolves_and_verifies_shell_build_manifest(tmp_path: Path) -
         FlashTask(manifest_path=manifest_path)(None)
 
 
-def test_flash_task_rejects_an_unknown_programmer_tool(tmp_path: Path) -> None:
-    # the programmer registry replaces the old hardcoded openFPGALoader-only
-    # check: an unrecognized tool is refused, a known one is accepted
+def test_flash_task_delegates_to_the_composed_programmer(tmp_path: Path) -> None:
+    # FlashTask composes a Programmer from the `programmer` group (no string
+    # tool dispatch): the default is openFPGALoader, an explicit adapter wins,
+    # and a non-Programmer value is refused
+    from dau_build.programmers import VivadoHwServerProgrammer
+
     output_root = _fake_shell_output(tmp_path)
     manifest_path = write_shell_build_manifest(output_root, name="dpv1-test", metadata={"build_status": "built"})
-    with pytest.raises(BuildStepError, match="unknown flash tool"):
-        FlashTask(tool="nonesuch", manifest_path=manifest_path)(None)
-    # vivado-hwserver is now a recognized tool (no raise before bitstream checks)
-    assert "dau_mm_job.bit" in FlashTask(tool="vivado-hwserver", manifest_path=manifest_path)(None).message
+
+    assert "programmer=openfpgaloader" in FlashTask(manifest_path=manifest_path)(None).message
+    assert "programmer=vivado-hwserver" in FlashTask(programmer=VivadoHwServerProgrammer(), manifest_path=manifest_path)(None).message
+    with pytest.raises(BuildStepError, match="is not a Programmer"):
+        FlashTask(programmer="nonesuch", manifest_path=manifest_path)(None)
 
 
 def test_flash_task_rejects_unbuilt_manifest(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds a `programmer` config group symmetric to the synth `backend` group, so a board is programmed through a pluggable adapter rather than hardcoded command branches (the guidelines' "second platform arrives through config + backend adapters, never copy-pasted command branches").

- `Programmer(ccflow.BaseModel)` base with `detect_step`/`program_step`; `OpenFpgaLoaderProgrammer`, `VivadoHwServerProgrammer`, and an `XsctProgrammer` stub.
- `programmer=programmers/{openfpgaloader,vivado-hwserver}` config group; `PlatformDefinition.program_method` (jtag/flash) wired as the default selector, with an explicit `programmer=` override.
- All three programming paths (`jtag_detect_step`/`program_volatile_step`, `flash_step`, `FlashTask`) now delegate to the composed programmer; the old string→type registry is removed. `detect_step` is optional (`ToolStep | None`) so a detect-less programmer (Vivado) composes a valid `program_method=flash` plan.
- dpv1 openFPGALoader detect/program argv stay byte-identical; goldens and drift-guards unchanged.

Reviewed by codex gpt-5.6-sol (APPROVE; byte-identity and flash-method plan composition empirically verified).