### PR TITLE
Thread the rows/cycle axis through the scan-composition walker

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -141,6 +141,32 @@ class ScanComposition(BaseModel):
             for lane in self.lanes:
                 if lane.partition is not None:
                     raise ScanCompositionError(f"lane tile {lane.module!r} carries a partition filter but the scan already has a shared partitioner")
+        # the rows/cycle axis rides the module-parameter channel: the feed
+        # stream's width is the front unpacker's OUT_WIDTH, and the fan-out
+        # must accept exactly that width — a mismatch would emit a top whose
+        # feed wires and fan-out port widths disagree
+        front_width = self.front_unpack.params.get("OUT_WIDTH", 64) if self.front_unpack is not None else 64
+        fanout_width = self.partitioner.params.get("IN_WIDTH", 64) if self.partitioner is not None else 64
+        if front_width not in (64, 128):
+            raise ScanCompositionError(f"front_unpack OUT_WIDTH must be 64 or 128, got {front_width}")
+        if fanout_width not in (64, 128):
+            raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be 64 or 128, got {fanout_width}")
+        if front_width == 128:
+            if self.partitioner is None:
+                raise ScanCompositionError(
+                    "a 128-bit front stream (front_unpack OUT_WIDTH=128) needs a shared partitioner/dispatcher accepting IN_WIDTH=128; "
+                    "the stream broadcast is 64-bit only"
+                )
+            if fanout_width != 128:
+                raise ScanCompositionError(
+                    f"the front unpacker emits a 128-bit stream but the shared partitioner {self.partitioner.module!r} accepts "
+                    f"IN_WIDTH={fanout_width}; the feed and fan-out widths must agree"
+                )
+        elif fanout_width != 64:
+            raise ScanCompositionError(
+                f"the shared partitioner {self.partitioner.module!r} declares IN_WIDTH={fanout_width} but the feed stream is 64-bit; "
+                "compose a front_unpack with OUT_WIDTH=128 to drive a wide fan-out"
+            )
 
 
 _DEFAULT_GENERATED_BY = "dau_build.scan_composition.generate_scan_composition_top_sv"
