### PR TITLE
Thread a platform wire id into the generated shell identity

### DIFF
--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -218,6 +218,11 @@ class PlatformDefinition(BaseModel):
     constraints: tuple[str, ...] = ()
     constraints_xdc: str = ""
     lane_placements: tuple[tuple[int, str], ...] = ()
+    # the platform's on-wire identity word (1–4 ASCII bytes) advertised in the
+    # PLATFORM_ID register: the shell generators encode it into the identity
+    # block so first-power reads back the right platform. dpv1 = "DPV1"
+    # (the default), dpv2 overrides with its own.
+    platform_id: str = "DPV1"
     program_method: str = "jtag"
     # the flash device's boot bus width when the board self-configures from
     # SPI (e.g. 4 for an SPIx4 part): a raw-bit JTAG `-f` write to such a
@@ -241,6 +246,20 @@ class PlatformDefinition(BaseModel):
     def _valid_program_method(cls, value: str) -> str:
         if value not in ("jtag", "flash"):
             raise ValueError(f"program_method must be 'jtag' or 'flash', got {value!r}")
+        return value
+
+    @field_validator("platform_id")
+    @classmethod
+    def _valid_platform_id(cls, value: str) -> str:
+        # 1–4 ASCII bytes: it must fit a single 32-bit PLATFORM_ID word (the
+        # same rule dau-core's encoder enforces; checked here without importing
+        # the private core, per this module's public/private wall)
+        try:
+            encoded = value.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ValueError(f"platform_id must be ASCII, got {value!r}") from exc
+        if not 1 <= len(encoded) <= 4:
+            raise ValueError(f"platform_id must be 1 to 4 ASCII bytes, got {value!r}")
         return value
 
     @field_validator("job_clock_mhz")

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -353,6 +353,7 @@ def _identity_registers_instance_sv() -> str:
     block that only knows OPERATOR_BITMAP rejects the parameter override
     at elaboration."""
     return """    dau_identity_registers #(
+        .PLATFORM_ID(PLATFORM_ID),
         .OPERATOR_BITMAP(OPERATOR_BITMAP),
         .LANE_COUNT(LANE_COUNT),
         .HOST_OPCODE_BITMAP(HOST_OPCODE_BITMAP),
