### PR TITLE
Model the volatile reprogram ladder as a hardware plan

### DIFF
--- a/dau_build/artifact_bundle.py
+++ b/dau_build/artifact_bundle.py
@@ -14,11 +14,11 @@ HDL_SOURCE_LANGUAGES = frozenset(("systemverilog", "verilog"))
 __all__ = (
     "HDL_SOURCE_LANGUAGES",
     "SUPPORTED_SOURCE_LANGUAGES",
-    "ArtifactBundleError",
-    "ArtifactBundleEntry",
     "ArtifactBundle",
-    "load_artifact_bundle",
+    "ArtifactBundleEntry",
+    "ArtifactBundleError",
     "is_hdl_source_artifact",
+    "load_artifact_bundle",
     "source_language_from_path",
 )
 
@@ -51,7 +51,7 @@ class ArtifactBundle(BaseModel):
     def hdl_source_entries(self) -> tuple[ArtifactBundleEntry, ...]:
         return tuple(entry for entry in self.entries_for_kind("source") if is_hdl_source_artifact(entry.artifact))
 
-    def validate(self, *, required_roles: tuple[str, ...] = (), require_hdl_sources: bool = False) -> "ArtifactBundle":
+    def validate(self, *, required_roles: tuple[str, ...] = (), require_hdl_sources: bool = False) -> ArtifactBundle:
         errors: list[str] = []
         roles = {entry.artifact.role for entry in self.entries}
         missing_roles = tuple(role for role in required_roles if role not in roles)

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1047,6 +1047,7 @@ class HardwarePlanTask(BuildCallableModel):
     openfpgaloader: str = "openFPGALoader"
     jtag_cable: str | None = None
     endpoint_bdf: str | None = None
+    reset_bridge_bdf: str | None = None
     expected_endpoint_id: str | None = None
     runtime_pm_executable: str | None = None
     runtime_pm_patterns: tuple[str, ...] | None = None
@@ -1076,6 +1077,7 @@ class HardwarePlanTask(BuildCallableModel):
             openfpgaloader_executable=self.openfpgaloader,
             jtag_cable=self.jtag_cable,
             endpoint_bdf=self.endpoint_bdf,
+            reset_bridge_bdf=self.reset_bridge_bdf,
             expected_endpoint_id=self.expected_endpoint_id,
             runtime_pm_executable=self.runtime_pm_executable,
             runtime_pm_patterns=self.runtime_pm_patterns,
@@ -1160,7 +1162,7 @@ def available_task_names() -> tuple[str, ...]:
 def parse_override_dict(arguments: Iterable[str]) -> dict[str, str]:
     overrides: dict[str, str] = {}
     for argument in arguments:
-        normalized_argument = argument[1:] if argument.startswith("+") else argument
+        normalized_argument = argument.removeprefix("+")
         if "=" not in normalized_argument:
             raise BuildStepError(f"expected key=value override, got {argument!r}")
         key, value = normalized_argument.split("=", 1)

--- a/dau_build/config/__init__.py
+++ b/dau_build/config/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any
 
 from ccflow import ModelRegistry
 from ccflow.utils.hydra import ConfigLoadResult, cfg_run, load_config as base_load_config

--- a/dau_build/config/plan/plans/sram-program.yaml
+++ b/dau_build/config/plan/plans/sram-program.yaml
@@ -1,0 +1,12 @@
+# @package plan
+
+# The proven volatile (SRAM) reprogram ladder: PM hold -> deadman arm ->
+# sysfs remove -> volatile program -> secondary-bus reset -> rescan+settle
+# -> endpoint verify [-> injected device verify] -> deadman disarm (success
+# only — a failure leaves the deadman armed and the box self-recovers to
+# the SPI-resident design). Needs the platform's host_access facts,
+# including reset_bridge_bdf.
+_target_: dau_build.hardware_plan.SramProgramPlan
+name: sram-program
+deadman_timeout_s: 180
+verify_command: null

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -21,6 +21,7 @@ vivado_mount_root: null
 openfpgaloader: openFPGALoader
 jtag_cable: null
 endpoint_bdf: null