@@ -704,16 +730,26 @@ def _fanout_sv(composition: ScanComposition, *, clk: str, stream_prefix: str = "
     return wire_decls, instance
 
 
+def _front_stream_width(composition: ScanComposition) -> int:
+    """The feed stream's bit width: the front unpacker's ``OUT_WIDTH``
+    module parameter (the rows/cycle axis — 64 emits two beats per quad row,
+    128 one whole row per beat), defaulting to the classic 64-bit framing
+    when the parameter is not overridden."""
+    if composition.front_unpack is None:
+        return 64
+    return composition.front_unpack.params.get("OUT_WIDTH", 64)
+
+
 def _front_unpack_wire_decls_sv(composition: ScanComposition) -> str:
     """The front unpacker's widened row stream (``feed_*``, driving the
-    fan-out input), its status bundle, and the sticky error latch. Empty
-    string when the composition carries no front unpacker, so the block stays
-    byte-identical."""
+    fan-out input at the composed ``OUT_WIDTH``), its status bundle, and the
+    sticky error latch. Empty string when the composition carries no front
+    unpacker, so the block stays byte-identical."""
     if composition.front_unpack is None:
         return ""
-    return """    wire feed_valid;
+    return f"""    wire feed_valid;
     wire feed_ready;
-    wire [63:0] feed_data;
+    wire [{_front_stream_width(composition) - 1}:0] feed_data;
     wire feed_last;
     wire front_unpack_status_valid;
     wire front_unpack_status_ready;

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -135,38 +135,46 @@ class ScanComposition(BaseModel):
     registers: RegisterLayout = RegisterLayout()
 
     def model_post_init(self, context) -> None:
-        if not self.lanes:
-            raise ScanCompositionError("a scan composition needs at least one lane")
-        if self.partitioner is not None:
-            for lane in self.lanes:
-                if lane.partition is not None:
-                    raise ScanCompositionError(f"lane tile {lane.module!r} carries a partition filter but the scan already has a shared partitioner")
-        # the rows/cycle axis rides the module-parameter channel: the feed
-        # stream's width is the front unpacker's OUT_WIDTH, and the fan-out
-        # must accept exactly that width — a mismatch would emit a top whose
-        # feed wires and fan-out port widths disagree
-        front_width = self.front_unpack.params.get("OUT_WIDTH", 64) if self.front_unpack is not None else 64
-        fanout_width = self.partitioner.params.get("IN_WIDTH", 64) if self.partitioner is not None else 64
-        if front_width not in (64, 128):
-            raise ScanCompositionError(f"front_unpack OUT_WIDTH must be 64 or 128, got {front_width}")
-        if fanout_width not in (64, 128):
-            raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be 64 or 128, got {fanout_width}")
-        if front_width == 128:
-            if self.partitioner is None:
-                raise ScanCompositionError(
-                    "a 128-bit front stream (front_unpack OUT_WIDTH=128) needs a shared partitioner/dispatcher accepting IN_WIDTH=128; "
-                    "the stream broadcast is 64-bit only"
-                )
-            if fanout_width != 128:
-                raise ScanCompositionError(
-                    f"the front unpacker emits a 128-bit stream but the shared partitioner {self.partitioner.module!r} accepts "
-                    f"IN_WIDTH={fanout_width}; the feed and fan-out widths must agree"
-                )
-        elif fanout_width != 64:
+        _validate_composition_shape(self)
+
+
+def _validate_composition_shape(composition: "ScanComposition") -> None:
+    """The composition's shape and width-coherence invariants. Called from
+    ``model_post_init`` AND from both public generators: ``model_copy`` skips
+    pydantic validation, so an emitted top/sim must re-check — an incoherent
+    copy would otherwise emit Verilog whose feed wires and fan-out port
+    widths disagree."""
+    if not composition.lanes:
+        raise ScanCompositionError("a scan composition needs at least one lane")
+    if composition.partitioner is not None:
+        for lane in composition.lanes:
+            if lane.partition is not None:
+                raise ScanCompositionError(f"lane tile {lane.module!r} carries a partition filter but the scan already has a shared partitioner")
+    # the rows/cycle axis rides the module-parameter channel: the feed
+    # stream's width is the front unpacker's OUT_WIDTH, and the fan-out
+    # must accept exactly that width
+    front_width = composition.front_unpack.params.get("OUT_WIDTH", 64) if composition.front_unpack is not None else 64
+    fanout_width = composition.partitioner.params.get("IN_WIDTH", 64) if composition.partitioner is not None else 64
+    if front_width not in (64, 128):
+        raise ScanCompositionError(f"front_unpack OUT_WIDTH must be 64 or 128, got {front_width}")
+    if fanout_width not in (64, 128):
+        raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be 64 or 128, got {fanout_width}")
+    if front_width == 128:
+        if composition.partitioner is None:
             raise ScanCompositionError(
-                f"the shared partitioner {self.partitioner.module!r} declares IN_WIDTH={fanout_width} but the feed stream is 64-bit; "
-                "compose a front_unpack with OUT_WIDTH=128 to drive a wide fan-out"
+                "a 128-bit front stream (front_unpack OUT_WIDTH=128) needs a shared partitioner/dispatcher accepting IN_WIDTH=128; "
+                "the stream broadcast is 64-bit only"
             )
+        if fanout_width != 128:
+            raise ScanCompositionError(
+                f"the front unpacker emits a 128-bit stream but the shared partitioner {composition.partitioner.module!r} accepts "
+                f"IN_WIDTH={fanout_width}; the feed and fan-out widths must agree"
+            )
+    elif fanout_width != 64:
+        raise ScanCompositionError(
+            f"the shared partitioner {composition.partitioner.module!r} declares IN_WIDTH={fanout_width} but the feed stream is 64-bit; "
+            "compose a front_unpack with OUT_WIDTH=128 to drive a wide fan-out"
+        )
 
 
 _DEFAULT_GENERATED_BY = "dau_build.scan_composition.generate_scan_composition_top_sv"
@@ -910,6 +918,7 @@ def generate_scan_composition_top_sv(
     config-binding key checked against the module's real input ports);
     without sources the walker emits from data alone. ``generated_by``
     names the generator in the output banner."""
