### PR TITLE
Document the search-path extension pattern and synthesize-cores

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Build tools for dau
 
 Two synthesis engines are supported: Vivado (the FPGA bitstream flow) and yosys (open-source synthesis that runs in CI). The config plumbing is backend-agnostic, so more can be added.
 
+Composition is the extension mechanism: any package can register its own config tree on the shared Hydra search path via a `hydra.lernaplugins` entry point, and its task/design/board groups compose through this CLI without dau-build importing that package. The core registry itself arrives this way — `dau-core` publishes every hardware building block as a `CoreDefinition` at `/dau-core/<name>`, and the `synthesize-cores` task resolves cores from that registry to run per-core out-of-context characterization (staged Tcl + command plan anywhere; `model.execute=true` on a synthesis host runs Vivado and flags envelope drift against the registered numbers):
+
+```bash
+dau-build task=tasks/build/synthesize-cores   'model.cores=[/dau-core/int32-predicate-filter]'   model.output_root=outputs/ooc model.part=xc7a200tfbg484-2
+```
+
 ## Quickstart
 
 Build the checked-in identity example — no board or vendor tools required:

--- a/docs/reference/tasks-and-steps.md
+++ b/docs/reference/tasks-and-steps.md
@@ -66,6 +66,25 @@ delegates to the synthesis engine composed from the `backend` group (default
 Mode: **run**. See the [config group reference](config-groups.md) for the engine
 models.
 
+### `tasks/build/synthesize-cores` — `SynthesizeCoresTask`
+
+Per-core out-of-context characterization through the registry: resolves
+`/dau-core/<name>` entries (the dau-core lernaplugin's config tree), stages one
+OOC synthesis per core — dependency-closed sources, `-generic` values from the
+core's declared parameters merged with validated `model.parameters` overrides,
+the part from `model.part` or the composed `platform` group, and the clock as
+an XDC read before `synth_design` — and writes the Tcl plus a command-plan
+runner. Required: `model.cores`, `model.output_root`.
+
+- Default (handoff): stages files only; run the plan where Vivado lives.
+- `model.execute=true`: runs Vivado per core, parses utilization/timing into
+  envelope reports, and flags drift against the envelope registered in the
+  core registry. `model.clock_ports` maps non-`clk` clocks (empty string =
+  combinational: no constraint, no timing report). Package cores are rejected
+  as synthesis tops.
+
+Mode: **run**.
+
 ### `tasks/build/build-shell-project` — `BuildShellProjectTask`
 
 Builds a standalone shell project from a generated Tcl script. Required:


### PR DESCRIPTION
README overview now explains the composition-as-extension pattern (`hydra.lernaplugins` config trees composing through this CLI, the dau-core registry at `/dau-core/<name>`) with a runnable non-privileged `synthesize-cores` handoff example; the task catalog gains the `tasks/build/synthesize-cores` reference entry.