@@ -963,6 +964,7 @@ def generate_scan_composition_top_sv(
     *,
     sources: Sequence[Path | str] | None = None,
     generated_by: str = _DEFAULT_GENERATED_BY,
+    platform_id: str = "DPV1",
 ) -> str:
     """Walk a ``ScanComposition``: one AXI burst reader scans the input
     window once and fans the row stream to the composition's lanes — each
@@ -980,6 +982,13 @@ def generate_scan_composition_top_sv(
     _validate_composition_shape(composition)  # model_copy skips model_post_init
     if sources is not None:
         _validate_against_sources(composition, sources)
+    # the on-wire platform identity word, encoded little-endian into a single
+    # 32-bit PLATFORM_ID parameter (inline so this public generator stays free
+    # of the private core's encoder)
+    platform_id_bytes = platform_id.encode("ascii")
+    if not 1 <= len(platform_id_bytes) <= 4:
+        raise ValueError(f"platform_id must be 1 to 4 ASCII bytes, got {platform_id!r}")
+    platform_id_u32 = int.from_bytes(platform_id_bytes.ljust(4, b"\x00"), "little")
     regs = composition.registers
     addr_width = composition.addr_width
     burst_beats = composition.burst_beats
@@ -1092,6 +1101,7 @@ def generate_scan_composition_top_sv(
 // lane(s) behind the DAU stream-job register contract with the NoC lane
 // register block. Plain-Verilog top (BD module references require it).
 module {module_name} #(
+    parameter [31:0] PLATFORM_ID = 32'h{platform_id_u32:08X},
     parameter [31:0] OPERATOR_BITMAP = 32'h{composition.operator_bitmap:08X},
     parameter [31:0] LANE_COUNT = 32'd{num_lanes},
     parameter [31:0] HOST_OPCODE_BITMAP = 32'h{composition.host_opcode_bitmap:08X},

--- a/dau_build/tests/fixtures/scan_composition/bar_noc_4.v
+++ b/dau_build/tests/fixtures/scan_composition/bar_noc_4.v
@@ -5,6 +5,7 @@
 // lane(s) behind the DAU stream-job register contract with the NoC lane
 // register block. Plain-Verilog top (BD module references require it).
 module dau_mm_bar_noc_job #(
+    parameter [31:0] PLATFORM_ID = 32'h31565044,
     parameter [31:0] OPERATOR_BITMAP = 32'h00000000,
     parameter [31:0] LANE_COUNT = 32'd4,
     parameter [31:0] HOST_OPCODE_BITMAP = 32'h00000000,
@@ -370,6 +371,7 @@ module dau_mm_bar_noc_job #(
     end
 
     dau_identity_registers #(
+        .PLATFORM_ID(PLATFORM_ID),
         .OPERATOR_BITMAP(OPERATOR_BITMAP),
         .LANE_COUNT(LANE_COUNT),
         .HOST_OPCODE_BITMAP(HOST_OPCODE_BITMAP),

--- a/dau_build/tests/fixtures/scan_composition/sorted_scan.v
+++ b/dau_build/tests/fixtures/scan_composition/sorted_scan.v
@@ -5,6 +5,7 @@
 // lane(s) behind the DAU stream-job register contract with the NoC lane
 // register block. Plain-Verilog top (BD module references require it).
 module dau_mm_sorted_scan_job #(
+    parameter [31:0] PLATFORM_ID = 32'h31565044,
     parameter [31:0] OPERATOR_BITMAP = 32'h00000000,
     parameter [31:0] LANE_COUNT = 32'd4,
     parameter [31:0] HOST_OPCODE_BITMAP = 32'h00000000,
@@ -374,6 +375,7 @@ module dau_mm_sorted_scan_job #(
     end
 
     dau_identity_registers #(
+        .PLATFORM_ID(PLATFORM_ID),
         .OPERATOR_BITMAP(OPERATOR_BITMAP),
         .LANE_COUNT(LANE_COUNT),
         .HOST_OPCODE_BITMAP(HOST_OPCODE_BITMAP),

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -64,6 +64,20 @@ def test_sorted_scan_top_matches_golden() -> None:
     assert generate_scan_composition_top_sv(_sorted_scan_composition()) == (_FIXTURES / "sorted_scan.v").read_text()
 
 
+def test_platform_id_threads_into_the_identity_parameter() -> None:
+    """The platform's wire id encodes little-endian into the top's PLATFORM_ID
+    parameter and overrides the identity block; the default is DPV1."""
+    default = generate_scan_composition_top_sv(_bar_noc_composition())
+    assert "parameter [31:0] PLATFORM_ID = 32'h31565044," in default  # "DPV1"
+    assert ".PLATFORM_ID(PLATFORM_ID)," in default
+
+    dpv2 = generate_scan_composition_top_sv(_bar_noc_composition(), platform_id="DPV2")
+    assert "parameter [31:0] PLATFORM_ID = 32'h32565044," in dpv2  # "DPV2"
+
+    with pytest.raises(ValueError, match="1 to 4 ASCII bytes"):
+        generate_scan_composition_top_sv(_bar_noc_composition(), platform_id="TOOLONG")
+
+
 def test_capability_words_are_caller_data_and_default_to_unadvertised() -> None:
     """The identity block advertises exactly what the composer computed:
     the bitmaps default to zero (never a static advertisement), the lane


### PR DESCRIPTION
PlatformDefinition gains a platform_id (1-4 ASCII bytes, default DPV1) and the scan-composition walker emits it as the top's PLATFORM_ID parameter plus an identity-block override, so a platform's own wire id reaches the PLATFORM_ID register at first power. The two top goldens gain the PLATFORM_ID param (32'h31565044 = DPV1); the sim generator has no identity block and is unchanged.

Groundwork for dpv2 advertising its own DPV2 id.