### PR TITLE
Serialize hardware plans on a host device lock

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1085,7 +1085,9 @@ class HardwarePlanTask(BuildCallableModel):
         )
         plan_result = plan.compose(config)
         if self.execute:
-            return_code = execute_plan_steps(plan_result)
+            # serialize the device: the executor holds a host lock on the
+            # endpoint BDF (a board is one exclusive resource)
+            return_code = execute_plan_steps(plan_result, endpoint_bdf=getattr(config, "endpoint_bdf", None))
             if return_code != 0:
                 raise BuildStepError(f"hardware plan {plan.name!r} failed with exit code {return_code}")
             return BuildStepResult(

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import base64
+import os
+import re
 import shlex
 import subprocess
 from collections.abc import Sequence
@@ -721,7 +723,28 @@ def format_plan_steps(steps: Sequence[ToolStep]) -> str:
     return "\n".join(f"{step.name}\t{step.command_line}" for step in steps)
 
 
-def execute_plan_steps(steps: Sequence[ToolStep]) -> int:
+def device_lock_dir() -> Path:
+    """The USER-PRIVATE runtime directory the device locks live in:
+    ``$XDG_RUNTIME_DIR/dau`` (the standard per-user, 0700, tmpfs runtime
+    location) when set, else ``~/.dau/locks``. User-private by design — a
+    bench is single-operator, so serializing the operator's own processes is
+    the requirement; a user-private dir (not world-writable ``/tmp``) has no
+    predictable-path symlink or ``fs.protected_regular`` attack surface, and
+    unlike ``tempfile.gettempdir()`` it is stable for that user."""
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    return Path(runtime) / "dau" if runtime else Path.home() / ".dau" / "locks"
+
+
+def device_lock_path(endpoint_bdf: str) -> Path:
+    """The advisory lock path for a device, keyed on its endpoint BDF, in
+    the user-private runtime dir. The BDF is lower-cased before keying so
+    equivalent spellings (``0000:0A:00.0`` / ``0000:0a:00.0``) map to ONE
+    lock — differing keys would silently defeat serialization."""
+    slug = re.sub(r"[^0-9a-zA-Z]+", "-", endpoint_bdf.lower()).strip("-")
+    return device_lock_dir() / f"dau-hw-{slug}.lock"
+
+
+def _run_plan_steps(steps: Sequence[ToolStep]) -> int:
     for index, step in enumerate(steps):
         print(f"+ {step.command_line}", flush=True)
         result = subprocess.run(step.argv)
@@ -732,6 +755,39 @@ def execute_plan_steps(steps: Sequence[ToolStep]) -> int:
                     subprocess.run(cleanup_step.argv)
             return result.returncode
     return 0
+
+
+def execute_plan_steps(steps: Sequence[ToolStep], *, endpoint_bdf: str | None = None) -> int:
+    """Run a hardware plan's steps in order. When ``endpoint_bdf`` is given,
+    the whole run is serialized under an advisory lock keyed on that device
+    (a board is one exclusive resource: no two plan runs from the operator's
+    processes may remove/reset/program the same endpoint at once). Without it
+    (a device-less plan) the steps run unserialized."""
+    if endpoint_bdf is None:
+        return _run_plan_steps(steps)
+    import fcntl
+
+    lock = device_lock_path(endpoint_bdf)
+    lock.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # mkdir(mode=) is umask-masked and only applied to newly-created leaves;
+    # force 0700 on the lock dir so a permissive umask can't leave it group/
+    # world-writable (another account could then swap the lock out from under
+    # O_NOFOLLOW, which only guards the final component)
+    try:
+        lock.parent.chmod(0o700)
+    except OSError:
+        pass  # not the owner / racing peer — flock still coordinates
+    # O_NOFOLLOW: refuse to follow a symlink at the lock path (the dir is
+    # user-private, so this is belt-and-braces)
+    fd = os.open(lock, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            return _run_plan_steps(steps)
+        finally:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)
 
 
 class HardwarePlan(BaseModel):
@@ -774,9 +830,7 @@ class ThunderboltReleasePlan(HardwarePlan):
         return thunderbolt_release_plan(config)
 
 
-def sram_program_plan(
-    config: HardwareToolchainConfig, *, deadman_timeout_s: int = 180, verify_command: str | None = None
-) -> tuple[ToolStep, ...]:
+def sram_program_plan(config: HardwareToolchainConfig, *, deadman_timeout_s: int = 180, verify_command: str | None = None) -> tuple[ToolStep, ...]:
     """The proven volatile (SRAM) reprogram ladder, safe order: PM hold ->
     deadman arm -> sysfs remove -> volatile program -> secondary-bus reset ->
     global rescan + settle -> endpoint verify [-> injected device verify] ->

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1527,9 +1527,7 @@ def test_toolchain_config_composes_from_platform_host_access() -> None:
 
     # dpv1's host_access config reproduces the proven bench facts exactly
     # (spi_boot_buswidth rides the platform, not host_access — supplied here)
-    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == _bench_config(
-        work_root=Path("/w"), spi_boot_buswidth=4
-    )
+    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == _bench_config(work_root=Path("/w"), spi_boot_buswidth=4)
 
     # a board with different access data changes the plans through config alone
     other = dpv1_platform().model_copy(deep=True)
@@ -1845,3 +1843,61 @@ def test_toolchain_config_rejects_an_unsupported_spi_width() -> None:
 
     with pytest.raises(pydantic.ValidationError):
         HardwareToolchainConfig(work_root=Path("/w"), spi_boot_buswidth=2)
+
+
+def test_device_lock_path_is_user_private_and_tmpdir_independent(monkeypatch) -> None:
+    from dau_build.hardware_plan import device_lock_path
+
+    # the per-user runtime dir, never world-writable /tmp; TMPDIR must not move it
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+    monkeypatch.setenv("TMPDIR", "/some/other/tmp")
+    a = device_lock_path("0000:04:00.0")
+    monkeypatch.setenv("TMPDIR", "/yet/another")
+    b = device_lock_path("0000:04:00.0")
+    assert a == b == Path("/run/user/1000/dau/dau-hw-0000-04-00-0.lock")
+    assert "/tmp/" not in str(a)
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    assert device_lock_path("0000:04:00.0") == Path.home() / ".dau" / "locks" / "dau-hw-0000-04-00-0.lock"
+
+
+def test_device_lock_path_canonicalizes_bdf_case() -> None:
+    from dau_build.hardware_plan import device_lock_path
+
+    # equivalent spellings must key ONE lock, else serialization is defeated
+    assert device_lock_path("0000:0A:00.0") == device_lock_path("0000:0a:00.0")
+
+
+def test_execute_serializes_on_the_device_lock(tmp_path, monkeypatch) -> None:
+    """Two overlapping executions of a device plan must not interleave: the
+    second blocks on the endpoint lock until the first releases."""
+    import threading
+    import time
+
+    from dau_build.hardware_plan import ToolStep, execute_plan_steps
+
+    # pin the lock path to this test's tmp dir (the monkeypatch targets the
+    # module attribute the executor reads, so no direct import is needed)
+    monkeypatch.setattr("dau_build.hardware_plan.device_lock_path", lambda bdf: tmp_path / "dev.lock")
+    log = tmp_path / "order.log"
+    # each "run" appends enter/exit around a sleep; if they interleave the
+    # log shows enter,enter — serialized it shows enter,exit,enter,exit
+    step = ToolStep("work", ("sh", "-c", f"echo enter >> {log}; sleep 0.4; echo exit >> {log}"))
+
+    def run():
+        execute_plan_steps((step,), endpoint_bdf="0000:04:00.0")
+
+    threads = [threading.Thread(target=run) for _ in range(2)]
+    threads[0].start()
+    time.sleep(0.05)
+    threads[1].start()
+    for thread in threads:
+        thread.join()
+    assert log.read_text().split() == ["enter", "exit", "enter", "exit"]
+
+
+def test_execute_without_a_device_runs_unserialized(tmp_path) -> None:
+    from dau_build.hardware_plan import ToolStep, execute_plan_steps
+
+    marker = tmp_path / "ran"
+    code = execute_plan_steps((ToolStep("t", ("sh", "-c", f"touch {marker}")),))
+    assert code == 0 and marker.exists()


### PR DESCRIPTION
Executed hardware plans (execute=true) now take a per-device advisory lock keyed on the endpoint BDF, so two overlapping runs cannot remove/reset/program the same board at once.

The lock lives in the user-private runtime dir ($XDG_RUNTIME_DIR/dau, else ~/.dau/locks), opened with O_NOFOLLOW — no world-writable /tmp attack surface. Serializes the operator's own processes; a bench is single-operator. The BDF is lower-cased before keying so equivalent spellings map to one lock.