### PR TITLE
Escalate only the privileged PCIe plan steps with a host prefix

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1052,6 +1052,7 @@ class HardwarePlanTask(BuildCallableModel):
     runtime_pm_executable: str | None = None
     runtime_pm_patterns: tuple[str, ...] | None = None
     rescan_bdfs: tuple[str, ...] | None = None
+    privilege_prefix: tuple[str, ...] | None = None
     execute: bool = False
 
     @Flow.call
@@ -1082,6 +1083,7 @@ class HardwarePlanTask(BuildCallableModel):
             runtime_pm_executable=self.runtime_pm_executable,
             runtime_pm_patterns=self.runtime_pm_patterns,
             rescan_bdfs=self.rescan_bdfs,
+            privilege_prefix=self.privilege_prefix,
         )
         plan_result = plan.compose(config)
         if self.execute:

--- a/dau_build/config/platform/platforms/dau/dpv1.yaml
+++ b/dau_build/config/platform/platforms/dau/dpv1.yaml
@@ -91,6 +91,11 @@ host_access:
   # secondary-bus reset target that re-inits the PCIe core after a
   # volatile reprogram
   reset_bridge_bdf: "0000:03:01.0"
+  # the bench host needs root for the sysfs/setpci/PM-hold steps; the
+  # deadman self-escalates and openFPGALoader runs as the user, so sudo
+  # fronts only the privileged steps
+  privilege_prefix:
+    - sudo
   rescan_bdfs:
     - "0000:03:01.0"
     - "0000:02:00.0"

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -26,4 +26,5 @@ expected_endpoint_id: null
 runtime_pm_executable: null
 runtime_pm_patterns: null
 rescan_bdfs: null
+privilege_prefix: null
 execute: false

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -80,6 +80,10 @@ class HardwareToolchainConfig(BaseModel):
     # only 4 is supported: the cfgmem generator writes SPIx4 (see
     # PlatformDefinition.spi_boot_buswidth)
     spi_boot_buswidth: Literal[4] | None = None
+    # command prefix for the privileged PCIe steps (sysfs/setpci/PM hold);
+    # the deadman self-escalates and the JTAG programmer runs as the user, so
+    # only the sysfs-writing steps carry it. Empty = already privileged.
+    privilege_prefix: tuple[str, ...] = ()
     programmer: Any = None
 
     @classmethod
@@ -103,6 +107,7 @@ class HardwareToolchainConfig(BaseModel):
                 "rescan_bdfs": access.rescan_bdfs,
                 "runtime_pm_patterns": access.runtime_pm_patterns,
                 "reset_bridge_bdf": access.reset_bridge_bdf,
+                "privilege_prefix": access.privilege_prefix,
             }
         method = getattr(platform, "program_method", None)
         if method is not None:
@@ -167,7 +172,7 @@ def build_and_program_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, .
         vivado_build_step(config),
         *detect_steps(config),
         program_volatile_step(config),
-        pci_rescan_step(config.required_host_access("rescan_bdfs")),
+        pci_rescan_step(config),
         lspci_endpoint_step(config),
     )
 
@@ -177,7 +182,7 @@ def recovery_plan(config: HardwareToolchainConfig) -> tuple[ToolStep, ...]:
         thunderbolt_hold_step(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
-        pci_rescan_step(config.required_host_access("rescan_bdfs")),
+        pci_rescan_step(config),
         lspci_endpoint_step(config),
     )
 
