### PR TITLE
Wire the wide lane: reader beats straight into the wide chain

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -116,7 +116,11 @@ class ScanComposition(BaseModel):
     still sees the clean 32-bit key). Its config carries the four field
     descriptors (``cfg_field{0..3}_{offset,width,signed}``) and
     ``cfg_bypass``. Absent (``None``), the top emits exactly as before —
-    every param-less golden stays byte-identical."""
+    every param-less golden stays byte-identical.
+
+    ``wide_lane`` selects the registry-legalized single-lane shape whose
+    stages consume the burst reader's whole wide beat directly. The private
+    bridge sets this flag; this public generator cannot consult its registry."""
 
     name: str
     module_name: str
@@ -132,6 +136,7 @@ class ScanComposition(BaseModel):
     # the narrow write M_AXI_W (the record writers stay 64-bit) so a wide DDR
     # read never forces narrow writes on a wide bus.
     data_width: int = 64
+    wide_lane: bool = False
     # capability words the identity block advertises (register map 0.2).
     # These are caller-computed data — the walker never guesses them: the
     # bitmaps default to zero ("advertise nothing") so a composition only
@@ -154,6 +159,15 @@ def _validate_composition_shape(composition: ScanComposition) -> None:
     widths disagree."""
     if not composition.lanes:
         raise ScanCompositionError("a scan composition needs at least one lane")
+    if composition.wide_lane:
+        if len(composition.lanes) != 1:
+            raise ScanCompositionError("a wide_lane scan composition needs exactly one lane")
+        if composition.partitioner is not None:
+            raise ScanCompositionError("a wide_lane scan composition cannot carry a shared partitioner")
+        if composition.front_unpack is not None:
+            raise ScanCompositionError("a wide_lane scan composition cannot carry a front_unpack")
+        if composition.lanes[0].partition is not None:
+            raise ScanCompositionError("a wide_lane scan composition cannot carry a lane partition")
     if composition.partitioner is not None:
         for lane in composition.lanes:
             if lane.partition is not None:
@@ -168,6 +182,8 @@ def _validate_composition_shape(composition: ScanComposition) -> None:
     data_width = composition.data_width
     if data_width not in _WIDTHS:
         raise ScanCompositionError(f"data_width must be one of {_WIDTHS}, got {data_width}")
+    if composition.wide_lane and data_width not in (128, 256, 512):
+        raise ScanCompositionError(f"wide_lane data_width must be one of (128, 256, 512), got {data_width}")
     front_width = composition.front_unpack.params.get("OUT_WIDTH", 64) if composition.front_unpack is not None else 64
     fanout_width = composition.partitioner.params.get("IN_WIDTH", 64) if composition.partitioner is not None else 64
     if composition.front_unpack is not None:
@@ -185,7 +201,7 @@ def _validate_composition_shape(composition: ScanComposition) -> None:
         feed_width = data_width
     if fanout_width not in _WIDTHS:
         raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be one of {_WIDTHS}, got {fanout_width}")
-    if feed_width > 64:
+    if feed_width > 64 and not composition.wide_lane:
         if composition.partitioner is None:
             raise ScanCompositionError(
                 f"a {feed_width}-bit feed stream needs a shared partitioner/dispatcher accepting IN_WIDTH={feed_width}; "
@@ -493,6 +509,16 @@ def _lane_front_sv(composition: ScanComposition, i: int, *, clk: str = "s_axi_ac
     stream, tap the broadcast directly (filterless lane), or instantiate the
     lane's partition filter off the broadcast."""
     lane = composition.lanes[i]
+    if composition.wide_lane:
+        return f"""    assign filt_out_valid_{i} = scan_valid;
+    assign scan_ready = filt_out_ready_{i};
+    assign filt_out_data_{i} = scan_data;
+    assign filt_out_last_{i} = scan_last;
+    assign filt_status_valid_{i} = 1'b0;
+    assign filt_status_ready_{i} = 1'b0;
+    assign filt_status_error_{i} = 1'b0;
+    assign filt_status_error_code_{i} = 8'd0;
+"""
     if composition.partitioner is not None:
         return f"""    assign filt_out_valid_{i} = part_out_valid[{i}];
     assign part_out_ready[{i}] = filt_out_ready_{i};
@@ -539,7 +565,7 @@ def _lane_status_glue_sv(composition: ScanComposition, i: int) -> str:
     ready fires only when nothing upstream of it is pending)."""
     lane = composition.lanes[i]
     if lane.chain:
