### PR TITLE
Route SPI-boot persistent flashes through the cfgmem path

### DIFF
--- a/dau_build/config/platform/platforms/dau/dpv1.yaml
+++ b/dau_build/config/platform/platforms/dau/dpv1.yaml
@@ -10,6 +10,8 @@ _target_: dau_build.platforms.PlatformDefinition
 name: dpv1
 part: xc7a200tfbg484-2
 program_method: jtag
+# S25FL256S boots SPIx4: persistent writes must use the vivado cfgmem path
+spi_boot_buswidth: 4
 # lane index -> GTPE2 channel site: the reversed lane-to-GT-channel mapping
 # the dpv1 board requires, applied as a pre-opt_design implementation hook
 # (XDC-time LOCs conflict with the XDMA IP's internal BEL/LOC constraints)

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -75,7 +75,9 @@ class HardwareToolchainConfig(BaseModel):
     # jtag->openFPGALoader, flash->vivado-hwserver); an explicit `programmer`
     # (a Programmer model composed from the `programmer` group) wins.
     program_method: str = "jtag"
-    spi_boot_buswidth: int | None = None
+    # only 4 is supported: the cfgmem generator writes SPIx4 (see
+    # PlatformDefinition.spi_boot_buswidth)
+    spi_boot_buswidth: Literal[4] | None = None
     programmer: Any = None
 
     @classmethod

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -75,6 +75,7 @@ class HardwareToolchainConfig(BaseModel):
     # jtag->openFPGALoader, flash->vivado-hwserver); an explicit `programmer`
     # (a Programmer model composed from the `programmer` group) wins.
     program_method: str = "jtag"
+    spi_boot_buswidth: int | None = None
     programmer: Any = None
 
     @classmethod
@@ -102,6 +103,7 @@ class HardwareToolchainConfig(BaseModel):
         method = getattr(platform, "program_method", None)
         if method is not None:
             values["program_method"] = method
+        values["spi_boot_buswidth"] = getattr(platform, "spi_boot_buswidth", None)
         if programmer is not None:
             values["programmer"] = programmer
         values.update({key: value for key, value in overrides.items() if value is not None})
@@ -391,11 +393,22 @@ def flash_plan(
     python: str = "python3",
     vivado_settings: Path = Path("/opt/Xilinx/2025.1/Vivado/settings64.sh"),
 ) -> tuple[ToolStep, ...]:
-    return (
+    steps = [
         thunderbolt_hold_step(config, dau_utils_root=dau_utils_root, python=python),
         flash_step(config, vivado_settings=vivado_settings),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
-    )
+    ]
+    if config.spi_boot_buswidth not in (None, 1):
+        # a JTAG/hot reset never runs the SPI configuration sequence: only a
+        # physical power-on brings the freshly-flashed image up alive. A
+        # printing step, deliberately not executable.
+        steps.append(
+            ToolStep(
+                "cold-power-cycle-required",
+                ("sh", "-c", "echo 'NOTE: physical cold power cycle required — the SPI boot sequence only runs from power-on'"),
+            )
+        )
+    return tuple(steps)
 
 
 def thunderbolt_hold_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, ...]:
@@ -525,7 +538,13 @@ def _smoke_steps(smoke_command: str | None) -> tuple[ToolStep, ...]:
 def flash_step(config: HardwareToolchainConfig, *, vivado_settings: Path) -> ToolStep:
     # a persistent write through the composed programmer (Vivado hw_server for
     # a flash board, openFPGALoader -f for a JTAG board) — the selector, not a