@@ -211,7 +216,7 @@ def local_build_and_program_plan(
         *detect_steps(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
-        pci_rescan_step(config.required_host_access("rescan_bdfs")),
+        pci_rescan_step(config),
         lspci_endpoint_step(config),
         *_smoke_steps(smoke_command),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
@@ -362,7 +367,7 @@ def validate_bitstream_plan(
         *detect_steps(config),
         remove_endpoint_step(config),
         program_volatile_step(config),
-        pci_rescan_step(config.required_host_access("rescan_bdfs")),
+        pci_rescan_step(config),
         lspci_endpoint_step(config),
         *_smoke_steps(smoke_command),
         thunderbolt_release_step(config, dau_utils_root=dau_utils_root, python=python),
@@ -589,17 +594,28 @@ def program_volatile_step(config: HardwareToolchainConfig) -> ToolStep:
     return config.resolve_programmer().program_step(config)
 
 
+def _privileged_sh(config: HardwareToolchainConfig, name: str, script: str) -> ToolStep:
+    """A privileged ``sh -c`` step, prefixed with the host's escalation
+    (e.g. ``sudo``) so the sysfs/config-space write runs as root. ``sudo``
+    fronts the whole ``sh -c`` so the shell REDIRECT executes as root too
+    (``sudo sh -c 'echo 1 > …'``, never ``sudo echo … >`` which redirects as
+    the caller)."""
+    return ToolStep(name, (*config.privilege_prefix, "sh", "-c", script))
+
+
 def remove_endpoint_step(config: HardwareToolchainConfig) -> ToolStep:
     remove_path = f"/sys/bus/pci/devices/{config.required_host_access('endpoint_bdf')}/remove"
-    return ToolStep("remove-endpoint", ("sh", "-c", f"test ! -e {remove_path} || echo 1 > {remove_path}"))
+    return _privileged_sh(config, "remove-endpoint", f"test ! -e {remove_path} || echo 1 > {remove_path}")
 
 
 def pci_global_rescan_step() -> ToolStep:
     return ToolStep("pci-global-rescan", ("sh", "-c", "echo 1 > /sys/bus/pci/rescan"))
 
 
-def pci_rescan_step(bridge_bdfs: Sequence[str] = ()) -> ToolStep:
-    return ToolStep("pci-rescan", ("sh", "-c", _pci_rescan_script(bridge_bdfs)))
+def pci_rescan_step(config: HardwareToolchainConfig) -> ToolStep:
+    # a privileged sysfs write, escalated with the host's prefix like the
+    # other rescan/remove steps
+    return _privileged_sh(config, "pci-rescan", _pci_rescan_script(config.required_host_access("rescan_bdfs")))
 
 
 def pm_hold_device_step(config: HardwareToolchainConfig) -> ToolStep:
@@ -612,7 +628,7 @@ def pm_hold_device_step(config: HardwareToolchainConfig) -> ToolStep:
     # failure with the device present propagates — proceeding into a
     # reprogram without the PM hold is exactly the wedge class this guards
     script = f"if [ -e /sys/bus/pci/devices/{quoted_bdf} ]; then {hold}; else echo 'pm hold skipped (device absent)'; fi"
-    return ToolStep("pm-hold-device", ("sh", "-c", script))
+    return _privileged_sh(config, "pm-hold-device", script)
 
 
 def deadman_arm_step(config: HardwareToolchainConfig, *, timeout_s: int = 180) -> ToolStep:
@@ -638,7 +654,7 @@ def secondary_bus_reset_step(config: HardwareToolchainConfig) -> ToolStep:
     # && chaining: a setpci failure must fail the STEP (a trailing sleep's
     # exit status would otherwise mask it and let the plan reach the disarm)
     script = f"setpci -s {bridge} BRIDGE_CONTROL=40:40 && sleep 0.6 && setpci -s {bridge} BRIDGE_CONTROL=00:40 && sleep 1.5"
-    return ToolStep("secondary-bus-reset", ("sh", "-c", script))
+    return _privileged_sh(config, "secondary-bus-reset", script)
 
 
 def lspci_endpoint_step(config: HardwareToolchainConfig) -> ToolStep:
@@ -844,7 +860,7 @@ def sram_program_plan(config: HardwareToolchainConfig, *, deadman_timeout_s: int
         secondary_bus_reset_step(config),
         # && chaining: a failed rescan write must fail the step, not be
         # masked by the settle sleep's exit status
-        ToolStep("pci-global-rescan-settle", ("sh", "-c", "echo 1 > /sys/bus/pci/rescan && sleep 4")),
+        _privileged_sh(config, "pci-global-rescan-settle", "echo 1 > /sys/bus/pci/rescan && sleep 4"),
         lspci_endpoint_step(config),
     ]
     if verify_command:

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -172,6 +172,12 @@ class HostAccess(BaseModel):
     # reprogram; a measured bench fact, explicit rather than inferred from
     # rescan_bdfs order
     reset_bridge_bdf: str | None = None
+    # command prefix for the host-side PRIVILEGED PCIe steps (sysfs writes,
+    # setpci, the runtime-PM hold), e.g. ("sudo",). The deadman self-escalates
+    # (it invokes `sudo systemctl` itself) and the JTAG programmer runs
+    # unprivileged, so this wraps ONLY the steps that write sysfs/config space.
+    # Empty (the default) = already privileged, or an unprivileged host.
+    privilege_prefix: tuple[str, ...] = ()
 
     @field_validator("pci_id", "endpoint_bdf")
     @classmethod

--- a/dau_build/tests/test_build_tasks.py
+++ b/dau_build/tests/test_build_tasks.py
@@ -601,6 +601,7 @@ def test_hardware_plan_task_composes_platform_host_access() -> None:
         expected_endpoint_id="10ee:7011",
         runtime_pm_patterns=("Thunderbolt", "JHL", "10ee:7011", "Xilinx"),
         rescan_bdfs=("0000:03:01.0", "0000:02:00.0", "0000:00:0d.3", "0000:00:0d.2", "0000:00:0d.0", "0000:00:07.2", "0000:00:07.0"),
+        privilege_prefix=("sudo",),
     )(None)
     composed = HardwarePlanTask(plan=RecoveryPlan(), work_root=Path("/repo/projects/vivado-shell"), platform=dpv1_platform())(None)
     # dpv1's host_access reproduces the explicit bench-fact plan text

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -833,9 +833,10 @@ def test_task_prints_recovery_plan_without_running_privileged_commands() -> None
     lines = result.message.splitlines()
     assert lines[0] == "thunderbolt-hold\tdau-utils-pci-runtime-pm hold --pattern Thunderbolt --pattern JHL --pattern 10ee:7011 --pattern Xilinx"
     assert lines[1:4] == [
-        "remove-endpoint\tsh -c 'test ! -e /sys/bus/pci/devices/0000:04:00.0/remove || echo 1 > /sys/bus/pci/devices/0000:04:00.0/remove'",
+        # dpv1 fronts the privileged sysfs steps with sudo; the JTAG program runs as the user
+        "remove-endpoint\tsudo sh -c 'test ! -e /sys/bus/pci/devices/0000:04:00.0/remove || echo 1 > /sys/bus/pci/devices/0000:04:00.0/remove'",
         "program-volatile\topenFPGALoader -c digilent_hs2 /repo/projects/vivado-shell/project.runs/impl_1/Top_wrapper.bit",
-        f"pci-rescan\tsh -c '{EXPECTED_PCI_RESCAN_SCRIPT}'",
+        f"pci-rescan\tsudo sh -c '{EXPECTED_PCI_RESCAN_SCRIPT}'",
     ]
     assert lines[4].startswith("lspci-endpoint\tsh -c ")
     assert EXPECTED_LSPCI_ENDPOINT_SNIPPET in lines[4]
@@ -1526,8 +1527,11 @@ def test_toolchain_config_composes_from_platform_host_access() -> None:
     from dau_build.platforms import dpv1_platform
 
     # dpv1's host_access config reproduces the proven bench facts exactly
-    # (spi_boot_buswidth rides the platform, not host_access — supplied here)
-    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == _bench_config(work_root=Path("/w"), spi_boot_buswidth=4)
+    # (spi_boot_buswidth rides the platform, not host_access — supplied here;
+    # dpv1 also fronts its privileged PCIe steps with sudo)
+    assert HardwareToolchainConfig.for_platform(dpv1_platform(), work_root=Path("/w")) == _bench_config(
+        work_root=Path("/w"), spi_boot_buswidth=4, privilege_prefix=("sudo",)
+    )
 
     # a board with different access data changes the plans through config alone
     other = dpv1_platform().model_copy(deep=True)
@@ -1540,10 +1544,11 @@ def test_toolchain_config_composes_from_platform_host_access() -> None:
     steps = recovery_plan(config)
     by_name = {step.name: step for step in steps}
     assert by_name["thunderbolt-hold"].argv == ("dau-utils-pci-runtime-pm", "hold", "--pattern", "Acme")
-    assert "0000:65:00.0/remove" in by_name["remove-endpoint"].argv[2]
+    # privileged steps are sudo-fronted (prefix-agnostic: check the rendered line)
+    assert "0000:65:00.0/remove" in by_name["remove-endpoint"].command_line
     assert by_name["program-volatile"].argv[1:3] == ("-c", "ft4232")
-    assert "0000:64:00.0" in by_name["pci-rescan"].argv[2]
-    assert "0000:03:01.0" not in by_name["pci-rescan"].argv[2]
+    assert "0000:64:00.0" in by_name["pci-rescan"].command_line
+    assert "0000:03:01.0" not in by_name["pci-rescan"].command_line
     assert "lspci -Dnn -d 10ee:9038" in by_name["lspci-endpoint"].argv[2]
     assert "0000:64:00.0" in by_name["lspci-endpoint"].argv[2]
 
@@ -1671,7 +1676,8 @@ def test_host_access_is_explicit_about_bdfs_and_patterns() -> None:
     steps = recovery_plan(config)
     by_name = {step.name: step for step in steps}
     assert by_name["thunderbolt-hold"].argv == ("dau-utils-pci-runtime-pm", "hold")
-    assert by_name["pci-rescan"].argv[2] == "echo 1 > /sys/bus/pci/rescan"
+    # with no bridge bdfs the rescan is the bare global write (sudo-fronted on dpv1)
+    assert by_name["pci-rescan"].argv[-1] == "echo 1 > /sys/bus/pci/rescan"
 
 
 def test_stage_task_name_must_be_non_empty(tmp_path: Path) -> None:
@@ -1729,6 +1735,25 @@ def test_sram_program_plan_is_the_proven_ladder() -> None:
     assert [step.name for step in bare] == [step.name for step in steps if step.name != "verify-device"]
 
 
+def test_sram_program_plan_prefixes_only_the_privileged_steps() -> None:
+    """The privilege prefix (sudo) fronts the sysfs/setpci/PM-hold steps so
+    their writes run as root, but NOT the deadman (it self-escalates via
+    `sudo systemctl`) or the JTAG program (it runs as the user) — escalating
+    those would change the deadman's unit ownership and need root JTAG."""
+    from dau_build.hardware_plan import SramProgramPlan
+
+    config = _bench_config(work_root=Path("/tmp/w"), bitstream_path=Path("/tmp/design.bit"), privilege_prefix=("sudo",))
+    by_name = {step.name: step for step in SramProgramPlan().compose(config)}
+
+    for privileged in ("pm-hold-device", "remove-endpoint", "secondary-bus-reset", "pci-global-rescan-settle"):
+        assert by_name[privileged].argv[:3] == ("sudo", "sh", "-c"), privileged
+    # the redirect runs under sudo (sudo fronts the whole sh -c)
+    assert "echo 1 > /sys/bus/pci/rescan" in by_name["pci-global-rescan-settle"].command_line
+
+    for unprivileged in ("deadman-arm", "program-volatile", "lspci-endpoint", "deadman-disarm"):
+        assert by_name[unprivileged].argv[0] != "sudo", unprivileged
+
+
 def test_sram_program_plan_requires_the_bridge_fact() -> None:
     from dau_build.hardware_plan import SramProgramPlan
 
@@ -1776,6 +1801,19 @@ def test_sram_program_plan_composes_from_the_config_group(tmp_path: Path) -> Non
         },
     )
     assert "deadman-arm" in result.message and "secondary-bus-reset" not in result.message.split("deadman-arm")[0]
