### PR TITLE
Add platform width tiers and lane envelope helpers

### DIFF
--- a/dau_build/config/platform/platforms/dau/dpv1.yaml
+++ b/dau_build/config/platform/platforms/dau/dpv1.yaml
@@ -12,6 +12,9 @@ part: xc7a200tfbg484-2
 program_method: jtag
 # S25FL256S boots SPIx4: persistent writes must use the vivado cfgmem path
 spi_boot_buswidth: 4
+# catalog width tiers: the DDR MIG UI is 128-bit on this board, so 64
+# (two-beat framing) and 128 (proven wide front) are the legal builds
+width_tiers: [64, 128]
 # lane index -> GTPE2 channel site: the reversed lane-to-GT-channel mapping
 # the dpv1 board requires, applied as a pre-opt_design implementation hook
 # (XDC-time LOCs conflict with the XDMA IP's internal BEL/LOC constraints)

--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -111,13 +111,12 @@ class MmDdrJobShellRequest(BaseModel):
     jobs: int = 12
 
     @model_validator(mode="after")
-    def _width_within_platform_tiers(self) -> "MmDdrJobShellRequest":
+    def _width_within_platform_tiers(self) -> MmDdrJobShellRequest:
         # the catalog gate at the source: a width outside the platform's
         # tier list never reaches tcl generation
         if self.data_width not in self.platform.width_tiers:
             raise ValueError(
-                f"data_width {self.data_width} is not a width tier of platform "
-                f"{self.platform.name!r} (width_tiers={list(self.platform.width_tiers)})"
+                f"data_width {self.data_width} is not a width tier of platform {self.platform.name!r} (width_tiers={list(self.platform.width_tiers)})"
             )
         return self
 