-    # hardcoded backend
+    # hardcoded backend. An SPI-boot board (spi_boot_buswidth set) always
+    # takes the vivado cfgmem path: a raw-bit -f write leaves its
+    # configuration memory-dead, and the JTAG programmer refuses it anyway.
+    if config.spi_boot_buswidth not in (None, 1) and config.programmer is None:
+        from dau_build.programmers import VivadoHwServerProgrammer
+
+        return VivadoHwServerProgrammer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
     return config.resolve_programmer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
 
 

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -544,6 +544,16 @@ def flash_step(config: HardwareToolchainConfig, *, vivado_settings: Path) -> Too
     if config.spi_boot_buswidth not in (None, 1) and config.programmer is None:
         from dau_build.programmers import VivadoHwServerProgrammer
 
+        if config.bitstream_path is not None:
+            # flash.tcl programs the work tree's own generated cfgmem image;
+            # silently ignoring an explicit bitstream would flash a stale or
+            # unrelated artifact. Refuse until an external-bit cfgmem stage
+            # exists — the volatile SRAM plan takes explicit bitstreams today.
+            raise ValueError(
+                "the cfgmem flash path programs the work tree's generated image and cannot take an external "
+                f"bitstream ({config.bitstream_path}); flash from the shell-build work tree, or use the volatile "
+                "SRAM plan for an explicit bitstream"
+            )
         return VivadoHwServerProgrammer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
     return config.resolve_programmer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
 

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -544,16 +544,9 @@ def flash_step(config: HardwareToolchainConfig, *, vivado_settings: Path) -> Too
     if config.spi_boot_buswidth not in (None, 1) and config.programmer is None:
         from dau_build.programmers import VivadoHwServerProgrammer
 
-        if config.bitstream_path is not None:
-            # flash.tcl programs the work tree's own generated cfgmem image;
-            # silently ignoring an explicit bitstream would flash a stale or
-            # unrelated artifact. Refuse until an external-bit cfgmem stage
-            # exists — the volatile SRAM plan takes explicit bitstreams today.
-            raise ValueError(
-                "the cfgmem flash path programs the work tree's generated image and cannot take an external "
-                f"bitstream ({config.bitstream_path}); flash from the shell-build work tree, or use the volatile "
-                "SRAM plan for an explicit bitstream"
-            )
+        # the programmer itself refuses an external bitstream (flash.tcl
+        # programs the work tree's generated image) — the guard covers every
+        # route, including an explicitly composed vivado-hwserver programmer
         return VivadoHwServerProgrammer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
     return config.resolve_programmer(vivado_settings=vivado_settings).program_step(config, mode="persistent")
 

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -213,6 +213,11 @@ class PlatformDefinition(BaseModel):
     constraints_xdc: str = ""
     lane_placements: tuple[tuple[int, str], ...] = ()
     program_method: str = "jtag"
+    # the flash device's boot bus width when the board self-configures from
+    # SPI (e.g. 4 for an SPIx4 part): a raw-bit JTAG `-f` write to such a
+    # flash leaves the board memory-dead — persistent programming must go
+    # through the vivado cfgmem path. None = no SPI-boot constraint.
+    spi_boot_buswidth: int | None = None
     job_clock_mhz: int | None = None
     placeholders: tuple[str, ...] = ()
 

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -19,7 +19,7 @@ public/private wall.
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Literal, Protocol
 
 from ccflow import BaseModel
 from pydantic import Field, field_validator
@@ -216,8 +216,10 @@ class PlatformDefinition(BaseModel):
     # the flash device's boot bus width when the board self-configures from
     # SPI (e.g. 4 for an SPIx4 part): a raw-bit JTAG `-f` write to such a
     # flash leaves the board memory-dead — persistent programming must go
-    # through the vivado cfgmem path. None = no SPI-boot constraint.
-    spi_boot_buswidth: int | None = None
+    # through the vivado cfgmem path. None = no SPI-boot constraint. Only 4
+    # is supported: the cfgmem generator (flash.tcl / vivado_build_tcl)
+    # writes SPIx4; another width would need its own cfgmem-generation path.
+    spi_boot_buswidth: Literal[4] | None = None
     job_clock_mhz: int | None = None
     placeholders: tuple[str, ...] = ()
 

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -72,6 +72,12 @@ class OpenFpgaLoaderProgrammer(Programmer):
         from dau_build.hardware_plan import ToolStep
 
         if mode == "persistent":