+
+
+def test_hardware_plan_task_privilege_prefix_is_cli_overridable(tmp_path: Path) -> None:
+    """`model.privilege_prefix` must be declared in the packaged task config so
+    Hydra's struct mode accepts the override (e.g. clear it to run as root)."""
+    result = run_request_config(
+        "task",
+        "tasks/hardware/hardware-plan",
+        overrides=["plan=plans/sram-program", "platform=platforms/dau/dpv1", "model.privilege_prefix=[]"],
+        model_values={"work_root": str(tmp_path), "bitstream": "/tmp/design.bit"},
+    )
+    # dpv1 defaults to sudo; the override clears it (already-root invocation)
+    assert "remove-endpoint\tsh -c" in result.message and "remove-endpoint\tsudo" not in result.message
 
 
 def test_spi_boot_board_flash_plan_takes_the_cfgmem_path() -> None:


### PR DESCRIPTION
Executed hardware plans (SRAM reprogram, recovery) run as the user on the bench. The deadman self-escalates (it invokes sudo systemctl itself) and the JTAG programmer runs unprivileged, but the sysfs writes (device remove, pci rescan), the setpci secondary-bus reset, and the runtime-PM hold need root.

A new host_access privilege_prefix (dpv1 = sudo) fronts only those privileged sh -c steps — sudo fronts the whole sh -c so the shell redirect runs as root too. deadman/program/lspci stay unprefixed (escalating the deadman would change its systemd unit ownership; the JTAG program needs no root). The prefix is CLI-overridable (model.privilege_prefix=[]) to run under an already-root invocation.