-        front_filtered = lane.partition is not None or composition.partitioner is not None
+        front_filtered = not composition.wide_lane and (lane.partition is not None or composition.partitioner is not None)
         stems = (["filt"] if front_filtered else []) + [f"chain{j}" for j in range(len(lane.chain))]
         valids = " || ".join(f"{stem}_status_valid_{i}" for stem in stems)
         error_mux = f"tile_status_error_{i}"
@@ -577,10 +603,11 @@ def _lane_status_glue_sv(composition: ScanComposition, i: int) -> str:
 def _lane_chain_wire_decls_sv(composition: ScanComposition, i: int) -> str:
     """Per-chain-stage wire declarations for lane ``i`` (empty for a
     chainless lane, keeping the chainless emission byte-identical)."""
+    stream_width = composition.data_width if composition.wide_lane else 64
     return "".join(
         f"""    wire chain{j}_out_valid_{i};
     wire chain{j}_out_ready_{i};
-    wire [63:0] chain{j}_out_data_{i};
+    wire [{stream_width - 1}:0] chain{j}_out_data_{i};
     wire chain{j}_out_last_{i};
     wire chain{j}_status_valid_{i};
     wire chain{j}_status_ready_{i};
@@ -595,10 +622,11 @@ def _lane_wire_decls_sv(composition: ScanComposition) -> str:
     """Per-lane internal wire declarations (lane front, chain stages, tile,
     status glue, writer, and the latched count register)."""
     addr_width = composition.addr_width
+    stream_width = composition.data_width if composition.wide_lane else 64
     return "\n".join(
         f"""    wire filt_out_valid_{i};
     wire filt_out_ready_{i};
-    wire [63:0] filt_out_data_{i};
+    wire [{stream_width - 1}:0] filt_out_data_{i};
     wire filt_out_last_{i};
     wire filt_status_valid_{i};
     wire filt_status_ready_{i};
@@ -1075,7 +1103,7 @@ def generate_scan_composition_top_sv(
     lane_flat_assigns = _lane_flat_assigns_sv(composition)
     lane_instances = _lane_units_sv(composition, clk="s_axi_aclk", writer_rst="!s_axi_aresetn")
     stream_prefix = "feed" if composition.front_unpack is not None else "scan"
-    fanout_wire_decls, fanout_instance = _fanout_sv(composition, clk="s_axi_aclk", stream_prefix=stream_prefix)
+    fanout_wire_decls, fanout_instance = ("", "") if composition.wide_lane else _fanout_sv(composition, clk="s_axi_aclk", stream_prefix=stream_prefix)
     front_unpack_wire_decls = _front_unpack_wire_decls_sv(composition)
     front_unpack_instance = _front_unpack_instance_sv(composition, clk="s_axi_aclk")
     front_unpack_error_branch = _front_unpack_error_branch_sv(composition, error="job_error", error_code="job_error_code")
@@ -1386,7 +1414,7 @@ def generate_scan_composition_sim_sv(
         for i in lanes
     )
     stream_prefix = "feed" if composition.front_unpack is not None else "scan"
-    fanout_wire_decls, fanout_instance = _fanout_sv(composition, clk="clk", stream_prefix=stream_prefix)
+    fanout_wire_decls, fanout_instance = ("", "") if composition.wide_lane else _fanout_sv(composition, clk="clk", stream_prefix=stream_prefix)
     front_unpack_wire_decls = _front_unpack_wire_decls_sv(composition)
     front_unpack_instance = _front_unpack_instance_sv(composition, clk="clk")
     front_unpack_error_branch = _front_unpack_error_branch_sv(composition, error="error", error_code="error_code")

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -802,6 +802,90 @@ def test_wide_data_width_splits_the_m_axi_into_wide_read_and_narrow_write() -> N
     assert "input wire [63:0] m_axi_rdata," not in sv
 
 
+def _wide_lane_composition() -> ScanComposition:
+    return ScanComposition(
+        name="wide-lane",
+        module_name="dau_mm_wide_lane_job",
+        lanes=(
+            LaneTile(
+                module="dau_int32_wide_row_projection",
+                params={"SLOTS": 4},
+                count_port="record_count",
+                chain=(
+                    TileInstance(module="dau_int32_wide_row_predicate_filter", params={"SLOTS": 4}),
+                    TileInstance(module="dau_int32_wide_row_transform", params={"SLOTS": 4}),
+                ),
+            ),
+        ),
+        data_width=512,
+        wide_lane=True,
+    )
+
+
+def test_wide_lane_taps_the_wide_reader_directly() -> None:
+    """A wide lane consumes whole reader beats through every chain stage,
+    then emits standard 64-bit records to the unchanged writer."""
+    sv = generate_scan_composition_top_sv(_wide_lane_composition())
+
+    assert "    assign filt_out_valid_0 = scan_valid;\n" in sv
+    assert "    assign scan_ready = filt_out_ready_0;\n" in sv
+    assert "    assign filt_out_data_0 = scan_data;\n" in sv
+    assert "    assign filt_out_last_0 = scan_last;\n" in sv
+    assert "    assign filt_status_valid_0 = 1'b0;\n" in sv
+    assert "    assign filt_status_ready_0 = 1'b0;\n" in sv
+    assert "    assign filt_status_error_0 = 1'b0;\n" in sv
+    assert "    assign filt_status_error_code_0 = 8'd0;\n" in sv
+    assert "dau_stream_broadcast" not in sv
+    assert " partitioner (" not in sv
+    assert "bcast_" not in sv
+    assert "part_out_" not in sv
+
+    assert "wire [511:0] filt_out_data_0;" in sv
+    assert "wire [511:0] chain0_out_data_0;" in sv
+    assert "wire [511:0] chain1_out_data_0;" in sv
+    assert "wire [63:0] tile_out_data_0;" in sv
+    assert "wire [63:0] wr_wdata_0;" in sv
+    assert sv.count(".SLOTS(4)") == 3
+
+    assert "M_AXI_R ARADDR" in sv and "M_AXI_W AWADDR" in sv
+    assert "input wire [511:0] m_axi_r_rdata" in sv
+    assert "output wire [63:0] m_axi_w_wdata" in sv
+    assert ".DATA_WIDTH(512)" in sv
+    assert "ASSOCIATED_BUSIF S_AXI:M_AXI_R:M_AXI_W" in sv
+    assert "wire length_ok = (input_length_bytes != 32'd0) && (input_length_bytes[5:0] == 6'd0);" in sv
+
+
+def test_wide_lane_requires_exactly_one_lane() -> None:
+    lane = LaneTile(module="dau_int32_wide_row_projection", count_port="record_count")
+    with pytest.raises(ValidationError, match="wide_lane.*exactly one lane"):
+        ScanComposition(name="bad", module_name="dau_bad", lanes=(lane, lane), data_width=512, wide_lane=True)
+
+
+def test_wide_lane_rejects_a_shared_partitioner() -> None:
+    composition = _wide_lane_composition().model_dump()
+    composition["partitioner"] = TileInstance(module="dau_int32_key_mask_dispatcher")
+    with pytest.raises(ValidationError, match="wide_lane.*shared partitioner"):
+        ScanComposition.model_validate(composition)
+
+
+def test_wide_lane_rejects_a_front_unpacker() -> None:
+    composition = _wide_lane_composition().model_dump()
+    composition["front_unpack"] = TileInstance(module="dau_int32_row_unpack")
+    with pytest.raises(ValidationError, match="wide_lane.*front_unpack"):
+        ScanComposition.model_validate(composition)
+
+
+def test_wide_lane_rejects_a_narrow_data_width() -> None:
+    with pytest.raises(ValidationError, match="wide_lane data_width.*128, 256, 512"):
+        ScanComposition(
+            name="bad",
+            module_name="dau_bad",
+            lanes=(LaneTile(module="dau_int32_wide_row_projection", count_port="record_count"),),
+            data_width=64,
+            wide_lane=True,
+        )
+
+
 def test_wide_data_width_needs_a_dispatcher_not_a_broadcast() -> None:
     """The broadcast shape is 64-bit only — a wide data_width with no shared
     partitioner is rejected (every lane would see every row)."""


### PR DESCRIPTION
`ScanComposition.wide_lane` selects the registry-legalized single-lane shape (dau-core#106): the burst reader's whole `data_width` beat wires directly into the lane's wide chain — no broadcast, no partitioner, no front unpacker instantiated — and the terminal's 64-bit record stream feeds the unchanged writer. Lane stream wires size to `data_width`; validation requires exactly one lane, no fan-out companions, and a 128/256/512 width. The private bridge sets the flag (this public generator cannot consult the registry).

Every existing emission is byte-identical (all golden fixtures untouched); the new tests pin the 512-bit wide-lane emission (direct scan tap, no `dau_stream_broadcast`, [511:0] lane wires, dual-master split intact, beat-aligned length gate) plus four refusals.

Suite: 415 passed (the `test_counter` verilator failure is the known local toolchain issue).