### PR TITLE
Add synthesize-cores task for per-core OOC characterization

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1120,17 +1120,35 @@ def _model_types_from_config_group(kind: str) -> Mapping[str, type[BuildCallable
     return MappingProxyType(model_types)
 
 
-STEP_MODEL_TYPES: Mapping[str, type[BuildCallableModel]] = _model_types_from_config_group("step")
+# STEP_MODEL_TYPES / TASK_MODEL_TYPES resolve lazily (module __getattr__):
+# deriving them imports every _target_ module, and a task module defined
+# outside build_steps imports BuildCallableModel from here — eager derivation
+# at import time would make that a circular import. Lazy keeps the config
+# tree the single registry while letting tasks live in their own modules
+# (the extension mechanism).
+_MODEL_TYPE_CACHE: dict[str, Mapping[str, type[BuildCallableModel]]] = {}
 
-TASK_MODEL_TYPES: Mapping[str, type[BuildCallableModel]] = _model_types_from_config_group("task")
+
+def _model_types(kind: str) -> Mapping[str, type[BuildCallableModel]]:
+    if kind not in _MODEL_TYPE_CACHE:
+        _MODEL_TYPE_CACHE[kind] = _model_types_from_config_group(kind)
+    return _MODEL_TYPE_CACHE[kind]
+
+
+def __getattr__(name: str):
+    if name == "STEP_MODEL_TYPES":
+        return _model_types("step")
+    if name == "TASK_MODEL_TYPES":
+        return _model_types("task")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def available_step_names() -> tuple[str, ...]:
-    return tuple(sorted(STEP_MODEL_TYPES))
+    return tuple(sorted(_model_types("step")))
 
 
 def available_task_names() -> tuple[str, ...]:
-    return tuple(sorted(TASK_MODEL_TYPES))
+    return tuple(sorted(_model_types("task")))
 
 
 def parse_override_dict(arguments: Iterable[str]) -> dict[str, str]:
@@ -1153,7 +1171,7 @@ def execute_override_step(arguments: Iterable[str]) -> BuildStepResult:
     step_name = overrides.pop("step", None)
     if not step_name:
         raise BuildStepError("missing required override: step")
-    return _execute_named_callable(STEP_MODEL_TYPES, step_name, overrides, request_kind="step")
+    return _execute_named_callable(_model_types("step"), step_name, overrides, request_kind="step")
 
 
 def execute_override_task(arguments: Iterable[str]) -> BuildStepResult:
@@ -1163,7 +1181,7 @@ def execute_override_task(arguments: Iterable[str]) -> BuildStepResult:
         raise BuildStepError("missing required override: task")
     if "step" in overrides:
         raise BuildStepError("task requests cannot also provide step")
-    return _execute_named_callable(TASK_MODEL_TYPES, task_name, overrides, request_kind="task")
+    return _execute_named_callable(_model_types("task"), task_name, overrides, request_kind="task")
 
 
 def execute_override_request(arguments: Iterable[str]) -> BuildStepResult:
@@ -1173,9 +1191,9 @@ def execute_override_request(arguments: Iterable[str]) -> BuildStepResult:
     if task_name and step_name:
         raise BuildStepError("provide either task or step, not both")
     if task_name:
-        return _execute_named_callable(TASK_MODEL_TYPES, task_name, overrides, request_kind="task")
+        return _execute_named_callable(_model_types("task"), task_name, overrides, request_kind="task")
     if step_name:
-        return _execute_named_callable(STEP_MODEL_TYPES, step_name, overrides, request_kind="step")
+        return _execute_named_callable(_model_types("step"), step_name, overrides, request_kind="step")
     raise BuildStepError("missing required override: task")
 
 

--- a/dau_build/config/task/tasks/build/synthesize-cores.yaml
+++ b/dau_build/config/task/tasks/build/synthesize-cores.yaml
@@ -1,0 +1,18 @@
+# @package model
+
+# Per-core out-of-context characterization through the registry: resolves
+# /dau-core/<name> entries from the dau-core lernaplugin, plans one OOC
+# vivado synthesis per core, and (execute=true, on the synthesis host)
+# parses envelope reports and flags drift against the registered envelope.
+#   dau-build task=tasks/build/synthesize-cores \
+#     'model.cores=[/dau-core/int32-streaming-top-k]' \
+#     model.output_root=./ooc platform=platforms/dau/dpv1 model.execute=true
+_target_: dau_build.synthesize_cores.SynthesizeCoresTask
+platform: ${oc.select:platform,null}
+cores: ???
+output_root: ???
+part: null
+clock_period_ns: 8.0
+parameters: {}
+execute: false
+vivado: vivado

--- a/dau_build/config/task/tasks/build/synthesize-cores.yaml
+++ b/dau_build/config/task/tasks/build/synthesize-cores.yaml
@@ -14,5 +14,6 @@ output_root: ???
 part: null
 clock_period_ns: 8.0
 parameters: {}
+clock_ports: {}
 execute: false
 vivado: vivado

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -112,9 +112,14 @@ class SynthesizeCoresTask(BuildCallableModel):
             definitions = loaded_cores()
             if name not in definitions:
                 raise UnknownCoreError(name)
-            return definitions[name]
+            definition = definitions[name]
         except UnknownCoreError as exc:
             raise BuildStepError(f"unknown core {entry!r}") from exc
+        if definition.kind.value == "package":
+            # a SystemVerilog package is not a synthesizable top; it rides
+            # along as a dependency of the tiles that import it
+            raise BuildStepError(f"core {entry!r} is a package, not a synthesizable top; select the tiles that depend on it")
+        return definition
 
     def _part(self) -> str:
         if self.part is not None:

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -1,0 +1,221 @@
+"""Per-core out-of-context characterization through the registry.
+
+``SynthesizeCoresTask`` resolves cores from the ccflow registry
+(``/dau-core/<core-name>``, the dau-core lernaplugin's config tree), plans
+one out-of-context Vivado synthesis per core (dependency-closed sources,
+``-generic`` values from the core's declared ``ParameterSpec`` defaults
+merged with task overrides, the platform part, a ``create_clock`` at the
+job clock), and writes the tcl + a command-plan runner under
+``output_root``. With ``execute=true`` (where vivado is installed — the
+synthesis host) it runs the plan and parses each utilization/timing report
+into a resource-envelope summary, flagging drift against the envelope
+registered in the core registry. Envelope numbers enter the registry only
+from this task — never from hand-run synthesis.
+"""
+
+# NOTE: no `from __future__ import annotations` — ccflow's Flow.call
+# inspects the real annotation objects on __call__ (the build_steps pattern)
+import re
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ccflow import BaseModel, Flow, NullContext
+
+from dau_build.build_steps import BuildCallableModel, BuildStepError, BuildStepResult
+
+__all__ = ("CoreEnvelopeReport", "SynthesizeCoresTask")
+
+_REGISTRY_PREFIX = "/dau-core/"
+
+
+class CoreEnvelopeReport(BaseModel):
+    """One core's parsed OOC result, comparable to its registered envelope."""
+
+    name: str
+    module: str
+    lut: int
+    ff: int
+    bram36: float
+    dsp: int
+    wns_ns: float
+    met: bool
+    registered_matches: bool | None = None  # None: no envelope registered
+
+
+class SynthesizeCoresTask(BuildCallableModel):
+    # registry paths (`/dau-core/<core-name>`; bare core names accepted)
+    cores: tuple[str, ...]
+    output_root: Path
+    # part source: explicit `part` wins, else the composed `platform=` group
+    platform: Any = None
+    part: str | None = None
+    clock_period_ns: float = 8.0
+    # per-core `-generic` overrides, keyed by core name then parameter name;
+    # an override of a parameter the core does not declare is rejected
+    parameters: Mapping[str, Mapping[str, int]] = {}
+    # run the plan (the synthesis host has vivado); false = handoff only
+    execute: bool = False
+    vivado: str = "vivado"
+
+    @Flow.call
+    def __call__(self, context: NullContext) -> BuildStepResult:  # noqa: ARG002 (ccflow requires the name `context`)
+        definitions = [self._resolve_core(entry) for entry in self.cores]
+        if not definitions:
+            raise BuildStepError("no cores selected; pass model.cores=[/dau-core/<name>,...]")
+        part = self._part()
+        self.output_root.mkdir(parents=True, exist_ok=True)
+        scripts = [self._stage_core(definition, part=part) for definition in definitions]
+        plan_path = self._write_plan(scripts)
+        if not self.execute:
+            return BuildStepResult(
+                step="synthesize-cores",
+                message=(
+                    f"dau-build-synthesize-cores\tcores={','.join(d.name for d in definitions)} part={part} "
+                    f"clock_ns={self.clock_period_ns} output_root={self.output_root} plan={plan_path} status=handoff-written"
+                ),
+            )
+        reports = [self._run_and_parse(definition, script) for definition, script in zip(definitions, scripts)]
+        drift = [report.name for report in reports if report.registered_matches is False]
+        summary = " ".join(
+            f"{r.name}:lut={r.lut},ff={r.ff},bram36={r.bram36},dsp={r.dsp},wns={r.wns_ns:+.3f},{'met' if r.met else 'VIOLATED'}" for r in reports
+        )
+        return BuildStepResult(
+            step="synthesize-cores",
+            message=(
+                f"dau-build-synthesize-cores\tcores={','.join(d.name for d in definitions)} part={part} "
+                f"clock_ns={self.clock_period_ns} output_root={self.output_root} {summary} "
+                f"envelope_drift={','.join(drift) if drift else 'none'} status=synthesized"
+            ),
+        )
+
+    def _resolve_core(self, entry: str):
+        name = entry.removeprefix(_REGISTRY_PREFIX)
+        if "/" in name:
+            raise BuildStepError(f"core entry {entry!r} is not a /dau-core/<name> registry path")
+        try:
+            from dau_core.cores import UnknownCoreError, loaded_cores
+        except ImportError as exc:
+            raise BuildStepError("dau-core is not installed; the core registry is unavailable") from exc
+        try:
+            definitions = loaded_cores()
+            if name not in definitions:
+                raise UnknownCoreError(name)
+            return definitions[name]
+        except UnknownCoreError as exc:
+            raise BuildStepError(f"unknown core {entry!r}") from exc
+
+    def _part(self) -> str:
+        if self.part is not None:
+            return self.part
+        part = getattr(self.platform, "part", None)
+        if part:
+            return part
+        raise BuildStepError("no part selected; pass model.part=... or compose a platform= group")
+
+    def _generics(self, definition) -> dict[str, int]:
+        values = {name: spec.default for name, spec in definition.parameters.items()}
+        overrides = self.parameters.get(definition.name, {})
+        unknown = set(overrides) - set(values)
+        if unknown:
+            raise BuildStepError(f"core {definition.name!r} declares no parameter {sorted(unknown)}; declared: {sorted(values) or 'none'}")
+        values.update(overrides)
+        return values
+
+    def _stage_core(self, definition, *, part: str) -> Path:
+        from dau_core.cores import sources_for
+
+        sources = sources_for(definition.name)
+        generics = self._generics(definition)
+        generic_args = "".join(f" -generic {name}={value}" for name, value in generics.items())
+        reads = "\n".join(f"read_verilog -sv {path}" for path in sources)
+        util_rpt = self.output_root / f"{definition.module}.util.rpt"
+        timing_rpt = self.output_root / f"{definition.module}.timing.rpt"
+        tcl = (
+            f"{reads}\n"
+            f"synth_design -top {definition.module} -part {part} -mode out_of_context{generic_args}\n"
+            f"create_clock -period {self.clock_period_ns:.3f} -name clk [get_ports clk]\n"
+            f"report_utilization -file {util_rpt}\n"
+            f"report_timing_summary -max_paths 1 -delay_type max -file {timing_rpt}\n"
+        )
+        script = self.output_root / f"{definition.module}.ooc.tcl"
+        script.write_text(tcl)
+        return script
+
+    def _write_plan(self, scripts: list[Path]) -> Path:
+        lines = ["#!/bin/sh", "set -e"]
+        for script in scripts:
+            stem = script.stem.removesuffix(".ooc")
+            lines.append(f"{self.vivado} -mode batch -source {script} -log {self.output_root / stem}.log -journal {self.output_root / stem}.jou")
+        plan = self.output_root / "synthesize-cores.sh"
+        plan.write_text("\n".join(lines) + "\n")
+        plan.chmod(0o755)
+        return plan
+
+    def _run_and_parse(self, definition, script: Path) -> CoreEnvelopeReport:
+        stem = script.stem.removesuffix(".ooc")
+        completed = subprocess.run(
+            [
+                self.vivado,
+                "-mode",
+                "batch",
+                "-source",
+                str(script),
+                "-log",
+                f"{self.output_root / stem}.log",
+                "-journal",
+                f"{self.output_root / stem}.jou",
+            ],
+            cwd=self.output_root,
+            capture_output=True,
+            text=True,
+        )
+        if completed.returncode != 0:
+            raise BuildStepError(f"vivado failed for {definition.name} (exit {completed.returncode}); see {self.output_root / stem}.log")
+        return self.parse_reports(definition, output_root=self.output_root)
+
+    @staticmethod
+    def parse_reports(definition, *, output_root: Path) -> CoreEnvelopeReport:
+        """Parse a core's utilization/timing reports into an envelope report,
+        comparing against the envelope registered in the core registry."""
+        util = (output_root / f"{definition.module}.util.rpt").read_text()
+        timing = (output_root / f"{definition.module}.timing.rpt").read_text()
+        lut = _util_value(util, r"Slice LUTs\*?")
+        ff = _util_value(util, r"Slice Registers")
+        bram = _util_float(util, r"Block RAM Tile")
+        dsp = _util_value(util, r"DSPs")
+        slack = re.search(r"Slack \((MET|VIOLATED)\)\s*:\s*(-?[\d.]+)ns", timing)
+        if slack is None:
+            raise BuildStepError(f"no slack line in {definition.module}.timing.rpt")
+        wns = float(slack.group(2)) if slack.group(1) == "MET" else -abs(float(slack.group(2)))
+        registered = definition.resources
+        matches = None
+        if registered is not None:
+            matches = (registered.lut, registered.ff, registered.bram36, registered.dsp) == (lut, ff, bram, dsp)
+        return CoreEnvelopeReport(
+            name=definition.name,
+            module=definition.module,
+            lut=lut,
+            ff=ff,
+            bram36=bram,
+            dsp=dsp,
+            wns_ns=wns,
+            met=slack.group(1) == "MET",
+            registered_matches=matches,
+        )
+
+
+def _util_value(report: str, label: str) -> int:
+    return int(_util_cell(report, label))
+
+
+def _util_float(report: str, label: str) -> float:
+    return float(_util_cell(report, label))
+
+
+def _util_cell(report: str, label: str) -> str:
+    match = re.search(rf"^\|\s*{label}\s*\|\s*([\d.]+)\s*\|", report, re.MULTILINE)
+    if match is None:
+        raise BuildStepError(f"no '{label}' row in utilization report")
+    return match.group(1)

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -16,6 +16,7 @@ from this task — never from hand-run synthesis.
 # NOTE: no `from __future__ import annotations` — ccflow's Flow.call
 # inspects the real annotation objects on __call__ (the build_steps pattern)
 import re
+import shlex
 import subprocess
 from collections.abc import Mapping
 from pathlib import Path
@@ -65,18 +66,21 @@ class SynthesizeCoresTask(BuildCallableModel):
         if not definitions:
             raise BuildStepError("no cores selected; pass model.cores=[/dau-core/<name>,...]")
         part = self._part()
-        self.output_root.mkdir(parents=True, exist_ok=True)
-        scripts = [self._stage_core(definition, part=part) for definition in definitions]
-        plan_path = self._write_plan(scripts)
+        # resolve once: relative output_root (./ooc) plus a subprocess cwd
+        # would otherwise double the prefix inside vivado
+        root = self.output_root.resolve()
+        root.mkdir(parents=True, exist_ok=True)
+        scripts = [self._stage_core(definition, part=part, root=root) for definition in definitions]
+        plan_path = self._write_plan(scripts, root=root)
         if not self.execute:
             return BuildStepResult(
                 step="synthesize-cores",
                 message=(
                     f"dau-build-synthesize-cores\tcores={','.join(d.name for d in definitions)} part={part} "
-                    f"clock_ns={self.clock_period_ns} output_root={self.output_root} plan={plan_path} status=handoff-written"
+                    f"clock_ns={self.clock_period_ns} output_root={root} plan={plan_path} status=handoff-written"
                 ),
             )
-        reports = [self._run_and_parse(definition, script) for definition, script in zip(definitions, scripts)]
+        reports = [self._run_and_parse(definition, script, root=root) for definition, script in zip(definitions, scripts)]
         drift = [report.name for report in reports if report.registered_matches is False]
         summary = " ".join(
             f"{r.name}:lut={r.lut},ff={r.ff},bram36={r.bram36},dsp={r.dsp},wns={r.wns_ns:+.3f},{'met' if r.met else 'VIOLATED'}" for r in reports
@@ -85,7 +89,7 @@ class SynthesizeCoresTask(BuildCallableModel):
             step="synthesize-cores",
             message=(
                 f"dau-build-synthesize-cores\tcores={','.join(d.name for d in definitions)} part={part} "
-                f"clock_ns={self.clock_period_ns} output_root={self.output_root} {summary} "
+                f"clock_ns={self.clock_period_ns} output_root={root} {summary} "
                 f"envelope_drift={','.join(drift) if drift else 'none'} status=synthesized"
             ),
         )
@@ -120,60 +124,71 @@ class SynthesizeCoresTask(BuildCallableModel):
         unknown = set(overrides) - set(values)
         if unknown:
             raise BuildStepError(f"core {definition.name!r} declares no parameter {sorted(unknown)}; declared: {sorted(values) or 'none'}")
+        for name, value in overrides.items():
+            _validate_override(definition.name, name, value, definition.parameters[name])
         values.update(overrides)
         return values
 
-    def _stage_core(self, definition, *, part: str) -> Path:
+    def _stage_core(self, definition, *, part: str, root: Path) -> Path:
         from dau_core.cores import sources_for
 
         sources = sources_for(definition.name)
         generics = self._generics(definition)
         generic_args = "".join(f" -generic {name}={value}" for name, value in generics.items())
-        reads = "\n".join(f"read_verilog -sv {path}" for path in sources)
-        util_rpt = self.output_root / f"{definition.module}.util.rpt"
-        timing_rpt = self.output_root / f"{definition.module}.timing.rpt"
+        reads = "\n".join(f"read_verilog -sv {_tcl_path(path)}" for path in sources)
+        # the clock rides an XDC read BEFORE synth_design so synthesis itself
+        # is clock-constrained (a create_clock after synth_design would leave
+        # synthesis unconstrained and only time the report)
+        xdc = root / f"{definition.module}.ooc.xdc"
+        xdc.write_text(f"create_clock -period {self.clock_period_ns:.3f} -name clk [get_ports clk]\n")
+        util_rpt = root / f"{definition.module}.util.rpt"
+        timing_rpt = root / f"{definition.module}.timing.rpt"
         tcl = (
             f"{reads}\n"
+            f"read_xdc -mode out_of_context {_tcl_path(xdc)}\n"
             f"synth_design -top {definition.module} -part {part} -mode out_of_context{generic_args}\n"
-            f"create_clock -period {self.clock_period_ns:.3f} -name clk [get_ports clk]\n"
-            f"report_utilization -file {util_rpt}\n"
-            f"report_timing_summary -max_paths 1 -delay_type max -file {timing_rpt}\n"
+            f"report_utilization -file {_tcl_path(util_rpt)}\n"
+            f"report_timing_summary -max_paths 1 -delay_type max -file {_tcl_path(timing_rpt)}\n"
         )
-        script = self.output_root / f"{definition.module}.ooc.tcl"
+        script = root / f"{definition.module}.ooc.tcl"
         script.write_text(tcl)
         return script
 
-    def _write_plan(self, scripts: list[Path]) -> Path:
+    def _write_plan(self, scripts: list[Path], *, root: Path) -> Path:
         lines = ["#!/bin/sh", "set -e"]
         for script in scripts:
-            stem = script.stem.removesuffix(".ooc")
-            lines.append(f"{self.vivado} -mode batch -source {script} -log {self.output_root / stem}.log -journal {self.output_root / stem}.jou")
-        plan = self.output_root / "synthesize-cores.sh"
+            lines.append(shlex.join(self._vivado_argv(script, root=root)))
+        plan = root / "synthesize-cores.sh"
         plan.write_text("\n".join(lines) + "\n")
         plan.chmod(0o755)
         return plan
 
-    def _run_and_parse(self, definition, script: Path) -> CoreEnvelopeReport:
+    def _vivado_argv(self, script: Path, *, root: Path) -> list[str]:
         stem = script.stem.removesuffix(".ooc")
+        return [
+            self.vivado,
+            "-mode",
+            "batch",
+            "-source",
+            str(script),
+            "-log",
+            f"{root / stem}.log",
+            "-journal",
+            f"{root / stem}.jou",
+        ]
+
+    def _run_and_parse(self, definition, script: Path, *, root: Path) -> CoreEnvelopeReport:
         completed = subprocess.run(
-            [
-                self.vivado,
-                "-mode",
-                "batch",
-                "-source",
-                str(script),
-                "-log",
-                f"{self.output_root / stem}.log",
-                "-journal",
-                f"{self.output_root / stem}.jou",
-            ],
-            cwd=self.output_root,
+            self._vivado_argv(script, root=root),
+            cwd=root,
             capture_output=True,
             text=True,
         )
         if completed.returncode != 0:
-            raise BuildStepError(f"vivado failed for {definition.name} (exit {completed.returncode}); see {self.output_root / stem}.log")
-        return self.parse_reports(definition, output_root=self.output_root)
+            raise BuildStepError(
+                f"vivado failed for {definition.name} (exit {completed.returncode}); see {root / script.stem.removesuffix('.ooc')}.log"
+            )
+        return self.parse_reports(definition, output_root=root)
 
     @staticmethod
     def parse_reports(definition, *, output_root: Path) -> CoreEnvelopeReport:
@@ -204,6 +219,35 @@ class SynthesizeCoresTask(BuildCallableModel):
             met=slack.group(1) == "MET",
             registered_matches=matches,
         )
+
+
+def _tcl_path(path: Path) -> str:
+    """Brace-quote a filesystem path for generated tcl (spaces survive)."""
+    return "{" + str(path) + "}"
+
+
+def _validate_override(core_name: str, name: str, value: int, spec) -> None:
+    """Enforce the registry's declared parameter constraints on an override —
+    the same rules dau-core's composition validates (ParameterSpec: choices,
+    positive, minimum/maximum, multiple_of, power_of_two) so an invalid value
+    is rejected here, never as an HDL elaboration failure."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise BuildStepError(f"core {core_name!r} parameter {name!r} must be a positive int, got {value!r}")
+    if spec.choices is not None:
+        if value not in spec.choices:
+            allowed = ", ".join(str(choice) for choice in spec.choices)
+            raise BuildStepError(f"core {core_name!r} parameter {name!r} must be one of {allowed}, got {value!r}")
+        return  # an enumerated choice set is the whole constraint
+    if value <= 0:
+        raise BuildStepError(f"core {core_name!r} parameter {name!r} must be a positive int, got {value!r}")
+    if value < spec.minimum:
+        raise BuildStepError(f"core {core_name!r} parameter {name!r} must be >= {spec.minimum}, got {value!r}")
+    if spec.maximum is not None and value > spec.maximum:
+        raise BuildStepError(f"core {core_name!r} parameter {name!r} must be <= {spec.maximum}, got {value!r}")
+    if value % spec.multiple_of != 0:
+        raise BuildStepError(f"core {core_name!r} parameter {name!r} must be a positive multiple of {spec.multiple_of}, got {value!r}")
+    if spec.power_of_two and value & (value - 1):
+        raise BuildStepError(f"core {core_name!r} parameter {name!r} must be a power of two, got {value!r}")
 
 
 def _util_value(report: str, label: str) -> int:

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -40,9 +40,9 @@ class CoreEnvelopeReport(BaseModel):
     ff: int
     bram36: float
     dsp: int
-    wns_ns: float
-    met: bool
-    registered_matches: bool | None = None  # None: no envelope registered
+    wns_ns: float | None = None  # None: characterized unclocked
+    met: bool | None = None
+    registered_matches: bool | None = None  # None: no envelope registered, or overrides changed the shape
 
 
 class SynthesizeCoresTask(BuildCallableModel):
@@ -56,6 +56,10 @@ class SynthesizeCoresTask(BuildCallableModel):
     # per-core `-generic` overrides, keyed by core name then parameter name;
     # an override of a parameter the core does not declare is rejected
     parameters: Mapping[str, Mapping[str, int]] = {}
+    # per-core clock port when it is not the tile contract's `clk`
+    # (identity-axil's s_axi_aclk); empty string = combinational, no clock
+    # constraint and no timing report
+    clock_ports: Mapping[str, str] = {}
     # run the plan (the synthesis host has vivado); false = handoff only
     execute: bool = False
     vivado: str = "vivado"
@@ -83,7 +87,9 @@ class SynthesizeCoresTask(BuildCallableModel):
         reports = [self._run_and_parse(definition, script, root=root) for definition, script in zip(definitions, scripts)]
         drift = [report.name for report in reports if report.registered_matches is False]
         summary = " ".join(
-            f"{r.name}:lut={r.lut},ff={r.ff},bram36={r.bram36},dsp={r.dsp},wns={r.wns_ns:+.3f},{'met' if r.met else 'VIOLATED'}" for r in reports
+            f"{r.name}:lut={r.lut},ff={r.ff},bram36={r.bram36},dsp={r.dsp},"
+            + (f"wns={r.wns_ns:+.3f},{'met' if r.met else 'VIOLATED'}" if r.wns_ns is not None else "unclocked")
+            for r in reports
         )
         return BuildStepResult(
             step="synthesize-cores",
@@ -138,18 +144,21 @@ class SynthesizeCoresTask(BuildCallableModel):
         reads = "\n".join(f"read_verilog -sv {_tcl_path(path)}" for path in sources)
         # the clock rides an XDC read BEFORE synth_design so synthesis itself
         # is clock-constrained (a create_clock after synth_design would leave
-        # synthesis unconstrained and only time the report)
-        xdc = root / f"{definition.module}.ooc.xdc"
-        xdc.write_text(f"create_clock -period {self.clock_period_ns:.3f} -name clk [get_ports clk]\n")
+        # synthesis unconstrained and only time the report); a core whose
+        # clock_ports entry is "" is combinational — no constraint, no timing
+        clock_port = self.clock_ports.get(definition.name, "clk")
         util_rpt = root / f"{definition.module}.util.rpt"
-        timing_rpt = root / f"{definition.module}.timing.rpt"
-        tcl = (
-            f"{reads}\n"
-            f"read_xdc -mode out_of_context {_tcl_path(xdc)}\n"
-            f"synth_design -top {definition.module} -part {part} -mode out_of_context{generic_args}\n"
-            f"report_utilization -file {_tcl_path(util_rpt)}\n"
-            f"report_timing_summary -max_paths 1 -delay_type max -file {_tcl_path(timing_rpt)}\n"
-        )
+        lines = [reads]
+        if clock_port:
+            xdc = root / f"{definition.module}.ooc.xdc"
+            xdc.write_text(f"create_clock -period {self.clock_period_ns:.3f} -name clk [get_ports {clock_port}]\n")
+            lines.append(f"read_xdc -mode out_of_context {_tcl_path(xdc)}")
+        lines.append(f"synth_design -top {definition.module} -part {part} -mode out_of_context{generic_args}")
+        lines.append(f"report_utilization -file {_tcl_path(util_rpt)}")
+        if clock_port:
+            timing_rpt = root / f"{definition.module}.timing.rpt"
+            lines.append(f"report_timing_summary -max_paths 1 -delay_type max -file {_tcl_path(timing_rpt)}")
+        tcl = "\n".join(lines) + "\n"
         script = root / f"{definition.module}.ooc.tcl"
         script.write_text(tcl)
         return script
@@ -191,22 +200,27 @@ class SynthesizeCoresTask(BuildCallableModel):
         return self.parse_reports(definition, output_root=root)
 
     @staticmethod
-    def parse_reports(definition, *, output_root: Path) -> CoreEnvelopeReport:
-        """Parse a core's utilization/timing reports into an envelope report,
-        comparing against the envelope registered in the core registry."""
+    def parse_reports(definition, *, output_root: Path, clocked: bool = True, compare: bool = True) -> CoreEnvelopeReport:
+        """Parse a core's utilization (and, when clocked, timing) reports into
+        an envelope report, comparing against the registered envelope only
+        when the build used the registered (default) parameters."""
         util = (output_root / f"{definition.module}.util.rpt").read_text()
-        timing = (output_root / f"{definition.module}.timing.rpt").read_text()
         lut = _util_value(util, r"Slice LUTs\*?")
         ff = _util_value(util, r"Slice Registers")
         bram = _util_float(util, r"Block RAM Tile")
         dsp = _util_value(util, r"DSPs")
-        slack = re.search(r"Slack \((MET|VIOLATED)\)\s*:\s*(-?[\d.]+)ns", timing)
-        if slack is None:
-            raise BuildStepError(f"no slack line in {definition.module}.timing.rpt")
-        wns = float(slack.group(2)) if slack.group(1) == "MET" else -abs(float(slack.group(2)))
+        wns = None
+        met = None
+        if clocked:
+            timing = (output_root / f"{definition.module}.timing.rpt").read_text()
+            slack = re.search(r"Slack \((MET|VIOLATED)\)\s*:\s*(-?[\d.]+)ns", timing)
+            if slack is None:
+                raise BuildStepError(f"no slack line in {definition.module}.timing.rpt")
+            wns = float(slack.group(2)) if slack.group(1) == "MET" else -abs(float(slack.group(2)))
+            met = slack.group(1) == "MET"
         registered = definition.resources
         matches = None
-        if registered is not None:
+        if compare and registered is not None:
             matches = (registered.lut, registered.ff, registered.bram36, registered.dsp) == (lut, ff, bram, dsp)
         return CoreEnvelopeReport(
             name=definition.name,
@@ -216,7 +230,7 @@ class SynthesizeCoresTask(BuildCallableModel):
             bram36=bram,
             dsp=dsp,
             wns_ns=wns,
-            met=slack.group(1) == "MET",
+            met=met,
             registered_matches=matches,
         )
 

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -197,7 +197,14 @@ class SynthesizeCoresTask(BuildCallableModel):
             raise BuildStepError(
                 f"vivado failed for {definition.name} (exit {completed.returncode}); see {root / script.stem.removesuffix('.ooc')}.log"
             )
-        return self.parse_reports(definition, output_root=root)
+        return self.parse_reports(
+            definition,
+            output_root=root,
+            clocked=bool(self.clock_ports.get(definition.name, "clk")),
+            # an envelope is registered for the DEFAULT parameters; an
+            # overridden build is a different shape, not drift
+            compare=definition.name not in self.parameters,
+        )
 
     @staticmethod
     def parse_reports(definition, *, output_root: Path, clocked: bool = True, compare: bool = True) -> CoreEnvelopeReport:

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -37,6 +37,7 @@ def test_build_step_and_task_dispatch_uses_ccflow_callable_models() -> None:
         "tasks/build/build-vivado-artifacts",
         "tasks/build/overlay-build",
         "tasks/build/synthesize",
+        "tasks/build/synthesize-cores",
         "tasks/flash/flash",
         "tasks/flash/smoke-test",
         "tasks/hardware/hardware-plan",

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -139,6 +139,7 @@ def _task_overrides(name: str, tmp_path: Path) -> tuple[str, ...]:
             f"model.dau_driver_root={tmp_path / 'dau-driver'}",
         ),
         "synthesize": ("model.spec_path=placeholder.yaml", "model.module=dau_identity_top", f"model.output_root={tmp_path / 'out'}"),
+        "synthesize-cores": ("model.cores=[/dau-core/int32-streaming-top-k]", f"model.output_root={tmp_path / 'ooc'}"),
         "validate-vivado-artifacts": (f"model.work_root={tmp_path / 'work'}",),
     }
     return base[name.split("/")[-1]]

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -25,7 +25,10 @@ def test_handoff_writes_ooc_tcl_and_plan(tmp_path: Path) -> None:
     tcl = (tmp_path / "dau_int32_streaming_top_k.ooc.tcl").read_text()
     assert "read_verilog -sv" in tcl and tcl.index("read_verilog") < tcl.index("synth_design")
     assert "synth_design -top dau_int32_streaming_top_k -part xc7a200tfbg484-2 -mode out_of_context -generic K=8" in tcl
-    assert "create_clock -period 8.000 -name clk [get_ports clk]" in tcl
+    # the clock constrains SYNTHESIS: the xdc reads before synth_design
+    assert "read_xdc -mode out_of_context" in tcl and tcl.index("read_xdc") < tcl.index("synth_design")
+    xdc = (tmp_path / "dau_int32_streaming_top_k.ooc.xdc").read_text()
+    assert "create_clock -period 8.000 -name clk [get_ports clk]" in xdc
     assert "report_utilization" in tcl and "report_timing_summary" in tcl
     plan = (tmp_path / "synthesize-cores.sh").read_text()
     assert "vivado -mode batch -source" in plan and "dau_int32_streaming_top_k.ooc.tcl" in plan
@@ -125,3 +128,26 @@ def test_task_composes_from_the_config_group(tmp_path: Path) -> None:
     outcome = cfg_run(result.cfg)
     assert "status=handoff-written" in outcome.message
     assert (tmp_path / "dau_int32_streaming_top_k.ooc.tcl").is_file()
+
+
+def test_parameter_override_constraints_are_enforced(tmp_path: Path) -> None:
+    # the registry's declared ParameterSpec bounds reject bad overrides here,
+    # never as an HDL elaboration failure
+    with pytest.raises(BuildStepError, match="positive int"):
+        _task(tmp_path, parameters={"int32-streaming-top-k": {"K": 0}})(NullContext())
+    with pytest.raises(BuildStepError, match="<= 128"):
+        _task(tmp_path, parameters={"int32-streaming-top-k": {"K": 200}})(NullContext())
+
+
+def test_relative_output_root_stages_absolute_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # a relative output_root (the documented ./ooc) resolves once; every
+    # staged path is absolute so a vivado cwd cannot double the prefix
+    monkeypatch.chdir(tmp_path)
+    result = _task(Path("ooc"))(NullContext())
+    assert "status=handoff-written" in result.message
+    tcl = (tmp_path / "ooc" / "dau_int32_streaming_top_k.ooc.tcl").read_text()
+    for line in tcl.splitlines():
+        if line.startswith("read_xdc") or "-file" in line:
+            assert str(tmp_path) in line, line
+    plan = (tmp_path / "ooc" / "synthesize-cores.sh").read_text()
+    assert str(tmp_path / "ooc" / "dau_int32_streaming_top_k.ooc.tcl") in plan

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -172,3 +172,8 @@ def test_overridden_parameters_skip_envelope_comparison(tmp_path: Path) -> None:
     # a K=32 build is a different shape than the registered K=8 envelope, not drift
     report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, compare=False)
     assert report.registered_matches is None
+
+
+def test_package_entries_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(BuildStepError, match="not a synthesizable top"):
+        _task(tmp_path, cores=("/dau-core/aggregation-pkg",))(NullContext())

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from ccflow import NullContext
+
+from dau_build.build_steps import BuildStepError
+from dau_build.synthesize_cores import SynthesizeCoresTask
+
+pytest.importorskip("dau_core", reason="dau-core not installed (registry unavailable)")
+
+_TOP_K = "/dau-core/int32-streaming-top-k"
+
+
+def _task(tmp_path: Path, **kwargs) -> SynthesizeCoresTask:
+    defaults = {"cores": (_TOP_K,), "output_root": tmp_path, "part": "xc7a200tfbg484-2"}
+    defaults.update(kwargs)
+    return SynthesizeCoresTask(**defaults)
+
+
+def test_handoff_writes_ooc_tcl_and_plan(tmp_path: Path) -> None:
+    result = _task(tmp_path)(NullContext())
+    assert "status=handoff-written" in result.message
+    tcl = (tmp_path / "dau_int32_streaming_top_k.ooc.tcl").read_text()
+    assert "read_verilog -sv" in tcl and tcl.index("read_verilog") < tcl.index("synth_design")
+    assert "synth_design -top dau_int32_streaming_top_k -part xc7a200tfbg484-2 -mode out_of_context -generic K=8" in tcl
+    assert "create_clock -period 8.000 -name clk [get_ports clk]" in tcl
+    assert "report_utilization" in tcl and "report_timing_summary" in tcl
+    plan = (tmp_path / "synthesize-cores.sh").read_text()
+    assert "vivado -mode batch -source" in plan and "dau_int32_streaming_top_k.ooc.tcl" in plan
+
+
+def test_sources_are_dependency_closed_in_order(tmp_path: Path) -> None:
+    _task(tmp_path, cores=("/dau-core/int32-stream-aggregation",))(NullContext())
+    tcl = (tmp_path / "dau_int32_stream_aggregation.ooc.tcl").read_text()
+    reads = [line for line in tcl.splitlines() if line.startswith("read_verilog")]
+    assert len(reads) > 1  # the package + tile deps come along
+    assert reads.index(next(r for r in reads if "dau_aggregation_pkg.sv" in r)) < reads.index(
+        next(r for r in reads if "dau_int32_stream_aggregation.sv" in r)
+    )
+
+
+def test_parameter_override_changes_generic(tmp_path: Path) -> None:
+    _task(tmp_path, parameters={"int32-streaming-top-k": {"K": 32}})(NullContext())
+    tcl = (tmp_path / "dau_int32_streaming_top_k.ooc.tcl").read_text()
+    assert "-generic K=32" in tcl
+
+
+def test_undeclared_parameter_override_is_rejected(tmp_path: Path) -> None:
+    with pytest.raises(BuildStepError, match="declares no parameter"):
+        _task(tmp_path, parameters={"int32-streaming-top-k": {"DEPTH": 4}})(NullContext())
+
+
+def test_unknown_core_and_bad_path_are_rejected(tmp_path: Path) -> None:
+    with pytest.raises(BuildStepError, match="unknown core"):
+        _task(tmp_path, cores=("/dau-core/no-such-core",))(NullContext())
+    with pytest.raises(BuildStepError, match="registry path"):
+        _task(tmp_path, cores=("/elsewhere/thing",))(NullContext())
+
+
+def test_part_falls_back_to_platform_and_errors_without_either(tmp_path: Path) -> None:
+    class FakePlatform:
+        part = "xc7k325tffg900-2"
+
+    task = SynthesizeCoresTask(cores=(_TOP_K,), output_root=tmp_path, platform=FakePlatform())
+    task(NullContext())
+    assert "-part xc7k325tffg900-2" in (tmp_path / "dau_int32_streaming_top_k.ooc.tcl").read_text()
+    with pytest.raises(BuildStepError, match="no part selected"):
+        SynthesizeCoresTask(cores=(_TOP_K,), output_root=tmp_path / "x")(NullContext())
+
+
+_UTIL_RPT = """
+| Slice LUTs*             | 1295 |     0 |          0 |    134600 |  0.96 |
+| Slice Registers         | 1196 |     0 |          0 |    269200 |  0.44 |
+| Block RAM Tile |    0 |     0 |          0 |       365 |  0.00 |
+| DSPs      |    0 |     0 |          0 |       740 |  0.00 |
+"""
+
+_TIMING_RPT = "Slack (MET) :             4.350ns  (required time - arrival time)\n"
+
+
+def test_parse_reports_builds_envelope_and_flags_drift(tmp_path: Path) -> None:
+    from dau_core.cores import core
+
+    definition = core("int32-streaming-top-k")
+    (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT)
+    (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text(_TIMING_RPT)
+    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path)
+    assert (report.lut, report.ff, report.bram36, report.dsp) == (1295, 1196, 0.0, 0)
+    assert report.wns_ns == 4.350 and report.met
+    assert report.registered_matches is True  # the registered envelope came from this shape
+
+    (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT.replace("1295", "999"))
+    drifted = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path)
+    assert drifted.registered_matches is False
+
+
+def test_parse_reports_negative_slack_is_violated(tmp_path: Path) -> None:
+    from dau_core.cores import core
+
+    definition = core("int32-streaming-top-k")
+    (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT)
+    (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text("Slack (VIOLATED) :        -0.898ns  (required time - arrival time)\n")
+    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path)
+    assert not report.met and report.wns_ns == -0.898
+
+
+def test_task_composes_from_the_config_group(tmp_path: Path) -> None:
+    """The CLI surface: task=tasks/build/synthesize-cores resolves this task
+    with cores/output_root overrides — the registry is the coupling, not an
+    import."""
+    from ccflow.utils.hydra import cfg_run
+
+    from dau_build.config import compose_config
+
+    result = compose_config(
+        [
+            "task=tasks/build/synthesize-cores",
+            f"model.cores=[{_TOP_K}]",
+            f"model.output_root={tmp_path}",
+            "model.part=xc7a200tfbg484-2",
+        ]
+    )
+    outcome = cfg_run(result.cfg)
+    assert "status=handoff-written" in outcome.message
+    assert (tmp_path / "dau_int32_streaming_top_k.ooc.tcl").is_file()

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -151,3 +151,24 @@ def test_relative_output_root_stages_absolute_paths(tmp_path: Path, monkeypatch:
             assert str(tmp_path) in line, line
     plan = (tmp_path / "ooc" / "synthesize-cores.sh").read_text()
     assert str(tmp_path / "ooc" / "dau_int32_streaming_top_k.ooc.tcl") in plan
+
+
+def test_clock_port_mapping_and_unclocked_core(tmp_path: Path) -> None:
+    # identity-axil clocks on s_axi_aclk; identity-registers is combinational
+    _task(tmp_path, cores=("/dau-core/identity-axil",), clock_ports={"identity-axil": "s_axi_aclk"})(NullContext())
+    xdc = (tmp_path / "dau_identity_axil.ooc.xdc").read_text()
+    assert "[get_ports s_axi_aclk]" in xdc
+    _task(tmp_path, cores=("/dau-core/identity-registers",), clock_ports={"identity-registers": ""})(NullContext())
+    tcl = (tmp_path / "dau_identity_registers.ooc.tcl").read_text()
+    assert "read_xdc" not in tcl and "report_timing_summary" not in tcl
+
+
+def test_overridden_parameters_skip_envelope_comparison(tmp_path: Path) -> None:
+    from dau_core.cores import core
+
+    definition = core("int32-streaming-top-k")
+    (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT.replace("1295", "5000"))
+    (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text(_TIMING_RPT)
+    # a K=32 build is a different shape than the registered K=8 envelope, not drift
+    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, compare=False)
+    assert report.registered_matches is None


### PR DESCRIPTION
Per-core out-of-context characterization through the registry — the sanctioned replacement for hand-run vivado.

`dau-build task=tasks/build/synthesize-cores 'model.cores=[/dau-core/<name>,...]' model.output_root=... platform=platforms/dau/dpv1 [model.execute=true]`

- Resolves `/dau-core/<name>` entries from the dau-core lernaplugin's registry (the searchpath is the coupling — no dau-core dependency; lazy import with a clean error).
- Stages one OOC synthesis per core: dependency-closed sources, `-generic` values from declared `ParameterSpec` defaults merged with overrides validated against the full declared constraints (choices/minimum/maximum/multiple_of/power_of_two), part from `model.part` or the composed `platform=` group, and the clock as an XDC read **before** `synth_design` so synthesis itself is constrained. `clock_ports` maps non-`clk` clocks (empty = combinational, no constraint/timing). Package entries are rejected as tops.
- Writes brace-quoted tcl + a shell-quoted command-plan runner (handoff mode); with `execute=true` on the synthesis host it runs vivado and parses utilization/timing reports into `CoreEnvelopeReport`s, flagging drift against the registered envelope (comparison suppressed for overridden-parameter builds — different shape, not drift).
- `STEP_MODEL_TYPES`/`TASK_MODEL_TYPES` now resolve lazily (module `__getattr__`) so task modules outside `build_steps` can import `BuildCallableModel` without a circular import — the config tree stays the single task registry.

Envelope numbers enter the core registry only from this task.