### PR TITLE
Tolerate only an absent endpoint during the PM hold

### DIFF
--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -581,7 +581,12 @@ def pm_hold_device_step(config: HardwareToolchainConfig) -> ToolStep:
     endpoint is absent (recovering a wedged device must not abort here)."""
     bdf = config.required_host_access("endpoint_bdf")
     hold = shlex.join((config.runtime_pm_executable, "hold", "--device", bdf))
-    return ToolStep("pm-hold-device", ("sh", "-c", f"{hold} || echo 'pm hold skipped (device absent)'"))
+    quoted_bdf = shlex.quote(str(bdf))
+    # tolerate ONLY an absent endpoint (recovering a wedged device); a hold
+    # failure with the device present propagates — proceeding into a
+    # reprogram without the PM hold is exactly the wedge class this guards
+    script = f"if [ -e /sys/bus/pci/devices/{quoted_bdf} ]; then {hold}; else echo 'pm hold skipped (device absent)'; fi"
+    return ToolStep("pm-hold-device", ("sh", "-c", script))
 
 
 def deadman_arm_step(config: HardwareToolchainConfig, *, timeout_s: int = 180) -> ToolStep:

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1709,7 +1709,10 @@ def test_sram_program_plan_is_the_proven_ladder() -> None:
     ]
     by_name = {step.name: step.command_line for step in steps}
     assert "dau-utils-pci-runtime-pm hold --device 0000:04:00.0" in by_name["pm-hold-device"]
-    assert "pm hold skipped" in by_name["pm-hold-device"]  # tolerant prep
+    # tolerant ONLY when the endpoint is absent; a hold failure with the
+    # device present must fail the step
+    assert "if [ -e /sys/bus/pci/devices/0000:04:00.0 ]" in by_name["pm-hold-device"]
+    assert "pm hold skipped (device absent)" in by_name["pm-hold-device"]
     assert by_name["deadman-arm"] == "dau-utils-deadman arm --timeout 180"
     assert by_name["program-volatile"] == "openFPGALoader -c digilent_hs2 /tmp/design.bit"
     assert "-f" not in by_name["program-volatile"].split()  # VOLATILE, never raw persistent


### PR DESCRIPTION
Codex re-review of #131: the unconditional `|| echo` converted every PM-hold failure (missing executable, permissions) into success, letting the plan reprogram without the hold. Now only an absent endpoint (the recovery case) is tolerated; any other hold failure fails the step before the deadman window opens.