+            if config.spi_boot_buswidth not in (None, 1):
+                raise ValueError(
+                    f"raw-bit persistent flash (-f) on an SPIx{config.spi_boot_buswidth}-boot board leaves the "
+                    "configuration memory-dead (the boot sequence needs the cfgmem-written image); use the "
+                    "vivado cfgmem path (the flash plan's flash.tcl) or a volatile SRAM program"
+                )
             return ToolStep("program-persistent", (self.executable, "-c", self._cable(config), "-f", str(config.bitstream)))
         return ToolStep("program-volatile", (self.executable, "-c", self._cable(config), str(config.bitstream)))
 

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -98,6 +98,15 @@ class VivadoHwServerProgrammer(Programmer):
             raise ValueError(
                 'vivado-hwserver has no volatile programming path; request the persistent flash write explicitly (mode="persistent", e.g. the flash plan) or compose a JTAG programmer'
             )
+        if config.bitstream_path is not None:
+            # flash.tcl programs the work tree's own generated cfgmem image;
+            # silently ignoring an explicit bitstream would flash a stale or
+            # unrelated artifact — guard EVERY route through this programmer
+            raise ValueError(
+                "the cfgmem flash path programs the work tree's generated image and cannot take an external "
+                f"bitstream ({config.bitstream_path}); flash from the shell-build work tree, or use the volatile "
+                "SRAM plan for an explicit bitstream"
+            )
         from dau_build.hardware_plan import ToolStep
 
         script = vivado_flash_script(

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1825,3 +1825,16 @@ def test_cfgmem_route_refuses_an_external_bitstream() -> None:
     config = _bench_config(work_root=Path("/w"), spi_boot_buswidth=4, bitstream_path=Path("/elsewhere/design.bit"))
     with pytest.raises(ValueError, match="cannot take an external"):
         flash_plan(config)
+
+
+def test_explicit_cfgmem_programmer_also_refuses_external_bitstreams() -> None:
+    from dau_build.programmers import VivadoHwServerProgrammer
+
+    config = _bench_config(
+        work_root=Path("/w"),
+        spi_boot_buswidth=4,
+        bitstream_path=Path("/elsewhere/design.bit"),
+        programmer=VivadoHwServerProgrammer(),
+    )
+    with pytest.raises(ValueError, match="cannot take an external"):
+        flash_plan(config)

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1526,7 +1526,10 @@ def test_toolchain_config_composes_from_platform_host_access() -> None:
     from dau_build.platforms import dpv1_platform
 
     # dpv1's host_access config reproduces the proven bench facts exactly
-    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == _bench_config(work_root=Path("/w"))
+    # (spi_boot_buswidth rides the platform, not host_access — supplied here)
+    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == _bench_config(
+        work_root=Path("/w"), spi_boot_buswidth=4
+    )
 
     # a board with different access data changes the plans through config alone
     other = dpv1_platform().model_copy(deep=True)
@@ -1775,3 +1778,42 @@ def test_sram_program_plan_composes_from_the_config_group(tmp_path: Path) -> Non
         },
     )
     assert "deadman-arm" in result.message and "secondary-bus-reset" not in result.message.split("deadman-arm")[0]