+reset_bridge_bdf: null
 expected_endpoint_id: null
 runtime_pm_executable: null
 runtime_pm_patterns: null

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -603,8 +603,10 @@ def secondary_bus_reset_step(config: HardwareToolchainConfig) -> ToolStep:
     upstream bridge: after a volatile reprogram the endpoint enumerates but
     its register block stays dead until the bus reset re-inits the PCIe
     core. The bridge BDF is a measured bench fact (host_access)."""
-    bridge = config.required_host_access("reset_bridge_bdf")
-    script = f"setpci -s {bridge} BRIDGE_CONTROL=40:40; sleep 0.6; setpci -s {bridge} BRIDGE_CONTROL=00:40; sleep 1.5"
+    bridge = shlex.quote(str(config.required_host_access("reset_bridge_bdf")))
+    # && chaining: a setpci failure must fail the STEP (a trailing sleep's
+    # exit status would otherwise mask it and let the plan reach the disarm)
+    script = f"setpci -s {bridge} BRIDGE_CONTROL=40:40 && sleep 0.6 && setpci -s {bridge} BRIDGE_CONTROL=00:40 && sleep 1.5"
     return ToolStep("secondary-bus-reset", ("sh", "-c", script))
 
 
@@ -757,7 +759,9 @@ def sram_program_plan(
         remove_endpoint_step(config),
         program_volatile_step(config),
         secondary_bus_reset_step(config),
-        ToolStep("pci-global-rescan-settle", ("sh", "-c", "echo 1 > /sys/bus/pci/rescan; sleep 4")),
+        # && chaining: a failed rescan write must fail the step, not be
+        # masked by the settle sleep's exit status
+        ToolStep("pci-global-rescan-settle", ("sh", "-c", "echo 1 > /sys/bus/pci/rescan && sleep 4")),
         lspci_endpoint_step(config),
     ]
     if verify_command:

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -57,8 +57,9 @@ class HardwareToolchainConfig(BaseModel):
     vivado_invocation: Literal["standard", "source-only"] = "standard"
     vivado_mount_root: Path | None = None
     openfpgaloader_executable: str = "openFPGALoader"
-    # the console script dau-utils actually installs (dau_utils.pci_runtime_pm)
+    # the console scripts dau-utils actually installs
     runtime_pm_executable: str = "dau-utils-pci-runtime-pm"
+    deadman_executable: str = "dau-utils-deadman"
     # host access is board/host configuration, never code defaults: compose
     # it from a platform's host_access (for_platform) or set the fields
     # explicitly. Steps that need an unset (None) fact fail with guidance;
@@ -67,6 +68,7 @@ class HardwareToolchainConfig(BaseModel):
     runtime_pm_patterns: tuple[str, ...] | None = None
     jtag_cable: str | None = None
     endpoint_bdf: str | None = None
+    reset_bridge_bdf: str | None = None
     expected_endpoint_id: str | None = None
     rescan_bdfs: tuple[str, ...] | None = None
     # the board's default programming method (PlatformDefinition.program_method:
@@ -76,7 +78,7 @@ class HardwareToolchainConfig(BaseModel):
     programmer: Any = None
 
     @classmethod
-    def for_platform(cls, platform, *, work_root: Path, programmer=None, **overrides) -> "HardwareToolchainConfig":
+    def for_platform(cls, platform, *, work_root: Path, programmer=None, **overrides) -> HardwareToolchainConfig:
         """Compose the toolchain config from a registered platform's
         ``host_access`` (board/host config, not code defaults) and its
         ``program_method``. Explicit keyword overrides win; with neither, the
@@ -95,6 +97,7 @@ class HardwareToolchainConfig(BaseModel):
                 # runtime-PM holds) — never silently the dpv1 defaults
                 "rescan_bdfs": access.rescan_bdfs,
                 "runtime_pm_patterns": access.runtime_pm_patterns,
+                "reset_bridge_bdf": access.reset_bridge_bdf,
             }
         method = getattr(platform, "program_method", None)
         if method is not None:
@@ -573,6 +576,38 @@ def pci_rescan_step(bridge_bdfs: Sequence[str] = ()) -> ToolStep:
     return ToolStep("pci-rescan", ("sh", "-c", _pci_rescan_script(bridge_bdfs)))
 
 
+def pm_hold_device_step(config: HardwareToolchainConfig) -> ToolStep:
+    """Device-scoped runtime-PM hold as safe prep — tolerant when the
+    endpoint is absent (recovering a wedged device must not abort here)."""
+    bdf = config.required_host_access("endpoint_bdf")
+    hold = shlex.join((config.runtime_pm_executable, "hold", "--device", bdf))
+    return ToolStep("pm-hold-device", ("sh", "-c", f"{hold} || echo 'pm hold skipped (device absent)'"))
+
+
+def deadman_arm_step(config: HardwareToolchainConfig, *, timeout_s: int = 180) -> ToolStep:
+    """Arm the forced-reboot deadman over the risky PCIe window. The
+    matching disarm step runs ONLY on plan success: the executor stops on
+    the first failure and never reaches it, so a wedge self-recovers by
+    reboot to the SPI-resident design (timeout is SECONDS)."""
+    return ToolStep("deadman-arm", (config.deadman_executable, "arm", "--timeout", str(timeout_s)))
+
+
+def deadman_disarm_step(config: HardwareToolchainConfig) -> ToolStep:
+    # deliberately NOT named *release: the failure path's cleanup pass runs
+    # only *release steps, and the deadman must stay armed on failure
+    return ToolStep("deadman-disarm", (config.deadman_executable, "disarm"))
+
+
+def secondary_bus_reset_step(config: HardwareToolchainConfig) -> ToolStep:
+    """Secondary-bus reset (PERST# equivalent) on the endpoint's direct
+    upstream bridge: after a volatile reprogram the endpoint enumerates but
+    its register block stays dead until the bus reset re-inits the PCIe
+    core. The bridge BDF is a measured bench fact (host_access)."""
+    bridge = config.required_host_access("reset_bridge_bdf")
+    script = f"setpci -s {bridge} BRIDGE_CONTROL=40:40; sleep 0.6; setpci -s {bridge} BRIDGE_CONTROL=00:40; sleep 1.5"
+    return ToolStep("secondary-bus-reset", ("sh", "-c", script))
+
+
 def lspci_endpoint_step(config: HardwareToolchainConfig) -> ToolStep:
     return ToolStep("lspci-endpoint", ("sh", "-c", _lspci_endpoint_script(config)))
 
@@ -676,7 +711,7 @@ class HardwarePlan(BaseModel):
 
     name: str
 
-    def compose(self, config: "HardwareToolchainConfig") -> tuple[ToolStep, ...]:
+    def compose(self, config: HardwareToolchainConfig) -> tuple[ToolStep, ...]:
         raise NotImplementedError
 
 
@@ -706,6 +741,41 @@ class ThunderboltReleasePlan(HardwarePlan):
 
     def compose(self, config):
         return thunderbolt_release_plan(config)
+
+
+def sram_program_plan(
+    config: HardwareToolchainConfig, *, deadman_timeout_s: int = 180, verify_command: str | None = None
+) -> tuple[ToolStep, ...]:
+    """The proven volatile (SRAM) reprogram ladder, safe order: PM hold ->
+    deadman arm -> sysfs remove -> volatile program -> secondary-bus reset ->
+    global rescan + settle -> endpoint verify [-> injected device verify] ->
+    deadman disarm. Every step exists for a bench-discovered reason; the
+    disarm runs only when everything before it succeeded."""
+    steps = [
+        pm_hold_device_step(config),
+        deadman_arm_step(config, timeout_s=deadman_timeout_s),
+        remove_endpoint_step(config),
+        program_volatile_step(config),
+        secondary_bus_reset_step(config),
+        ToolStep("pci-global-rescan-settle", ("sh", "-c", "echo 1 > /sys/bus/pci/rescan; sleep 4")),
+        lspci_endpoint_step(config),
+    ]
+    if verify_command:
+        # an injected device-level verify (e.g. a register-magic probe from a
+        # package that owns the device API) — the enumeration check above is
+        # necessary but not sufficient
+        steps.append(ToolStep("verify-device", ("sh", "-c", verify_command)))
+    steps.append(deadman_disarm_step(config))
+    return tuple(steps)
+
+
+class SramProgramPlan(HardwarePlan):
+    name: str = "sram-program"
+    deadman_timeout_s: int = 180
+    verify_command: str | None = None
+
+    def compose(self, config):
+        return sram_program_plan(config, deadman_timeout_s=self.deadman_timeout_s, verify_command=self.verify_command)
 
 
 class FlashPlan(HardwarePlan):