@@ -392,6 +391,9 @@ def mm_ddr_job_shell_project_tcl(request: MmDdrJobShellRequest) -> str:
     ui_clk domain; resets follow the proven wiring (sys_rst and aresetn
     tied high, calibration status on LED_A4, XADC temperature into
     device_temp_i)."""
+    # re-run the tier gate here: model_copy(update=) skips validators, so a
+    # copied request could otherwise carry a width the platform refuses
+    request._width_within_platform_tiers()
     preamble = _project_preamble_tcl(
         request,
         banner=(

--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from ccflow import BaseModel
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from dau_build.platforms import PlatformDefinition
 
@@ -109,6 +109,17 @@ class MmDdrJobShellRequest(BaseModel):
     # smartconnect slaves. Mirrors the composition's data_width.
     data_width: int = 64
     jobs: int = 12
+
+    @model_validator(mode="after")
+    def _width_within_platform_tiers(self) -> "MmDdrJobShellRequest":
+        # the catalog gate at the source: a width outside the platform's
+        # tier list never reaches tcl generation
+        if self.data_width not in self.platform.width_tiers:
+            raise ValueError(
+                f"data_width {self.data_width} is not a width tier of platform "
+                f"{self.platform.name!r} (width_tiers={list(self.platform.width_tiers)})"
+            )
+        return self
 
     @property
     def resolved_part(self) -> str:

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -231,6 +231,12 @@ class PlatformDefinition(BaseModel):
     # is supported: the cfgmem generator (flash.tcl / vivado_build_tcl)
     # writes SPIx4; another width would need its own cfgmem-generation path.
     spi_boot_buswidth: Literal[4] | None = None
+    # the platform's supported memory-read width tiers (the precompiled
+    # bitstream catalog dimension): each entry is a legal `width=` build
+    # selection on this board. Bounded by the memory system's AXI width and
+    # by what has closed timing on the part — a build request outside the
+    # list is refused before any tool runs.
+    width_tiers: tuple[int, ...] = (64,)
     job_clock_mhz: int | None = None
     placeholders: tuple[str, ...] = ()
 
@@ -246,6 +252,18 @@ class PlatformDefinition(BaseModel):
     def _valid_program_method(cls, value: str) -> str:
         if value not in ("jtag", "flash"):
             raise ValueError(f"program_method must be 'jtag' or 'flash', got {value!r}")
+        return value
+
+    @field_validator("width_tiers")
+    @classmethod
+    def _valid_width_tiers(cls, value: tuple[int, ...]) -> tuple[int, ...]:
+        if not value:
+            raise ValueError("width_tiers must name at least one tier")
+        bad = [tier for tier in value if tier not in (64, 128, 256, 512)]
+        if bad:
+            raise ValueError(f"width_tiers entries must be 64/128/256/512, got {bad}")
+        if len(set(value)) != len(value):
+            raise ValueError(f"width_tiers has duplicates: {value}")
         return value
 
     @field_validator("platform_id")
@@ -315,6 +333,43 @@ def fits(used: ResourceUse, platform: PlatformDefinition) -> FitReport:
     headroom = {key: budget_by[key] - used_by[key] for key in budget_by}
     utilization = {key: used_by[key] / budget_by[key] for key in budget_by}
     return FitReport(fits=all(value >= 0 for value in headroom.values()), headroom=headroom, utilization=utilization)
+
+
+def min_lanes_for_full_rate(data_width: int) -> int:
+    """The width-tier sizing law: a W-bit front delivers W/128 quad rows per
+    beat and each lane drains one row per two cycles, so a catalog image
+    sized to the front's delivered bandwidth needs ``lanes >= 2 * (W/128)``
+    (64-bit two-beat framing is half a row per cycle — one lane matches it).
+    Today's wide dispatcher serializes to one row per cycle, which two lanes
+    already saturate; the law sizes for the front's full rate so precompiled
+    images do not under-lane when parallel dispatch lands."""
+    if data_width not in (64, 128, 256, 512):
+        raise ValueError(f"data_width must be 64/128/256/512, got {data_width}")
+    return max(1, 2 * (data_width // 128))
+
+
+def max_lanes(lane_resources: ResourceUse, platform: PlatformDefinition, *, overhead: ResourceUse | None = None) -> int:
+    """The envelope's lane ceiling: how many copies of one lane's resource
+    footprint fit the platform budget after the composition's shared
+    overhead (front/dispatcher/reader — pass the non-lane remainder as
+    ``overhead``). Returns 0 when even the overhead alone does not fit —
+    the caller decides whether that is a refusal or a smaller design.
+    (Lane count is also a timing-closure knob — the 2026-07-19 lesson —
+    so the pricing layer treats this as a CEILING, not a target.)"""
+    budget = platform.budget
+    remaining = {
+        "lut": budget.lut - (overhead.lut if overhead else 0),
+        "ff": budget.ff - (overhead.ff if overhead else 0),
+        "bram36": budget.bram36 - (overhead.bram36 if overhead else 0.0),
+        "dsp": budget.dsp - (overhead.dsp if overhead else 0),
+    }
+    if any(value < 0 for value in remaining.values()):
+        return 0
+    per_lane = {"lut": lane_resources.lut, "ff": lane_resources.ff, "bram36": lane_resources.bram36, "dsp": lane_resources.dsp}
+    ceilings = [int(remaining[key] // per_lane[key]) for key in per_lane if per_lane[key] > 0]
+    if not ceilings:
+        raise ValueError("lane_resources must use at least one resource")
+    return min(ceilings)
 
 
 def dpv1_platform() -> PlatformDefinition:

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -371,10 +371,10 @@ def max_lanes(lane_resources: ResourceUse, platform: PlatformDefinition, *, over
         if use is not None and (use.lut < 0 or use.ff < 0 or use.bram36 < 0 or use.dsp < 0):
             raise ValueError(f"{label} components must be nonnegative")
     remaining = {
-        "lut": budget.lut - (overhead.lut if overhead else 0),
-        "ff": budget.ff - (overhead.ff if overhead else 0),
-        "bram36": _halves(budget.bram36, "budget") - (_halves(overhead.bram36, "overhead") if overhead else 0),
-        "dsp": budget.dsp - (overhead.dsp if overhead else 0),
+        "lut": budget.lut - (overhead.lut if overhead is not None else 0),
+        "ff": budget.ff - (overhead.ff if overhead is not None else 0),
+        "bram36": _halves(budget.bram36, "budget") - (_halves(overhead.bram36, "overhead") if overhead is not None else 0),
+        "dsp": budget.dsp - (overhead.dsp if overhead is not None else 0),
     }
     if any(value < 0 for value in remaining.values()):
         return 0

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -357,19 +357,37 @@ def max_lanes(lane_resources: ResourceUse, platform: PlatformDefinition, *, over
     (Lane count is also a timing-closure knob — the 2026-07-19 lesson —
     so the pricing layer treats this as a CEILING, not a target.)"""
     budget = platform.budget