+
+
+def test_spi_boot_board_flash_plan_takes_the_cfgmem_path() -> None:
+    """A raw-bit -f write to an SPIx4-boot flash leaves the board
+    memory-dead: the flash plan must route persistent writes through the
+    vivado cfgmem path and end with the cold-power-cycle notice."""
+    config = _bench_config(work_root=Path("/w"), spi_boot_buswidth=4)
+    steps = flash_plan(config)
+    names = [step.name for step in steps]
+    assert names == ["thunderbolt-hold", "flash", "thunderbolt-release", "cold-power-cycle-required"]
+    flash = next(step for step in steps if step.name == "flash")
+    assert "flash.tcl" in flash.command_line
+    assert " -f " not in f" {flash.command_line} "
+    notice = next(step for step in steps if step.name == "cold-power-cycle-required")
+    assert "cold power cycle" in notice.command_line
+
+
+def test_openfpgaloader_refuses_persistent_on_spi_boot() -> None:
+    from dau_build.programmers import OpenFpgaLoaderProgrammer
+
+    config = _bench_config(work_root=Path("/w"), spi_boot_buswidth=4)
+    with pytest.raises(ValueError, match="memory-dead"):
+        OpenFpgaLoaderProgrammer().program_step(config, mode="persistent")
+    # volatile stays available (the SRAM ladder), and a non-SPI-boot board
+    # keeps the raw persistent path
+    volatile = OpenFpgaLoaderProgrammer().program_step(config, mode="volatile")
+    assert "-f" not in volatile.argv
+    plain = _bench_config(work_root=Path("/w"))
+    persistent = OpenFpgaLoaderProgrammer().program_step(plain, mode="persistent")
+    assert "-f" in persistent.argv
+
+
+def test_dpv1_platform_carries_the_spi_boot_fact() -> None:
+    from dau_build.platforms import dpv1_platform
+
+    platform = dpv1_platform()
+    assert platform.spi_boot_buswidth == 4
+    config = HardwareToolchainConfig.for_platform(platform, work_root=Path("/w"))
+    assert config.spi_boot_buswidth == 4

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1838,3 +1838,10 @@ def test_explicit_cfgmem_programmer_also_refuses_external_bitstreams() -> None:
     )
     with pytest.raises(ValueError, match="cannot take an external"):
         flash_plan(config)
+
+
+def test_toolchain_config_rejects_an_unsupported_spi_width() -> None:
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError):
+        HardwareToolchainConfig(work_root=Path("/w"), spi_boot_buswidth=2)

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1817,3 +1817,11 @@ def test_dpv1_platform_carries_the_spi_boot_fact() -> None:
     assert platform.spi_boot_buswidth == 4
     config = HardwareToolchainConfig.for_platform(platform, work_root=Path("/w"))
     assert config.spi_boot_buswidth == 4
+
+
+def test_cfgmem_route_refuses_an_external_bitstream() -> None:
+    """flash.tcl programs the work tree's own generated image: an explicit
+    bitstream override must fail loudly, never flash a stale artifact."""
+    config = _bench_config(work_root=Path("/w"), spi_boot_buswidth=4, bitstream_path=Path("/elsewhere/design.bit"))
+    with pytest.raises(ValueError, match="cannot take an external"):
+        flash_plan(config)


### PR DESCRIPTION
Increment 2 of dau-docs-private/ROADMAP_DAU_BUILD_FIXES.md: the stale `plans/flash` emitted `openFPGALoader -f <raw bit>`, which the bench proved leaves an SPIx4-boot dpv1 board memory-dead.

- New `PlatformDefinition.spi_boot_buswidth` (`Literal[4] | None`; dpv1 = 4), threaded through `for_platform` and `HardwareToolchainConfig` (also `Literal[4] | None` — belt and braces).
- The JTAG programmer **refuses** persistent mode on SPI-boot boards; `flash_step` routes them to the vivado cfgmem path (`flash.tcl`) regardless of `program_method`.
- The cfgmem programmer **refuses an external bitstream** (flash.tcl programs the work tree's generated image) — the guard lives in the programmer so an explicitly composed one hits it too.
- `flash_plan` ends with a printed cold-power-cycle notice for SPI-boot boards.

Codex drove four rounds (SPI-boot routing, external-bitstream leak via explicit programmer, unsupported-width leak at both boundaries); final pass clean. dpv1 `plans/flash` now emits the proven cfgmem flow, no `-f`.