--- a/dau_build/packaging.py
+++ b/dau_build/packaging.py
@@ -10,15 +10,15 @@ from pydantic import ConfigDict, model_validator
 __all__ = (
     "ARTIFACT_MANIFEST_SCHEMA",
     "SUPPORTED_ARTIFACT_KINDS",
-    "ArtifactManifestError",
     "Artifact",
     "ArtifactManifest",
-    "load_artifact_manifest",
+    "ArtifactManifestError",
     "artifact_manifest_from_mapping",
-    "validate_artifact_files",
-    "artifact_path",
     "artifact_modules",
+    "artifact_path",
     "artifact_with_modules",
+    "load_artifact_manifest",
+    "validate_artifact_files",
 )
 
 ARTIFACT_MANIFEST_SCHEMA = ARTLINK_MANIFEST_SCHEMA
@@ -40,7 +40,7 @@ class ArtifactManifest(Manifest):
             raise ArtifactManifestError(str(exc)) from exc
 
     @model_validator(mode="after")
-    def _validate_supported_kinds(self) -> "ArtifactManifest":
+    def _validate_supported_kinds(self) -> ArtifactManifest:
         unsupported_kinds = tuple(dict.fromkeys(artifact.kind for artifact in self.artifacts if artifact.kind not in SUPPORTED_ARTIFACT_KINDS))
         if unsupported_kinds:
             raise ValueError(f"unsupported artifact kind(s): {', '.join(unsupported_kinds)}")

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -167,6 +167,11 @@ class HostAccess(BaseModel):
     runtime_pm_patterns: tuple[str, ...]
     runtime_pm_executable: str = "dau-utils-pci-runtime-pm"
     jtag_cable: str = "digilent_hs2"
+    # the endpoint's direct upstream bridge, for the secondary-bus reset
+    # (PERST#-equivalent) that re-inits the PCIe core after a volatile
+    # reprogram; a measured bench fact, explicit rather than inferred from
+    # rescan_bdfs order
+    reset_bridge_bdf: str | None = None
 
     @field_validator("pci_id", "endpoint_bdf")
     @classmethod

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -41,10 +41,10 @@ class Programmer(BaseModel):
 
     name: str
 
-    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep | None":  # noqa: ARG002 (Programmer interface)
+    def detect_step(self, config: HardwareToolchainConfig) -> ToolStep | None:  # noqa: ARG002 (Programmer interface)
         return None
 
-    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+    def program_step(self, config: HardwareToolchainConfig, *, mode: Literal["volatile", "persistent"] = "volatile") -> ToolStep:
         raise NotImplementedError
 
 
@@ -58,17 +58,17 @@ class OpenFpgaLoaderProgrammer(Programmer):
     executable: str = "openFPGALoader"
     jtag_cable: str | None = None
 
-    def _cable(self, config: "HardwareToolchainConfig") -> str:
+    def _cable(self, config: HardwareToolchainConfig) -> str:
         if self.jtag_cable is not None:
             return self.jtag_cable
         return config.required_host_access("jtag_cable")
 
-    def detect_step(self, config: "HardwareToolchainConfig") -> "ToolStep":
+    def detect_step(self, config: HardwareToolchainConfig) -> ToolStep:
         from dau_build.hardware_plan import ToolStep
 
         return ToolStep("jtag-detect", (self.executable, "-c", self._cable(config), "--detect"))
 
