### PR TITLE
Emit tile SV module-parameter overrides in the scan-composition walker

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -650,8 +650,11 @@ def _fanout_sv(composition: ScanComposition, *, clk: str) -> tuple[str, str]:
     wire [{num_lanes - 1}:0] part_status_ready;
     wire [{num_lanes - 1}:0] part_status_error;
     wire [{num_lanes * 8 - 1}:0] part_status_error_code;"""
+        if "NUM_PARTITIONS" in composition.partitioner.params:
+            raise ScanCompositionError("the shared partitioner's NUM_PARTITIONS is derived from the lane count; do not override it via params")
+        partitioner_extra_params = "".join(f",\n        .{name}({value})" for name, value in composition.partitioner.params.items())
         instance = f"""    {composition.partitioner.module} #(
-        .NUM_PARTITIONS({num_lanes})
+        .NUM_PARTITIONS({num_lanes}){partitioner_extra_params}
     ) partitioner (
         .clk({clk}),
         .rst(lane_rst),

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -37,10 +37,16 @@ class ScanCompositionError(ValueError):
 
 class TileInstance(BaseModel):
     """One HDL module plus its config-port bindings (SystemVerilog literals
-    or expressions in terms of the top's signals)."""
+    or expressions in terms of the top's signals) and any module-parameter
+    overrides (``params``: SystemVerilog PARAMETERs — elaboration-time sizes
+    like the membership core's ``KEY_SPACE`` — emitted as a ``#(...)`` override
+    on the instance). A tile with no ``params`` is emitted exactly as before
+    the channel existed (no ``#(...)``), so every param-less golden stays
+    byte-identical."""
 
     module: str
     config: dict[str, str] = {}
+    params: dict[str, int] = {}
 
 
 class LaneTile(TileInstance):
@@ -331,6 +337,18 @@ def _tile_config_binds_sv(config) -> str:
     return "".join(f"        .{port}({value}),\n" for port, value in config.items())
 
 
+def _tile_param_override_sv(tile: TileInstance) -> str:
+    """A SystemVerilog module-parameter override for a tile instance
+    (``dau_int32_X #(.KEY_SPACE(6000000)) inst (...)``), inserted between the
+    module name and the instance name. Empty string when the tile carries no
+    params — a param-less tile emits byte-identically to before the
+    module-parameter channel, so every existing golden stays green."""
+    if not tile.params:
+        return ""
+    binds = ",\n".join(f"        .{name}({value})" for name, value in tile.params.items())
+    return f" #(\n{binds}\n    )"
+
+
 def _lane_front_sv(composition: ScanComposition, i: int, *, clk: str = "s_axi_aclk") -> str:
     """The lane front for lane ``i``: tap the shared partitioner's per-lane
     stream, tap the broadcast directly (filterless lane), or instantiate the
@@ -355,7 +373,7 @@ def _lane_front_sv(composition: ScanComposition, i: int, *, clk: str = "s_axi_ac
     assign filt_status_error_{i} = 1'b0;
     assign filt_status_error_code_{i} = 8'd0;
 """
-    return f"""    {lane.partition.module} partition_{i} (
+    return f"""    {lane.partition.module}{_tile_param_override_sv(lane.partition)} partition_{i} (
         .clk({clk}),
         .rst(lane_rst),
 {_tile_config_binds_sv(lane.partition.config)}        .input_valid(bcast_valid[{i}]),
@@ -523,7 +541,7 @@ def _lane_chain_sv(composition: ScanComposition, i: int, *, clk: str) -> str:
     for j, stage in enumerate(composition.lanes[i].chain):
         upstream = "filt_out" if j == 0 else f"chain{j - 1}_out"
         parts.append(
-            f"""    {stage.module} chain_{i}_{j} (
+            f"""    {stage.module}{_tile_param_override_sv(stage)} chain_{i}_{j} (
         .clk({clk}),
         .rst(lane_rst),
 {_tile_config_binds_sv(stage.config)}        .input_valid({upstream}_valid_{i}),
@@ -559,7 +577,7 @@ def _lane_units_sv(composition: ScanComposition, *, clk: str, writer_rst: str) -
     burst_beats = composition.burst_beats
     return "\n\n".join(
         f"""{_lane_front_sv(composition, i, clk=clk)}
-{_lane_chain_sv(composition, i, clk=clk)}    {composition.lanes[i].module} tile_{i} (
+{_lane_chain_sv(composition, i, clk=clk)}    {composition.lanes[i].module}{_tile_param_override_sv(composition.lanes[i])} tile_{i} (
         .clk({clk}),
         .rst(lane_rst),
 {_tile_config_binds_sv(composition.lanes[i].config)}        .input_valid({_lane_tile_upstream(composition, i)}_valid_{i}),

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -305,6 +305,26 @@ def test_param_override_emits_on_partition_and_terminal_tile_slots() -> None:
     assert "    dau_terminal_tile #(\n        .KEY_SPACE(2048)\n    ) tile_0 (" in text
 
 
+def test_param_override_emits_on_the_shared_partitioner() -> None:
+    # a param-less shared partitioner emits only the derived NUM_PARTITIONS (byte-identical)
+    plain = generate_scan_composition_top_sv(_sorted_scan_composition())
+    assert "    dau_int32_range_partitioner #(\n        .NUM_PARTITIONS(4)\n    ) partitioner (" in plain
+    # custom params append after NUM_PARTITIONS
+    with_params = _sorted_scan_composition().model_copy(
+        update={"partitioner": TileInstance(module="dau_int32_range_partitioner", config={"cfg_splitters": "s"}, params={"KEY_SPACE": 4096})}
+    )
+    text = generate_scan_composition_top_sv(with_params)
+    assert "    dau_int32_range_partitioner #(\n        .NUM_PARTITIONS(4),\n        .KEY_SPACE(4096)\n    ) partitioner (" in text
+
+
+def test_shared_partitioner_rejects_a_num_partitions_param_override() -> None:
+    composition = _sorted_scan_composition().model_copy(
+        update={"partitioner": TileInstance(module="dau_int32_range_partitioner", config={"cfg_splitters": "s"}, params={"NUM_PARTITIONS": 8})}
+    )
+    with pytest.raises(ScanCompositionError, match="NUM_PARTITIONS is derived"):
+        generate_scan_composition_top_sv(composition)
+
+
 def test_param_less_goldens_are_untouched_by_the_param_channel() -> None:
     """The param channel adds a field that defaults empty: every existing
     golden must still match byte-for-byte (this repeats the golden asserts to

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -260,6 +260,60 @@ def test_sim_harness_carries_the_same_chain() -> None:
     assert ".input_valid(chain1_out_valid_0)," in tile_block
 
 
+def test_param_override_emits_on_the_tile_and_param_less_stays_byte_identical() -> None:
+    """A tile carrying params emits a ``#(.KEY_SPACE(N))`` override between
+    the module name and instance; a param-less composition emits exactly as
+    before (the byte-identity goldens above pin that)."""
+    # the exact "module tile_0 (" substring proves there is no #(...) wedged
+    # between the module name and the instance name for a param-less tile
+    param_free = generate_scan_composition_top_sv(_bar_noc_composition())
+    assert "    dau_int32_bar_aggregation tile_0 (" in param_free
+
+    membership = ScanComposition(
+        name="membership",
+        module_name="dau_mm_membership_job",
+        lanes=(
+            LaneTile(
+                module="dau_int32_field_sum_aggregation",
+                config={"cfg_field_mask": "4'b0010"},
+                count_port="aggregated_count",
+                chain=(TileInstance(module="dau_int32_key_membership_filter", params={"KEY_SPACE": 6_000_000}),),
+            ),
+        ),
+    )
+    text = generate_scan_composition_top_sv(membership)
+    assert "    dau_int32_key_membership_filter #(\n        .KEY_SPACE(6000000)\n    ) chain_0_0 (" in text
+    # the param-less terminal tile carries no override
+    assert "    dau_int32_field_sum_aggregation tile_0 (" in text
+
+
+def test_param_override_emits_on_partition_and_terminal_tile_slots() -> None:
+    composition = ScanComposition(
+        name="param-slots",
+        module_name="dau_mm_param_slots_job",
+        lanes=(
+            LaneTile(
+                module="dau_terminal_tile",
+                count_port="row_count",
+                params={"KEY_SPACE": 2048},
+                partition=TileInstance(module="dau_key_filter", params={"KEY_SPACE": 128}),
+            ),
+        ),
+    )
+    text = generate_scan_composition_top_sv(composition)
+    assert "    dau_key_filter #(\n        .KEY_SPACE(128)\n    ) partition_0 (" in text
+    assert "    dau_terminal_tile #(\n        .KEY_SPACE(2048)\n    ) tile_0 (" in text
+
+
+def test_param_less_goldens_are_untouched_by_the_param_channel() -> None:
+    """The param channel adds a field that defaults empty: every existing
+    golden must still match byte-for-byte (this repeats the golden asserts to
+    pin them against the param-channel change explicitly)."""
+    assert generate_scan_composition_top_sv(_bar_noc_composition()) == (_FIXTURES / "bar_noc_4.v").read_text()
+    assert generate_scan_composition_top_sv(_sorted_scan_composition()) == (_FIXTURES / "sorted_scan.v").read_text()
+    assert generate_scan_composition_sim_sv(_bar_noc_composition()) == (_FIXTURES / "bar_noc_4_sim.v").read_text()
+
+
 _CONFORMING_TILE = """
 module lane_tile (
     input  wire logic        clk,


### PR DESCRIPTION
The generic scan-composition walker now emits a SystemVerilog parameter override on any tile carrying `params` — `dau_int32_X #(.KEY_SPACE(6000000)) inst (...)` — for the lane tile, partition, chain stages, and the shared partitioner (its custom params append after the derived NUM_PARTITIONS; a NUM_PARTITIONS override is rejected). A param-less tile emits exactly as before, so every existing design's shell-top golden stays byte-identical (pinned by the byte-identity goldens). Public, no private imports.

Reviewed with codex gpt-5.6-sol (APPROVE; it caught and I fixed the shared-partitioner emission bypass; byte-identity goldens verified).