+
+    def _halves(value: float, label: str) -> int:
+        # BRAM counts in exact half-BRAM36 (RAMB18) units: float floor
+        # division undercounts (335 // 0.1 == 3349.0) and real placements
+        # are half-granular anyway
+        halves = round(value * 2)
+        if abs(value * 2 - halves) > 1e-9:
+            raise ValueError(f"{label} bram36 must be half-BRAM granular, got {value}")
+        return halves
+
+    for label, use in (("lane_resources", lane_resources), ("overhead", overhead)):
+        if use is not None and (use.lut < 0 or use.ff < 0 or use.bram36 < 0 or use.dsp < 0):
+            raise ValueError(f"{label} components must be nonnegative")
     remaining = {
         "lut": budget.lut - (overhead.lut if overhead else 0),
         "ff": budget.ff - (overhead.ff if overhead else 0),
-        "bram36": budget.bram36 - (overhead.bram36 if overhead else 0.0),
+        "bram36": _halves(budget.bram36, "budget") - (_halves(overhead.bram36, "overhead") if overhead else 0),
         "dsp": budget.dsp - (overhead.dsp if overhead else 0),
     }
     if any(value < 0 for value in remaining.values()):
         return 0
-    per_lane = {"lut": lane_resources.lut, "ff": lane_resources.ff, "bram36": lane_resources.bram36, "dsp": lane_resources.dsp}
-    ceilings = [int(remaining[key] // per_lane[key]) for key in per_lane if per_lane[key] > 0]
+    per_lane = {
+        "lut": lane_resources.lut,
+        "ff": lane_resources.ff,
+        "bram36": _halves(lane_resources.bram36, "lane_resources"),
+        "dsp": lane_resources.dsp,
+    }
+    ceilings = [remaining[key] // per_lane[key] for key in per_lane if per_lane[key] > 0]
     if not ceilings:
         raise ValueError("lane_resources must use at least one resource")
-    return min(ceilings)
+    return int(min(ceilings))
 
 
 def dpv1_platform() -> PlatformDefinition:

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -31,6 +31,30 @@ def _request(tmp_path: Path) -> MmJobShellRequest:
     )
 
 
+def _wide_tier_platform():
+    from dau_build.platforms import dpv1_platform
+
+    # a wide-tier board stand-in: dpv1 facts with the full catalog unlocked
+    return dpv1_platform().model_copy(update={"width_tiers": (64, 128, 256, 512)})
+
+
+def test_request_refuses_a_width_outside_the_platform_tiers(tmp_path) -> None:
+    import pytest as _pytest
+    from pydantic import ValidationError
+
+    prj = tmp_path / "mig.prj"
+    prj.write_text('<Project NoOfControllers="1"></Project>\n')
+    with _pytest.raises(ValidationError, match="not a width tier of platform 'dpv1'"):
+        MmDdrJobShellRequest(
+            output_root=tmp_path,
+            hdl_sources=(),
+            generated_sources=(("top.v", "module top; endmodule\n"),),
+            top_module="top",
+            mig_prj=prj,
+            data_width=512,
+        )
+
+
 def test_personality_mirrors_the_proven_shell() -> None:
     # the hardware rules: 64-bit prefetchable BARs, 128K KB-scale AXI-Lite, QPLL1
     assert dpv1_xdma_personality().params["axil_master_64bit_en"] == "true"
@@ -357,6 +381,7 @@ def test_wide_data_width_ddr_tcl_wires_split_masters(tmp_path) -> None:
         generated_sources=(("top.v", "module top; endmodule\n"),),
         top_module="top",
         mig_prj=prj,
+        platform=_wide_tier_platform(),
         data_width=512,
     )
     text = mm_ddr_job_shell_project_tcl(request)

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -38,6 +38,24 @@ def _wide_tier_platform():
     return dpv1_platform().model_copy(update={"width_tiers": (64, 128, 256, 512)})
 
 
+def test_generator_refuses_a_copied_request_outside_the_tiers(tmp_path) -> None:
+    # model_copy(update=) skips validators — the tcl generator re-runs the
+    # tier gate so a copied request cannot slip a refused width through
+    import pytest as _pytest
+
+    prj = tmp_path / "mig.prj"
+    prj.write_text('<Project NoOfControllers="1"></Project>\n')
+    request = MmDdrJobShellRequest(
+        output_root=tmp_path,
+        hdl_sources=(),
+        generated_sources=(("top.v", "module top; endmodule\n"),),
+        top_module="top",
+        mig_prj=prj,
+    )
+    with _pytest.raises(ValueError, match="not a width tier"):
+        mm_ddr_job_shell_project_tcl(request.model_copy(update={"data_width": 512}))
+
+
 def test_request_refuses_a_width_outside_the_platform_tiers(tmp_path) -> None:
     import pytest as _pytest
     from pydantic import ValidationError

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -14,6 +14,8 @@ from dau_build.platforms import (
     XdmaPersonality,
     dpv1_platform,
     fits,
+    max_lanes,
+    min_lanes_for_full_rate,
     require_measured,
 )
 
@@ -111,6 +113,53 @@ def test_fits_exactly_at_budget_is_ok() -> None:
     assert report.fits
     assert all(value == 0 for value in report.headroom.values())
     assert all(value == pytest.approx(1.0) for value in report.utilization.values())
+
+
+def test_width_tiers_default_and_dpv1_config() -> None:
+    # the model default is the universal 64-bit tier; dpv1's config names
+    # the two tiers its 128-bit MIG UI supports
+    assert PlatformDefinition.model_fields["width_tiers"].default == (64,)
+    assert dpv1_platform().width_tiers == (64, 128)
+
+
+def test_width_tiers_validation() -> None:
+    with pytest.raises(ValidationError, match="at least one tier"):
+        _dpv1_with(width_tiers=())
+    with pytest.raises(ValidationError, match="64/128/256/512"):
+        _dpv1_with(width_tiers=(64, 96))
+    with pytest.raises(ValidationError, match="duplicates"):
+        _dpv1_with(width_tiers=(64, 64))
+    assert _dpv1_with(width_tiers=(64, 128, 256, 512)).width_tiers == (64, 128, 256, 512)
+
+
+def test_min_lanes_for_full_rate_follows_the_sizing_law() -> None:
+    assert min_lanes_for_full_rate(64) == 1
+    assert min_lanes_for_full_rate(128) == 2
+    assert min_lanes_for_full_rate(256) == 4
+    assert min_lanes_for_full_rate(512) == 8
+    with pytest.raises(ValueError, match="64/128/256/512"):
+        min_lanes_for_full_rate(96)
+
+
+def test_max_lanes_is_the_budget_ceiling() -> None:
+    platform = dpv1_platform()  # budget lut=108800
+    lane = _Use(lut=1000, ff=800, bram36=0.5, dsp=1)
+    # no overhead: lut allows 108, ff allows more, dsp allows 740 -> min governs
+    assert max_lanes(lane, platform) == min(
+        platform.budget.lut // 1000,
+        platform.budget.ff // 800,
+        int(platform.budget.bram36 // 0.5),
+        platform.budget.dsp // 1,
+    )
+    # overhead shrinks the pool
+    overhead = _Use(lut=platform.budget.lut - 2500, ff=0, bram36=0.0, dsp=0)
+    assert max_lanes(lane, platform, overhead=overhead) == 2
+    # overhead alone over budget -> 0
+    too_big = _Use(lut=platform.budget.lut + 1, ff=0, bram36=0.0, dsp=0)
+    assert max_lanes(lane, platform, overhead=too_big) == 0
+    # a zero-cost lane is nonsense input, refused loudly
+    with pytest.raises(ValueError, match="at least one resource"):
+        max_lanes(_Use(lut=0, ff=0, bram36=0.0, dsp=0), platform)
 
 
 def test_dpv1_platform_is_the_single_source_for_the_shell() -> None:

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -160,6 +160,25 @@ def test_max_lanes_is_the_budget_ceiling() -> None:
     # a zero-cost lane is nonsense input, refused loudly
     with pytest.raises(ValueError, match="at least one resource"):
         max_lanes(_Use(lut=0, ff=0, bram36=0.0, dsp=0), platform)
+    # negative components (malformed envelopes) refuse instead of
+    # inflating the ceiling
+    with pytest.raises(ValueError, match="nonnegative"):
+        max_lanes(_Use(lut=-1, ff=0, bram36=0.0, dsp=0), platform)
+    with pytest.raises(ValueError, match="nonnegative"):
+        max_lanes(lane, platform, overhead=_Use(lut=-5000, ff=0, bram36=0.0, dsp=0))
+
+
+def test_max_lanes_bram_arithmetic_is_exact() -> None:
+    # half-BRAM units, not float floor division: 365 BRAM36 holds exactly
+    # 730 half-BRAM lanes (335 // 0.1 == 3349.0 is the float trap)
+    platform = dpv1_platform()
+    lane = _Use(lut=1, ff=1, bram36=0.5, dsp=0)
+    assert max_lanes(lane, platform) == min(
+        platform.budget.lut, platform.budget.ff, round(platform.budget.bram36 * 2)
+    )
+    # non-half-granular BRAM is not a real placement
+    with pytest.raises(ValueError, match="half-BRAM granular"):
+        max_lanes(_Use(lut=1, ff=1, bram36=0.3, dsp=0), platform)
 
 
 def test_dpv1_platform_is_the_single_source_for_the_shell() -> None:

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -173,9 +173,7 @@ def test_max_lanes_bram_arithmetic_is_exact() -> None:
     # 730 half-BRAM lanes (335 // 0.1 == 3349.0 is the float trap)
     platform = dpv1_platform()
     lane = _Use(lut=1, ff=1, bram36=0.5, dsp=0)
-    assert max_lanes(lane, platform) == min(
-        platform.budget.lut, platform.budget.ff, round(platform.budget.bram36 * 2)
-    )
+    assert max_lanes(lane, platform) == min(platform.budget.lut, platform.budget.ff, round(platform.budget.bram36 * 2))
     # non-half-granular BRAM is not a real placement
     with pytest.raises(ValueError, match="half-BRAM granular"):
         max_lanes(_Use(lut=1, ff=1, bram36=0.3, dsp=0), platform)


### PR DESCRIPTION
Platforms now declare their supported memory-read width tiers (`width_tiers`, default `(64,)`) — the precompiled-bitstream catalog dimension. dpv1's config names `[64, 128]` (its MIG UI is 128-bit). Entries validate against the legal tier set, non-empty, no duplicates.

Two envelope helpers beside `fits()`:
- `min_lanes_for_full_rate(data_width)` — the sizing law `lanes >= 2*(W/128)`: sized to the front's delivered bandwidth so precompiled images do not under-lane when parallel dispatch lands (today's serializer caps at one row/cycle, which two lanes saturate — noted in the docstring).
- `max_lanes(lane_resources, platform, overhead=)` — the budget ceiling for lane replication after the composition's shared overhead; 0 when the overhead alone does not fit, loud refusal on a zero-cost lane.

Suite: 362 passed, 1 skipped (the `test_counter` verilator failure is the pre-existing local toolchain issue, fails identically on main).