+    _validate_composition_shape(composition)  # model_copy skips model_post_init
     if sources is not None:
         _validate_against_sources(composition, sources)
     regs = composition.registers
@@ -1204,6 +1213,7 @@ def generate_scan_composition_sim_sv(
     name with a ``_sim`` suffix; ``mem_words``/``read_latency`` parameterize
     the backdoor RAM. ``sources`` arms the same slang-backed interface
     validation as the shell walker."""
+    _validate_composition_shape(composition)  # model_copy skips model_post_init
     if sources is not None:
         _validate_against_sources(composition, sources)
     addr_width = composition.addr_width

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -455,6 +455,28 @@ def test_wide_front_requires_a_matching_wide_fanout() -> None:
         )
 
 
+def test_generators_revalidate_a_model_copied_composition() -> None:
+    # model_copy(update=...) skips model_post_init, so BOTH generators must
+    # re-check shape/width coherence — an incoherent copy must never emit
+    # width-broken Verilog
+    wide_unpack = TileInstance(module="dau_int32_row_unpack", config=dict(_FRONT_UNPACK_CONFIG), params={"OUT_WIDTH": 128})
+    broadcast_mismatch = _bar_noc_composition().model_copy(update={"front_unpack": wide_unpack})
+    with pytest.raises(ScanCompositionError, match="needs a shared partitioner"):
+        generate_scan_composition_top_sv(broadcast_mismatch)
+    with pytest.raises(ScanCompositionError, match="needs a shared partitioner"):
+        generate_scan_composition_sim_sv(broadcast_mismatch)
+    narrow_fanout = _wide_front_composition().model_copy(update={"partitioner": TileInstance(module="dau_int32_key_mask_dispatcher")})
+    with pytest.raises(ScanCompositionError, match="widths must agree"):
+        generate_scan_composition_top_sv(narrow_fanout)
+    with pytest.raises(ScanCompositionError, match="widths must agree"):
+        generate_scan_composition_sim_sv(narrow_fanout)
+    bad_width = _wide_front_composition().model_copy(
+        update={"partitioner": TileInstance(module="dau_int32_key_mask_dispatcher", params={"IN_WIDTH": 96})}
+    )
+    with pytest.raises(ScanCompositionError, match="IN_WIDTH must be 64 or 128"):
+        generate_scan_composition_top_sv(bad_width)
+
+
 def test_front_unpack_status_is_latched_and_folded_into_job_error() -> None:
     text = generate_scan_composition_top_sv(_front_unpacked_composition())
     # the front-stage status close-out is consumed (ready tied high) ...

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -387,6 +387,74 @@ def test_front_unpack_wires_reader_through_unpacker_to_the_fanout() -> None:
     assert "    wire feed_valid;\n    wire feed_ready;\n    wire [63:0] feed_data;\n    wire feed_last;\n" in text
 
 
+def _wide_front_composition() -> ScanComposition:
+    """The rows/cycle-axis shape: a 128-bit front unpacker (OUT_WIDTH=128, one
+    whole quad row per beat) feeding a key-mask dispatcher (IN_WIDTH=128) that
+    routes each row to one of four filterless lanes."""
+    return ScanComposition(
+        name="bar-noc-wide",
+        module_name="dau_mm_bar_noc_wide_job",
+        lanes=tuple(
+            LaneTile(module="dau_int32_bar_aggregation", config={"cfg_mode": "2'd0", "cfg_row_count": "64'd0"}, count_port="bar_count")
+            for _ in range(4)
+        ),
+        partitioner=TileInstance(module="dau_int32_key_mask_dispatcher", params={"IN_WIDTH": 128}),
+        front_unpack=TileInstance(module="dau_int32_row_unpack", config=dict(_FRONT_UNPACK_CONFIG), params={"OUT_WIDTH": 128}),
+    )
+
+
+def test_wide_front_widens_the_feed_and_threads_the_width_params() -> None:
+    # the feed stream is declared at the front unpacker's OUT_WIDTH and both
+    # width params land on their instances via the module-parameter channel
+    text = generate_scan_composition_top_sv(_wide_front_composition())
+    assert "    wire feed_valid;\n    wire feed_ready;\n    wire [127:0] feed_data;\n    wire feed_last;\n" in text
+    assert "dau_int32_row_unpack #(\n        .OUT_WIDTH(128)\n    )" in text
+    dispatcher_block = text.split("dau_int32_key_mask_dispatcher #(")[1].split(");")[0]
+    assert ".NUM_PARTITIONS(4)" in dispatcher_block
+    assert ".IN_WIDTH(128)" in dispatcher_block
+    assert ".input_data(feed_data)," in dispatcher_block
+    # per-lane taps stay the 64-bit two-beat framing (no operator widens)
+    assert "assign filt_out_data_0 = part_out_data[63:0];" in text
+    # the sim harness mirrors the same width
+    sim = generate_scan_composition_sim_sv(_wide_front_composition())
+    assert "wire [127:0] feed_data;" in sim
+
+
+def test_wide_front_requires_a_matching_wide_fanout() -> None:
+    # broadcast is 64-bit only: a wide front with no shared partitioner is
+    # rejected, as is any feed/fan-out width mismatch (either direction).
+    # Constructed directly — model_copy skips model_post_init validation.
+    wide_unpack = TileInstance(module="dau_int32_row_unpack", config=dict(_FRONT_UNPACK_CONFIG), params={"OUT_WIDTH": 128})
+    plain_lanes = tuple(
+        LaneTile(module="dau_int32_bar_aggregation", config={"cfg_mode": "2'd0", "cfg_row_count": "64'd0"}, count_port="bar_count") for _ in range(4)
+    )
+    with pytest.raises(ValidationError, match="needs a shared partitioner"):
+        ScanComposition(name="bad", module_name="dau_bad", lanes=plain_lanes, front_unpack=wide_unpack)
+    with pytest.raises(ValidationError, match="widths must agree"):
+        ScanComposition(
+            name="bad",
+            module_name="dau_bad",
+            lanes=plain_lanes,
+            partitioner=TileInstance(module="dau_int32_key_mask_dispatcher"),
+            front_unpack=wide_unpack,
+        )
+    with pytest.raises(ValidationError, match="feed stream is 64-bit"):
+        ScanComposition(
+            name="bad",
+            module_name="dau_bad",
+            lanes=plain_lanes,
+            partitioner=TileInstance(module="dau_int32_key_mask_dispatcher", params={"IN_WIDTH": 128}),
+        )
+    with pytest.raises(ValidationError, match="OUT_WIDTH must be 64 or 128"):
+        ScanComposition(
+            name="bad",
+            module_name="dau_bad",
+            lanes=plain_lanes,
+            partitioner=TileInstance(module="dau_int32_key_mask_dispatcher", params={"IN_WIDTH": 128}),
+            front_unpack=TileInstance(module="dau_int32_row_unpack", config=dict(_FRONT_UNPACK_CONFIG), params={"OUT_WIDTH": 96}),
+        )
+
+
 def test_front_unpack_status_is_latched_and_folded_into_job_error() -> None:
     text = generate_scan_composition_top_sv(_front_unpacked_composition())
     # the front-stage status close-out is consumed (ready tied high) ...


### PR DESCRIPTION
The rows/cycle axis rides the EXISTING module-parameter channel — no new composition field. The walker sizes the feed_* stream wires from the front unpacker's OUT_WIDTH parameter (wire [127:0] feed_data when the front emits one whole quad row per beat), and the shared partitioner's IN_WIDTH lands through the existing extra-params emission — so a wide composition is just a front_unpack carrying OUT_WIDTH=128 feeding a key-mask dispatcher carrying IN_WIDTH=128, with the per-lane taps staying the 64-bit two-beat framing (no operator widens).

Shape/width coherence lives in _validate_composition_shape, called from model_post_init AND from both public generators — model_copy(update=...) skips pydantic validation, so an incoherent copy can never emit Verilog whose feed wires and fan-out port widths disagree. Checks: raw widths in {64,128}; a 128-bit front requires a shared partitioner with IN_WIDTH=128 (the stream broadcast is 64-bit only); both mismatch directions rejected. Param-less compositions emit byte-identically (all pinned goldens unchanged; 319 passed, 1 skipped).

Reviewed with codex gpt-5.6-sol (APPROVE, after a round that moved revalidation into the generators to close the model_copy bypass).