### PR TITLE
Fix lint under ruff 0.16 broad default

### DIFF
--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -763,12 +763,12 @@ def device_lock_path(endpoint_bdf: str) -> Path:
 def _run_plan_steps(steps: Sequence[ToolStep]) -> int:
     for index, step in enumerate(steps):
         print(f"+ {step.command_line}", flush=True)
-        result = subprocess.run(step.argv)
+        result = subprocess.run(step.argv, check=False)
         if result.returncode != 0:
             for cleanup_step in steps[index + 1 :]:
                 if cleanup_step.name.endswith("release"):
                     print(f"+ {cleanup_step.command_line}", flush=True)
-                    subprocess.run(cleanup_step.argv)
+                    subprocess.run(cleanup_step.argv, check=False)
             return result.returncode
     return 0
 

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -45,8 +45,8 @@ class TileInstance(BaseModel):
     byte-identical."""
 
     module: str
-    config: dict[str, str] = {}
-    params: dict[str, int] = {}
+    config: dict[str, str] = {}  # noqa: RUF012  # pydantic deep-copies field defaults per instance
+    params: dict[str, int] = {}  # noqa: RUF012  # pydantic deep-copies field defaults per instance
 
 
 class LaneTile(TileInstance):

--- a/dau_build/svparser.py
+++ b/dau_build/svparser.py
@@ -248,7 +248,6 @@ class Inout(Port):
     """Bidirectional port."""
 
 
-
 class Wire(BaseModel):
     """Internal wire/reg/logic/bit declaration within a module body."""
 
@@ -495,7 +494,7 @@ class Module(_Base):
         namespace.update(getattr(self, "__localparams__", {}))
         try:
             return int(eval(_translate_sv_expr(str(expr)), {"__builtins__": {}}, namespace))
-        except Exception:
+        except Exception:  # noqa: BLE001  # any eval failure means the dimension is unresolvable
             return None
 
     def _parse_localparams(self):
@@ -655,7 +654,7 @@ class Module(_Base):
                 keyword = "wire"
                 try:
                     dimensions = self._parse_dimensions(member.type)
-                except Exception:
+                except Exception:  # noqa: BLE001  # unparseable net type falls back to scalar
                     dimensions = Dimensions(dimensions=[1])
                 for decl in member.declarators:
                     name = decl.name.value
@@ -701,9 +700,8 @@ class Module(_Base):
             if isinstance(member, ProceduralBlockSyntax):
                 kind = kind_map.get(member.kind, str(member.kind))
                 sensitivity = ""
-                if member.kind == SyntaxKind.AlwaysFFBlock:
-                    if hasattr(member.statement, "timingControl") and member.statement.timingControl:
-                        sensitivity = str(member.statement.timingControl).strip()
+                if member.kind == SyntaxKind.AlwaysFFBlock and (hasattr(member.statement, "timingControl") and member.statement.timingControl):
+                    sensitivity = str(member.statement.timingControl).strip()
                 body = str(member).strip()
                 block = ProceduralBlock(kind=kind, sensitivity=sensitivity, body=body)
                 if kind == "always_comb":
@@ -748,7 +746,7 @@ class Module(_Base):
                             val = str(connection.expr[0][0]).strip()
                         link = Link(name=val, connection=val, position=i)
                         mod.links.append(link)
-                    except Exception:
+                    except Exception:  # noqa: BLE001, S110  # skip connections whose expr shape we can't read
                         pass
             gen_block.modules.append(mod)
             return
@@ -841,7 +839,7 @@ class Design(BaseModel):
             try:
                 mod = Module.from_file(f)
                 design.modules[mod.name] = mod
-            except Exception:
+            except Exception:  # noqa: BLE001, S110  # skip files that fail to parse, keep the rest
                 pass
         return design
 
@@ -856,7 +854,7 @@ class Design(BaseModel):
 
     def resolve(self) -> Design:
         """Resolve all submodule references within the design."""
-        for name, mod in self.modules.items():
+        for mod in self.modules.values():
             for i, sub in enumerate(mod.modules):
                 if sub.name in self.modules:
                     resolved = self.modules[sub.name]
@@ -1180,7 +1178,7 @@ class Design(BaseModel):
 
     def __str__(self):
         parts = [f"Design({len(self.modules)} modules):"]
-        for name, mod in self.modules.items():
+        for mod in self.modules.values():
             parts.append(f"  {mod.to_string('  ')}")
         return "\n".join(parts)
 

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -197,6 +197,7 @@ class SynthesizeCoresTask(BuildCallableModel):
             cwd=root,
             capture_output=True,
             text=True,
+            check=False,
         )
         if completed.returncode != 0:
             raise BuildStepError(

--- a/dau_build/tests/test_artifact_bundle.py
+++ b/dau_build/tests/test_artifact_bundle.py
@@ -10,18 +10,7 @@ def test_artifact_bundle_rejects_manifest_missing_required_roles(tmp_path: Path)
     (tmp_path / "python" / "model.py").write_text("class ReferenceModel: pass\n", encoding="utf-8")
     manifest_path = tmp_path / "package.artifacts.yaml"
     manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: python-only-package",
-                "artifacts:",
-                "  - path: python/model.py",
-                "    kind: source",
-                "    role: python-source",
-                "    language: python",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: python-only-package\nartifacts:\n  - path: python/model.py\n    kind: source\n    role: python-source\n    language: python\n",
         encoding="utf-8",
     )
 
@@ -38,28 +27,7 @@ def test_artifact_bundle_rejects_duplicate_module_providers(tmp_path: Path) -> N
     (tmp_path / "rtl" / "filter_b.sv").write_text("module filter_b; endmodule\n", encoding="utf-8")
     manifest_path = tmp_path / "package.artifacts.yaml"
     manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: duplicate-module-package",
-                "artifacts:",
-                "  - path: rtl/filter_a.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "    provides:",
-                "      - kind: hdl-module",
-                "        name: filter",
-                "  - path: rtl/filter_b.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "    provides:",
-                "      - kind: hdl-module",
-                "        name: filter",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: duplicate-module-package\nartifacts:\n  - path: rtl/filter_a.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n    provides:\n      - kind: hdl-module\n        name: filter\n  - path: rtl/filter_b.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n    provides:\n      - kind: hdl-module\n        name: filter\n",
         encoding="utf-8",
     )
 
@@ -76,18 +44,7 @@ def test_artifact_bundle_rejects_unsupported_source_languages(tmp_path: Path) ->
     (tmp_path / "src" / "kernel.cpp").write_text("void kernel() {}\n", encoding="utf-8")
     manifest_path = tmp_path / "package.artifacts.yaml"
     manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: unsupported-source-package",
-                "artifacts:",
-                "  - path: src/kernel.cpp",
-                "    kind: source",
-                "    role: native-source",
-                "    language: cpp",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: unsupported-source-package\nartifacts:\n  - path: src/kernel.cpp\n    kind: source\n    role: native-source\n    language: cpp\n",
         encoding="utf-8",
     )
 
@@ -104,21 +61,7 @@ def test_artifact_bundle_rejects_missing_hdl_sources_when_required(tmp_path: Pat
     (tmp_path / "python" / "model.py").write_text("class Model: pass\n", encoding="utf-8")
     manifest_path = tmp_path / "model.artifacts.yaml"
     manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: model-only",
-                "artifacts:",
-                "  - path: python/model.py",
-                "    kind: source",
-                "    role: python-reference",
-                "    language: python",
-                "    provides:",
-                "      - kind: python-symbol",
-                "        name: Model",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: model-only\nartifacts:\n  - path: python/model.py\n    kind: source\n    role: python-reference\n    language: python\n    provides:\n      - kind: python-symbol\n        name: Model\n",
         encoding="utf-8",
     )
 

--- a/dau_build/tests/test_build_spec.py
+++ b/dau_build/tests/test_build_spec.py
@@ -325,58 +325,12 @@ def test_build_spec_consumes_yaml_artifact_manifest_inputs(tmp_path: Path) -> No
     (package_dir / "bitstreams" / "package.bit").write_bytes(b"DAU")
     package_manifest_path = package_dir / "package.artifacts.yaml"
     package_manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: packaged-filter",
-                "artifacts:",
-                "  - path: rtl/packaged_filter.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "  - path: python/model.py",
-                "    kind: source",
-                "    role: python-source",
-                "    language: python",
-                "    provides:",
-                "      - kind: python-symbol",
-                "        name: PackagedFilter",
-                "  - path: constraints/package.xdc",
-                "    kind: metadata",
-                "    role: constraints",
-                "    format: xdc",
-                "  - path: bitstreams/package.bit",
-                "    kind: binary",
-                "    role: bitstream",
-                "    format: xilinx-bitstream",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: packaged-filter\nartifacts:\n  - path: rtl/packaged_filter.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n  - path: python/model.py\n    kind: source\n    role: python-source\n    language: python\n    provides:\n      - kind: python-symbol\n        name: PackagedFilter\n  - path: constraints/package.xdc\n    kind: metadata\n    role: constraints\n    format: xdc\n  - path: bitstreams/package.bit\n    kind: binary\n    role: bitstream\n    format: xilinx-bitstream\n",
         encoding="utf-8",
     )
     spec_path = tmp_path / "dau-build.yaml"
     spec_path.write_text(
-        "\n".join(
-            (
-                "name: packaged-filter-pipeline",
-                "top_name: dau_packaged_top",
-                "platform: sim",
-                "shell: unit-test",
-                "artifact_stem: dau-packaged",
-                'register_map_version: "0.1"',
-                'stream_protocol_version: "0.1"',
-                "clock: clk",
-                "reset: reset",
-                "operators:",
-                "  - packaged-filter",
-                "artifact_manifests:",
-                "  - package/package.artifacts.yaml",
-                "modules:",
-                "  - packaged_filter",
-                "backend: none",
-                "",
-            )
-        ),
+        'name: packaged-filter-pipeline\ntop_name: dau_packaged_top\nplatform: sim\nshell: unit-test\nartifact_stem: dau-packaged\nregister_map_version: "0.1"\nstream_protocol_version: "0.1"\nclock: clk\nreset: reset\noperators:\n  - packaged-filter\nartifact_manifests:\n  - package/package.artifacts.yaml\nmodules:\n  - packaged_filter\nbackend: none\n',
         encoding="utf-8",
     )
 
@@ -405,43 +359,12 @@ def test_build_spec_reports_manifest_inputs_without_hdl(tmp_path: Path) -> None:
     (package_dir / "python" / "model.py").write_text("class ReferenceModel: pass\n", encoding="utf-8")
     package_manifest_path = package_dir / "package.artifacts.yaml"
     package_manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: python-only-package",
-                "artifacts:",
-                "  - path: python/model.py",
-                "    kind: source",
-                "    role: python-source",
-                "    language: python",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: python-only-package\nartifacts:\n  - path: python/model.py\n    kind: source\n    role: python-source\n    language: python\n",
         encoding="utf-8",
     )
     spec_path = tmp_path / "dau-build.yaml"
     spec_path.write_text(
-        "\n".join(
-            (
-                "name: python-only-pipeline",
-                "top_name: dau_python_top",
-                "platform: sim",
-                "shell: unit-test",
-                "artifact_stem: dau-python",
-                'register_map_version: "0.1"',
-                'stream_protocol_version: "0.1"',
-                "clock: clk",
-                "reset: reset",
-                "operators:",
-                "  - python-only",
-                "artifact_manifests:",
-                "  - package/package.artifacts.yaml",
-                "modules:",
-                "  - missing_hdl",
-                "backend: none",
-                "",
-            )
-        ),
+        'name: python-only-pipeline\ntop_name: dau_python_top\nplatform: sim\nshell: unit-test\nartifact_stem: dau-python\nregister_map_version: "0.1"\nstream_protocol_version: "0.1"\nclock: clk\nreset: reset\noperators:\n  - python-only\nartifact_manifests:\n  - package/package.artifacts.yaml\nmodules:\n  - missing_hdl\nbackend: none\n',
         encoding="utf-8",
     )
 
@@ -465,55 +388,12 @@ def test_cli_inspect_reports_manifest_input_origins(tmp_path: Path, capsys) -> N
     (package_dir / "bitstreams" / "package.bit").write_bytes(b"DAU")
     package_manifest_path = package_dir / "package.artifacts.yaml"
     package_manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: packaged-filter",
-                "artifacts:",
-                "  - path: rtl/packaged_filter.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "  - path: python/model.py",
-                "    kind: source",
-                "    role: python-source",
-                "    language: python",
-                "  - path: constraints/package.xdc",
-                "    kind: metadata",
-                "    role: constraints",
-                "    format: xdc",
-                "  - path: bitstreams/package.bit",
-                "    kind: binary",
-                "    role: bitstream",
-                "    format: xilinx-bitstream",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: packaged-filter\nartifacts:\n  - path: rtl/packaged_filter.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n  - path: python/model.py\n    kind: source\n    role: python-source\n    language: python\n  - path: constraints/package.xdc\n    kind: metadata\n    role: constraints\n    format: xdc\n  - path: bitstreams/package.bit\n    kind: binary\n    role: bitstream\n    format: xilinx-bitstream\n",
         encoding="utf-8",
     )
     spec_path = tmp_path / "dau-build.yaml"
     spec_path.write_text(
-        "\n".join(
-            (
-                "name: packaged-filter-pipeline",
-                "top_name: dau_packaged_top",
-                "platform: sim",
-                "shell: unit-test",
-                "artifact_stem: dau-packaged",
-                'register_map_version: "0.1"',
-                'stream_protocol_version: "0.1"',
-                "clock: clk",
-                "reset: reset",
-                "operators:",
-                "  - packaged-filter",
-                "artifact_manifests:",
-                "  - package/package.artifacts.yaml",
-                "modules:",
-                "  - packaged_filter",
-                "backend: none",
-                "",
-            )
-        ),
+        'name: packaged-filter-pipeline\ntop_name: dau_packaged_top\nplatform: sim\nshell: unit-test\nartifact_stem: dau-packaged\nregister_map_version: "0.1"\nstream_protocol_version: "0.1"\nclock: clk\nreset: reset\noperators:\n  - packaged-filter\nartifact_manifests:\n  - package/package.artifacts.yaml\nmodules:\n  - packaged_filter\nbackend: none\n',
         encoding="utf-8",
     )
 

--- a/dau_build/tests/test_build_steps.py
+++ b/dau_build/tests/test_build_steps.py
@@ -122,16 +122,7 @@ def test_resolved_config_step_reports_typed_board_driver_operator_and_memory_mod
 
     assert result == BuildStepResult(
         step="resolved-config",
-        message="\n".join(
-            (
-                "dau-build-resolved-config",
-                "board\tname=vivado-xdma platform=vivado-xdma shell=xdma-ddr",
-                "backend\tname=none invocation=dry-run",
-                "driver\tos=host transport=xdma",
-                "operators\tset=spec names=identity",
-                "memory\thost_staging_bytes=0 device_staging_bytes=0",
-            )
-        ),
+        message="dau-build-resolved-config\nboard\tname=vivado-xdma platform=vivado-xdma shell=xdma-ddr\nbackend\tname=none invocation=dry-run\ndriver\tos=host transport=xdma\noperators\tset=spec names=identity\nmemory\thost_staging_bytes=0 device_staging_bytes=0",
     )
 
 
@@ -326,25 +317,7 @@ def _write_counter_spec(tmp_path: Path) -> Path:
 def _write_counter_testbench(tmp_path: Path) -> Path:
     testbench_path = tmp_path / "counter_tb.sv"
     testbench_path.write_text(
-        "\n".join(
-            (
-                "`timescale 1ns/1ps",
-                "module counter_tb;",
-                "  logic clk = 1'b0;",
-                "  logic [31:0] out;",
-                "  counter dut(.clk(clk), .out(out));",
-                "  always #5 clk = ~clk;",
-                "  initial begin",
-                "    repeat (3) @(posedge clk);",
-                "    #1;",
-                '    if (out != 32\'d3) $fatal(1, "counter mismatch: %0d", out);',
-                '    $display("DAU_BUILD_COUNTER_TB_OK");',
-                "    $finish;",
-                "  end",
-                "endmodule",
-                "",
-            )
-        ),
+        '`timescale 1ns/1ps\nmodule counter_tb;\n  logic clk = 1\'b0;\n  logic [31:0] out;\n  counter dut(.clk(clk), .out(out));\n  always #5 clk = ~clk;\n  initial begin\n    repeat (3) @(posedge clk);\n    #1;\n    if (out != 32\'d3) $fatal(1, "counter mismatch: %0d", out);\n    $display("DAU_BUILD_COUNTER_TB_OK");\n    $finish;\n  end\nendmodule\n',
         encoding="utf-8",
     )
     return testbench_path
@@ -353,19 +326,7 @@ def _write_counter_testbench(tmp_path: Path) -> Path:
 def _write_counter_profile_manifest(tmp_path: Path, testbench_path: Path) -> Path:
     profile_path = tmp_path / "counter-profiles.yaml"
     profile_path.write_text(
-        "\n".join(
-            (
-                "schema: dau.simulation-profile/v0",
-                "profiles:",
-                "  - name: counter-profile",
-                "    simulator: verilator",
-                "    top_module: counter_tb",
-                "    expect_stdout: DAU_BUILD_COUNTER_TB_OK",
-                "    sources:",
-                "      - artifact: counter-tb",
-                "",
-            )
-        ),
+        "schema: dau.simulation-profile/v0\nprofiles:\n  - name: counter-profile\n    simulator: verilator\n    top_module: counter_tb\n    expect_stdout: DAU_BUILD_COUNTER_TB_OK\n    sources:\n      - artifact: counter-tb\n",
         encoding="utf-8",
     )
     manifest_path = tmp_path / "counter-profiles.artifacts.yaml"
@@ -409,6 +370,7 @@ def test_task_dispatch_import_stays_light() -> None:
             "import sys; import dau_build.build_steps; heavy = [m for m in ('amaranth', 'pyslang', 'dau_sim') if m in sys.modules]; raise SystemExit(1 if heavy else 0)",
         ],
         capture_output=True,
+        check=False,
     )
     assert completed.returncode == 0, completed.stderr.decode()
 

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -159,18 +159,18 @@ def test_write_artifacts_emits_generated_sources_and_scripts(tmp_path: Path) -> 
 def _probe_platform(**overrides):
     from dau_build.platforms import HostLink, PlatformDefinition, PlatformMemory, ResourceBudget, XdmaPersonality
 
-    base = dict(
-        name="probe-k7",
-        part="xc7k325tffg900-2",
-        budget=ResourceBudget(lut=178800, ff=382600, bram36=415, dsp=810),
-        host_link=HostLink(
+    base = {
+        "name": "probe-k7",
+        "part": "xc7k325tffg900-2",
+        "budget": ResourceBudget(lut=178800, ff=382600, bram36=415, dsp=810),
+        "host_link": HostLink(
             interface="pcie-xdma",
             pcie_lanes=8,
             xdma_personality=XdmaPersonality(params={"pl_link_cap_max_link_width": "X8", "axisten_freq": "125"}),
         ),
-        memory=PlatformMemory(kind="ddr3", size_bytes=8 << 30),
-        constraints_xdc="set_property CFGBVS GND [current_design]\n",
-    )
+        "memory": PlatformMemory(kind="ddr3", size_bytes=8 << 30),
+        "constraints_xdc": "set_property CFGBVS GND [current_design]\n",
+    }
     base.update(overrides)
     return PlatformDefinition(**base)
 
@@ -215,12 +215,12 @@ def test_platform_threads_through_the_ddr_project(tmp_path: Path) -> None:
 def test_request_part_resolves_from_the_platform(tmp_path: Path) -> None:
     tile = tmp_path / "stream_tile.sv"
     tile.write_text("module stream_tile; endmodule\n")
-    common = dict(
-        output_root=tmp_path / "shell",
-        hdl_sources=(tile,),
-        generated_sources=(("my_mm_top.v", "module my_mm_top; endmodule\n"),),
-        top_module="my_mm_top",
-    )
+    common = {
+        "output_root": tmp_path / "shell",
+        "hdl_sources": (tile,),
+        "generated_sources": (("my_mm_top.v", "module my_mm_top; endmodule\n"),),
+        "top_module": "my_mm_top",
+    }
     assert MmJobShellRequest(**common).resolved_part == "xc7a200tfbg484-2"  # dpv1 default
     assert MmJobShellRequest(platform=_probe_platform(), **common).resolved_part == "xc7k325tffg900-2"
     # an explicit part override wins over the platform
@@ -233,12 +233,12 @@ def test_request_part_resolves_from_the_platform(tmp_path: Path) -> None:
 def test_default_platform_instances_are_not_shared(tmp_path: Path) -> None:
     tile = tmp_path / "stream_tile.sv"
     tile.write_text("module stream_tile; endmodule\n")
-    common = dict(
-        output_root=tmp_path / "shell",
-        hdl_sources=(tile,),
-        generated_sources=(("my_mm_top.v", "module my_mm_top; endmodule\n"),),
-        top_module="my_mm_top",
-    )
+    common = {
+        "output_root": tmp_path / "shell",
+        "hdl_sources": (tile,),
+        "generated_sources": (("my_mm_top.v", "module my_mm_top; endmodule\n"),),
+        "top_module": "my_mm_top",
+    }
     first = MmJobShellRequest(**common)
     first.platform.host_link.xdma_personality.params["plltype"] = "TAMPERED"
     second = MmJobShellRequest(**common)

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -350,28 +350,7 @@ def test_structured_vivado_backend_request_supports_source_only_mount_root(tmp_p
     (bundle_root / "rtl" / "operator.sv").write_text("module operator; endmodule\n", encoding="utf-8")
     bundle_path = bundle_root / "dau-identity.artifacts.yaml"
     bundle_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: dau-identity",
-                "artifacts:",
-                "  - path: generated/dau_identity_top.sv",
-                "    kind: source",
-                "    role: generated-top",
-                "    language: systemverilog",
-                "    provides:",
-                "      - kind: hdl-module",
-                "        name: dau_identity_top",
-                "  - path: rtl/operator.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "    provides:",
-                "      - kind: hdl-module",
-                "        name: operator",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: dau-identity\nartifacts:\n  - path: generated/dau_identity_top.sv\n    kind: source\n    role: generated-top\n    language: systemverilog\n    provides:\n      - kind: hdl-module\n        name: dau_identity_top\n  - path: rtl/operator.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n    provides:\n      - kind: hdl-module\n        name: operator\n",
         encoding="utf-8",
     )
     request = VivadoBackendRequest(
@@ -420,28 +399,7 @@ def test_structured_vivado_backend_request_consumes_dau_artifact_bundle(tmp_path
     (bundle_root / "rtl" / "operator.sv").write_text("module operator; endmodule\n", encoding="utf-8")
     bundle_path = bundle_root / "dau-identity.artifacts.yaml"
     bundle_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: dau-identity",
-                "artifacts:",
-                "  - path: generated/dau_identity_top.sv",
-                "    kind: source",
-                "    role: generated-top",
-                "    language: systemverilog",
-                "    provides:",
-                "      - kind: hdl-module",
-                "        name: dau_identity_top",
-                "  - path: rtl/operator.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "    provides:",
-                "      - kind: hdl-module",
-                "        name: operator",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: dau-identity\nartifacts:\n  - path: generated/dau_identity_top.sv\n    kind: source\n    role: generated-top\n    language: systemverilog\n    provides:\n      - kind: hdl-module\n        name: dau_identity_top\n  - path: rtl/operator.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n    provides:\n      - kind: hdl-module\n        name: operator\n",
         encoding="utf-8",
     )
     request = VivadoBackendRequest(
@@ -1202,7 +1160,7 @@ def test_task_execute_runs_plan_steps_in_order(monkeypatch) -> None:
     class Completed:
         returncode = 0
 
-    def fake_run(argv):
+    def fake_run(argv, check=False):
         calls.append(tuple(argv))
         return Completed()
 
@@ -1234,7 +1192,7 @@ def test_cli_execute_releases_runtime_pm_after_failed_local_plan_step(monkeypatc
         def __init__(self, returncode: int) -> None:
             self.returncode = returncode
 
-    def fake_run(argv):
+    def fake_run(argv, check=False):
         calls.append(tuple(argv))
         return Completed(return_codes[len(calls) - 1])
 
@@ -1473,12 +1431,12 @@ def test_local_build_and_program_plan_honors_the_injected_definition(tmp_path: P
 
 def test_project_manifest_records_and_guards_an_injected_definition(tmp_path: Path) -> None:
     definition = _acme_overlay_definition()
-    request_kwargs = dict(
-        source_shell_root=Path("/repo/projects/nite"),
-        work_root=tmp_path,
-        dau_core_root=Path("/repo/acme"),
-        dau_driver_root=Path("/repo/dau-driver"),
-    )
+    request_kwargs = {
+        "source_shell_root": Path("/repo/projects/nite"),
+        "work_root": tmp_path,
+        "dau_core_root": Path("/repo/acme"),
+        "dau_driver_root": Path("/repo/dau-driver"),
+    }
 
     injected = dict(
         vivado_backend.vivado_project_generation_manifest(VivadoProjectGenerationRequest(**request_kwargs, overlay_definition=definition))

--- a/dau_build/tests/test_packaging.py
+++ b/dau_build/tests/test_packaging.py
@@ -106,18 +106,7 @@ def test_artifact_manifest_rejects_duplicate_artifact_paths() -> None:
 def test_load_artifact_manifest_rejects_missing_artifact_files(tmp_path: Path) -> None:
     manifest_path = tmp_path / "manifest.yaml"
     manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.manifest/v0",
-                "name: missing-file-bundle",
-                "artifacts:",
-                "  - path: rtl/missing.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "",
-            )
-        ),
+        "schema: artlink.manifest/v0\nname: missing-file-bundle\nartifacts:\n  - path: rtl/missing.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n",
         encoding="utf-8",
     )
 
@@ -139,18 +128,7 @@ def test_load_artifact_manifest_rejects_removed_artifact_schema(tmp_path: Path) 
     (tmp_path / "rtl" / "filter.sv").write_text("module filter; endmodule\n", encoding="utf-8")
     manifest_path = tmp_path / "old-schema.artifacts.yaml"
     manifest_path.write_text(
-        "\n".join(
-            (
-                "schema: artlink.artifact-manifest/v0",
-                "name: removed-schema-bundle",
-                "artifacts:",
-                "  - path: rtl/filter.sv",
-                "    kind: source",
-                "    role: hdl-source",
-                "    language: systemverilog",
-                "",
-            )
-        ),
+        "schema: artlink.artifact-manifest/v0\nname: removed-schema-bundle\nartifacts:\n  - path: rtl/filter.sv\n    kind: source\n    role: hdl-source\n    language: systemverilog\n",
         encoding="utf-8",
     )
 

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -163,28 +163,7 @@ def test_user_config_dir_overlay_adds_a_board(tmp_path) -> None:
     overlay = tmp_path / "user-configs"
     (overlay / "platform").mkdir(parents=True)
     (overlay / "platform" / "myboard.yaml").write_text(
-        "\n".join(
-            (
-                "# @package platform",
-                "_target_: dau_build.platforms.PlatformDefinition",
-                "name: myboard",
-                "part: xc7k70tfbg484-2",
-                "budget:",
-                "  _target_: dau_build.platforms.ResourceBudget",
-                "  lut: 41000",
-                "  ff: 82000",
-                "  bram36: 135",
-                "  dsp: 240",
-                "host_link:",
-                "  _target_: dau_build.platforms.HostLink",
-                "  interface: pcie-xdma",
-                "  pcie_lanes: 1",
-                "memory:",
-                "  _target_: dau_build.platforms.PlatformMemory",
-                "  kind: ddr3",
-                "  size_bytes: 1073741824",
-            )
-        )
+        "# @package platform\n_target_: dau_build.platforms.PlatformDefinition\nname: myboard\npart: xc7k70tfbg484-2\nbudget:\n  _target_: dau_build.platforms.ResourceBudget\n  lut: 41000\n  ff: 82000\n  bram36: 135\n  dsp: 240\nhost_link:\n  _target_: dau_build.platforms.HostLink\n  interface: pcie-xdma\n  pcie_lanes: 1\nmemory:\n  _target_: dau_build.platforms.PlatformMemory\n  kind: ddr3\n  size_bytes: 1073741824"
     )
     board = resolve_platform("myboard", config_dir=str(overlay))
     assert board.name == "myboard"
@@ -196,13 +175,13 @@ def test_user_config_dir_overlay_adds_a_board(tmp_path) -> None:
 
 
 def _dpv1_with(**overrides: object) -> PlatformDefinition:
-    base = dict(
-        name="dpv1",
-        part="xc7a200tfbg484-2",
-        budget=ResourceBudget(lut=134600, ff=269200, bram36=365, dsp=740),
-        host_link=HostLink(interface="pcie-xdma", pcie_lanes=4),
-        memory=PlatformMemory(kind="ddr3", size_bytes=1 << 30),
-    )
+    base = {
+        "name": "dpv1",
+        "part": "xc7a200tfbg484-2",
+        "budget": ResourceBudget(lut=134600, ff=269200, bram36=365, dsp=740),
+        "host_link": HostLink(interface="pcie-xdma", pcie_lanes=4),
+        "memory": PlatformMemory(kind="ddr3", size_bytes=1 << 30),
+    }
     base.update(overrides)
     return PlatformDefinition(**base)  # type: ignore[arg-type]
 

--- a/dau_build/tests/test_simulate_profile_task.py
+++ b/dau_build/tests/test_simulate_profile_task.py
@@ -36,20 +36,7 @@ def _write_self_contained_counter_manifest(tmp_path) -> Path:
     counter_source = Path(__file__).parent / "sv" / "counter.sv"
     profile_path = tmp_path / "counter-only-profiles.yaml"
     profile_path.write_text(
-        "\n".join(
-            (
-                "schema: dau.simulation-profile/v0",
-                "profiles:",
-                "  - name: counter-profile",
-                "    simulator: verilator",
-                "    top_module: counter_tb",
-                "    expect_stdout: DAU_BUILD_COUNTER_TB_OK",
-                "    sources:",
-                "      - artifact: counter-source",
-                "      - artifact: counter-tb",
-                "",
-            )
-        ),
+        "schema: dau.simulation-profile/v0\nprofiles:\n  - name: counter-profile\n    simulator: verilator\n    top_module: counter_tb\n    expect_stdout: DAU_BUILD_COUNTER_TB_OK\n    sources:\n      - artifact: counter-source\n      - artifact: counter-tb\n",
         encoding="utf-8",
     )
     manifest_path = tmp_path / "counter-only-profiles.artifacts.yaml"

--- a/dau_build/tests/test_yosys_backend.py
+++ b/dau_build/tests/test_yosys_backend.py
@@ -17,7 +17,7 @@ def _slang_available() -> bool:
     if which("yosys") is None:
         return False
     try:
-        proc = subprocess.run(["yosys", "-m", "slang", "-p", "help read_slang"], capture_output=True, text=True)
+        proc = subprocess.run(["yosys", "-m", "slang", "-p", "help read_slang"], capture_output=True, text=True, check=False)
     except FileNotFoundError:
         return False
     return proc.returncode == 0

--- a/dau_build/yosys_backend.py
+++ b/dau_build/yosys_backend.py
@@ -88,7 +88,7 @@ def run_yosys_synthesis(request: YosysBackendRequest) -> YosysSynthesisResult:
         argv += ["-m", "slang"]
     argv += ["-s", str(script_path)]
     try:
-        proc = subprocess.run(argv, capture_output=True, text=True)
+        proc = subprocess.run(argv, capture_output=True, text=True, check=False)
     except FileNotFoundError as exc:
         raise YosysBackendError(f"yosys executable {request.yosys!r} not found") from exc
     log_path = request.output_root / request.log_name


### PR DESCRIPTION
ruff 0.16.0 broadened its default rule set, surfacing 41 findings under the existing config (`extend-select=[ARG,I]`). Fixed all by correcting the code, never by relaxing rules.

Findings fixed by category:
- FLY002 (join -> f-string) x19: test fixtures building multi-line YAML now use the equivalent literal.
- PLW1510 (subprocess.run without check) x6: added explicit `check=False` where returncode is inspected afterward (behavior-preserving; hardware-plan executor and yosys backend deliberately branch on returncode). Two test `fake_run` fakes updated to accept the keyword.
- C408 (dict() -> literal) x5: test override builders now use dict literals.
- BLE001 (blind except) x4: targeted noqa with reason for deliberate catch-alls in the SV parser (unresolvable dim eval, unparseable net type, unreadable connection expr, per-file parse skip).
- S110 (try-except-pass) x2: paired with the BLE001 noqa + reason on the two best-effort SV-parser swallows.
- RUF012 (mutable class default) x2: false positive on pydantic `TileInstance` fields (pydantic deep-copies defaults per instance) - targeted noqa.
- PERF102 (dict iteration) x2: switched to `.values()` where keys were unused.
- SIM102 (collapsible if) x1: merged nested `if` in the procedural-block parser.

`ruff check` and `ruff format --check` pass clean. Full suite: 354 passed, 1 skipped.