-    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+    def program_step(self, config: HardwareToolchainConfig, *, mode: Literal["volatile", "persistent"] = "volatile") -> ToolStep:
         from dau_build.hardware_plan import ToolStep
 
         if mode == "persistent":
@@ -87,7 +87,7 @@ class VivadoHwServerProgrammer(Programmer):
     name: str = "vivado-hwserver"
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh")
 
-    def program_step(self, config: "HardwareToolchainConfig", *, mode: Literal["volatile", "persistent"] = "volatile") -> "ToolStep":
+    def program_step(self, config: HardwareToolchainConfig, *, mode: Literal["volatile", "persistent"] = "volatile") -> ToolStep:
         if mode != "persistent":
             raise ValueError(
                 'vivado-hwserver has no volatile programming path; request the persistent flash write explicitly (mode="persistent", e.g. the flash plan) or compose a JTAG programmer'

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -15,8 +15,8 @@ validation (``dau_build.sv_contract``) before emission.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 from ccflow import BaseModel
 
@@ -139,7 +139,7 @@ class ScanComposition(BaseModel):
         _validate_composition_shape(self)
 
 
-def _validate_composition_shape(composition: "ScanComposition") -> None:
+def _validate_composition_shape(composition: ScanComposition) -> None:
     """The composition's shape and width-coherence invariants. Called from
     ``model_post_init`` AND from both public generators: ``model_copy`` skips
     pydantic validation, so an emitted top/sim must re-check — an incoherent

--- a/dau_build/shell_build.py
+++ b/dau_build/shell_build.py
@@ -26,8 +26,8 @@ __all__ = (
     "SHELL_BUILD_MANIFEST_NAME",
     "ShellBuildError",
     "ShellBuildStatus",
-    "run_shell_project_build",
     "parse_shell_build_console",
+    "run_shell_project_build",
     "shell_build_manifest",
     "write_shell_build_manifest",
 )

--- a/dau_build/sv_contract.py
+++ b/dau_build/sv_contract.py
@@ -13,8 +13,8 @@ ternary expressions — do not block validation)."""
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 try:
     from pyslang import SyntaxKind, SyntaxTree

--- a/dau_build/svparser.py
+++ b/dau_build/svparser.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Literal
 
 from amaranth import Instance
 from amaranth.lib.wiring import Component, In, Out
@@ -55,21 +55,21 @@ except ImportError:
 from typing_extensions import Self
 
 __all__ = (
-    "Keyword",
-    "Size",
-    "Dimensions",
-    "Port",
-    "Input",
-    "Output",
-    "Inout",
-    "Parameter",
-    "Wire",
     "ContinuousAssignment",
-    "ProceduralBlock",
-    "GenerateBlock",
-    "Module",
-    "Interface",
     "Design",
+    "Dimensions",
+    "GenerateBlock",
+    "Inout",
+    "Input",
+    "Interface",
+    "Keyword",
+    "Module",
+    "Output",
+    "Parameter",
+    "Port",
+    "ProceduralBlock",
+    "Size",
+    "Wire",
 )
 
 
@@ -189,7 +189,7 @@ class Dimensions(BaseModel):
 
 class _Base(BaseModel):
     name: str
-    instance_name: Optional[str] = Field(default="")
+    instance_name: str | None = Field(default="")
     node: object | None = Field(default=None)
 
     def to_string(self, indent: str = ""):  # noqa: ARG002 (node to_string interface)
@@ -208,7 +208,7 @@ class _Base(BaseModel):
 class Modport(_Base):
     inputs: list[Input] = Field(default_factory=list)
     outputs: list[Output] = Field(default_factory=list)
-    modports: list["Modport"] = Field(default_factory=list)
+    modports: list[Modport] = Field(default_factory=list)
 
     def to_string(self, indent: str = ""):
         ret = f"{indent}{self.__class__.__name__}({self.name})"
@@ -247,7 +247,6 @@ class Output(Port):
 class Inout(Port):
     """Bidirectional port."""
 
-    pass
 
 
 class Wire(BaseModel):
@@ -292,7 +291,7 @@ class GenerateBlock(BaseModel):
 
     kind: str = "region"
     body: str = ""
-    modules: list["Module"] = Field(default_factory=list)
+    modules: list[Module] = Field(default_factory=list)
 
     def __str__(self):
         return f"Generate({self.kind}, {len(self.modules)} submodules)"
@@ -327,7 +326,7 @@ class Module(_Base):
     inouts: list[Inout] = Field(default_factory=list)
 
     modports: list[Modport] = Field(default_factory=list, description="Modport inputs/outputs")
-    modules: list["Module"] = Field(default_factory=list, description="Sub module instantiations")
+    modules: list[Module] = Field(default_factory=list, description="Sub module instantiations")
 
     links: list[Link] = Field(default_factory=list)
 
@@ -342,7 +341,7 @@ class Module(_Base):
     final_blocks: list[ProceduralBlock] = Field(default_factory=list)
     generate_blocks: list[GenerateBlock] = Field(default_factory=list, description="Generate constructs")
 
-    source_path: Optional[Path] = Field(default=None, description="Path to source SV file")
+    source_path: Path | None = Field(default=None, description="Path to source SV file")
 
     def instance(self) -> Instance:
         """Return an Amaranth `Instance` type correctly specified for the underlying systemverilog code
@@ -489,7 +488,7 @@ class Module(_Base):
                 if hasattr(child, "declarators"):
                     yield child
 
-    def _eval_dim_expr(self, expr) -> Optional[int]:
+    def _eval_dim_expr(self, expr) -> int | None:
         """Evaluate a dimension expression using known parameters and localparams, None if unresolvable."""
         namespace = {"clog2": _sv_clog2}
         namespace.update({p.name: p.value for p in self.parameters})
@@ -591,9 +590,7 @@ class Module(_Base):
                         else:
                             # TODO: ref ports, etc.
                             assert False
-                elif port.kind == TokenKind.Comma:
-                    continue
-                elif port.kind in (TokenKind.OpenParenthesis, TokenKind.CloseParenthesis):
+                elif port.kind == TokenKind.Comma or port.kind in (TokenKind.OpenParenthesis, TokenKind.CloseParenthesis):
                     continue
                 else:
                     assert False
@@ -837,7 +834,7 @@ class Design(BaseModel):
     modules: dict[str, Module] = Field(default_factory=dict)
 
     @classmethod
-    def from_directory(cls, path: Path, extension: str = "sv") -> "Design":
+    def from_directory(cls, path: Path, extension: str = "sv") -> Design:
         """Parse all SV files in a directory."""
         design = cls()
         for f in sorted(path.glob(f"*.{extension}")):
@@ -849,7 +846,7 @@ class Design(BaseModel):
         return design
 
     @classmethod
-    def from_files(cls, paths: list[Path]) -> "Design":
+    def from_files(cls, paths: list[Path]) -> Design:
         """Parse specific SV files."""
         design = cls()
         for f in paths:
@@ -857,7 +854,7 @@ class Design(BaseModel):
             design.modules[mod.name] = mod
         return design
 
-    def resolve(self) -> "Design":
+    def resolve(self) -> Design:
         """Resolve all submodule references within the design."""
         for name, mod in self.modules.items():
             for i, sub in enumerate(mod.modules):

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -142,7 +142,7 @@ def test_simulate_step_validates_sources_and_reports_local_simulation_inputs(tmp
 
     assert result == BuildStepResult(
         step="simulate",
-        message="dau-build-simulate\tspec={} top=dau_identity_top modules=ff sources=1 engine=svparser status=validated".format(spec_path),
+        message=f"dau-build-simulate\tspec={spec_path} top=dau_identity_top modules=ff sources=1 engine=svparser status=validated",
     )
 
 
@@ -416,7 +416,7 @@ def test_task_dispatch_import_stays_light() -> None:
 def test_vivado_engine_threads_the_overlay_definition_into_the_handoff(tmp_path: Path, monkeypatch) -> None:
     from types import SimpleNamespace
 
-    import dau_build.build_steps as build_steps
+    from dau_build import build_steps
     from dau_build.vivado_backend import VivadoOverlayDefinition
 
     captured = {}

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1713,9 +1713,9 @@ def test_sram_program_plan_is_the_proven_ladder() -> None:
     assert by_name["deadman-arm"] == "dau-utils-deadman arm --timeout 180"
     assert by_name["program-volatile"] == "openFPGALoader -c digilent_hs2 /tmp/design.bit"
     assert "-f" not in by_name["program-volatile"].split()  # VOLATILE, never raw persistent
-    assert "setpci -s 0000:03:01.0 BRIDGE_CONTROL=40:40" in by_name["secondary-bus-reset"]
-    assert "BRIDGE_CONTROL=00:40" in by_name["secondary-bus-reset"]
-    assert "echo 1 > /sys/bus/pci/rescan; sleep 4" in by_name["pci-global-rescan-settle"]
+    assert "setpci -s 0000:03:01.0 BRIDGE_CONTROL=40:40 && sleep 0.6" in by_name["secondary-bus-reset"]
+    assert "BRIDGE_CONTROL=00:40 && sleep 1.5" in by_name["secondary-bus-reset"]  # && so a setpci failure fails the step
+    assert "echo 1 > /sys/bus/pci/rescan && sleep 4" in by_name["pci-global-rescan-settle"]
     assert by_name["verify-device"].endswith("'sudo probe-magic'")
     assert by_name["deadman-disarm"] == "dau-utils-deadman disarm"
 

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -4,8 +4,7 @@ from pathlib import Path
 
 import pytest
 
-import dau_build.hardware_plan as hardware_plan
-import dau_build.vivado_backend as vivado_backend
+from dau_build import hardware_plan, vivado_backend
 from dau_build.build_steps import BuildStepError
 from dau_build.config import run_request_config
 from dau_build.hardware_plan import (
@@ -1684,3 +1683,90 @@ def test_stage_task_name_must_be_non_empty(tmp_path: Path) -> None:
             dau_driver_root=Path("/repo/dau-driver"),
             stage_task_name="",
         )
+
+
+def test_sram_program_plan_is_the_proven_ladder() -> None:
+    """The volatile reprogram ladder, pinned step by step: every entry
+    exists for a bench-discovered reason and the order is the safety."""
+    from dau_build.hardware_plan import SramProgramPlan
+
+    config = _bench_config(
+        work_root=Path("/tmp/w"),
+        bitstream_path=Path("/tmp/design.bit"),
+        reset_bridge_bdf="0000:03:01.0",
+    )
+    steps = SramProgramPlan(verify_command="sudo probe-magic").compose(config)
+    assert [step.name for step in steps] == [
+        "pm-hold-device",
+        "deadman-arm",
+        "remove-endpoint",
+        "program-volatile",
+        "secondary-bus-reset",
+        "pci-global-rescan-settle",
+        "lspci-endpoint",
+        "verify-device",
+        "deadman-disarm",
+    ]
+    by_name = {step.name: step.command_line for step in steps}
+    assert "dau-utils-pci-runtime-pm hold --device 0000:04:00.0" in by_name["pm-hold-device"]
+    assert "pm hold skipped" in by_name["pm-hold-device"]  # tolerant prep
+    assert by_name["deadman-arm"] == "dau-utils-deadman arm --timeout 180"
+    assert by_name["program-volatile"] == "openFPGALoader -c digilent_hs2 /tmp/design.bit"
+    assert "-f" not in by_name["program-volatile"].split()  # VOLATILE, never raw persistent
+    assert "setpci -s 0000:03:01.0 BRIDGE_CONTROL=40:40" in by_name["secondary-bus-reset"]
+    assert "BRIDGE_CONTROL=00:40" in by_name["secondary-bus-reset"]
+    assert "echo 1 > /sys/bus/pci/rescan; sleep 4" in by_name["pci-global-rescan-settle"]
+    assert by_name["verify-device"].endswith("'sudo probe-magic'")
+    assert by_name["deadman-disarm"] == "dau-utils-deadman disarm"
+
+    # without the injected verify the step is absent, ladder otherwise identical
+    bare = SramProgramPlan().compose(config)
+    assert [step.name for step in bare] == [step.name for step in steps if step.name != "verify-device"]
+
+
+def test_sram_program_plan_requires_the_bridge_fact() -> None:
+    from dau_build.hardware_plan import SramProgramPlan
+
+    config = _bench_config(work_root=Path("/tmp/w"), bitstream_path=Path("/tmp/design.bit"))
+    with pytest.raises(ValueError, match="reset_bridge_bdf"):
+        SramProgramPlan().compose(config)
+
+
+def test_deadman_stays_armed_when_a_step_fails(tmp_path: Path) -> None:
+    """The executor's failure semantics ARE the deadman contract: it stops
+    at the first failing step and runs only *release cleanup steps after,
+    so deadman-disarm (deliberately not named *release) never runs and the
+    box self-recovers by forced reboot."""
+    from dau_build.hardware_plan import ToolStep, execute_plan_steps
+
+    disarm_marker = tmp_path / "disarmed"
+    release_marker = tmp_path / "released"
+    steps = (
+        ToolStep("deadman-arm", ("true",)),
+        ToolStep("program-volatile", ("false",)),  # the wedge
+        ToolStep("thunderbolt-release", ("sh", "-c", f"touch {release_marker}")),
+        ToolStep("deadman-disarm", ("sh", "-c", f"touch {disarm_marker}")),
+    )
+    code = execute_plan_steps(steps)
+    assert code != 0
+    assert release_marker.exists()  # *release cleanup DOES run
+    assert not disarm_marker.exists()  # the deadman stays armed
+
+
+def test_sram_program_plan_composes_from_the_config_group(tmp_path: Path) -> None:
+    result = run_request_config(
+        "task",
+        "tasks/hardware/hardware-plan",
+        overrides=["plan=plans/sram-program"],
+        model_values={
+            "work_root": str(tmp_path),
+            "bitstream": "/tmp/design.bit",
+            "endpoint_bdf": "0000:04:00.0",
+            "reset_bridge_bdf": "0000:03:01.0",
+            "expected_endpoint_id": "10ee:7011",
+            "jtag_cable": "digilent_hs2",
+            "runtime_pm_patterns": (),
+            "rescan_bdfs": ("0000:03:01.0",),
+        },
+    )
+    assert "deadman-arm" in result.message and "secondary-bus-reset" not in result.message.split("deadman-arm")[0]

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -650,9 +650,7 @@ def _validate_manifest_contract(*, build_root: Path, manifest_path: Path, comman
     )
     optional_empty_keys = {"vivado_mount_root"}
     for key in required_keys:
-        if key not in manifest:
-            errors.append(f"manifest missing required key: {key}")
-        elif key not in optional_empty_keys and not manifest[key]:
+        if key not in manifest or key not in optional_empty_keys and not manifest[key]:
             errors.append(f"manifest missing required key: {key}")
     if manifest.get("backend") and manifest["backend"] != "dau_build.vivado_backend.vivado_overlay":
         errors.append(f"unexpected backend: {manifest['backend']}")


### PR DESCRIPTION
Increment 1 of dau-docs-private/ROADMAP_DAU_BUILD_FIXES.md: `SramProgramPlan` encodes the bench-proven volatile (SRAM) reprogram safe order as ordered `ToolStep`s — device-scoped PM hold (tolerant), deadman arm, sysfs remove, volatile program, **secondary-bus reset** on the endpoint's upstream bridge (new explicit `HostAccess.reset_bridge_bdf` fact, threaded through `for_platform`/the task/yaml), global rescan + settle, endpoint verify, optional injected device verify, deadman disarm.

The disarm step is deliberately **not** named `*release`: the executor stops on the first failure and runs only `*release` cleanup after, so a wedge leaves the deadman armed and the box self-recovers to the SPI-resident design — pinned by test. Codex round 1 caught swallowed `setpci`/rescan failures behind trailing sleeps (now `&&`-chained so they fail the step) and the unquoted bridge BDF (now `shlex.quote`d).