### PR TITLE
Add the fused-chain close-out protocol to the walker

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -583,6 +583,12 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
     silent = [j for j in range(len(lane.chain)) if j not in draining]
     stems = (["filt"] if front_filtered else []) + [f"chain{j}" for j in silent]
 
+    # a draining stage's status is consumed the cycle it appears, so an error
+    # missed here is gone for good: CAPTURE OUTRANKS the per-job clear. An
+    # error coinciding with job_start belongs to the job just ending and is
+    # carried into the new job's status rather than silently dropped — a loud
+    # failure on the next job beats a clean report over a corrupt one.
+    raising = " || ".join(f"(chain{j}_status_valid_{i} && chain{j}_status_error_{i})" for j in draining)
     lines = [
         f"    reg fused_err_{i};",
         f"    reg [7:0] fused_err_code_{i};",
@@ -590,17 +596,17 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
         "        if (!s_axi_aresetn) begin",
         f"            fused_err_{i} <= 1'b0;",
         f"            fused_err_code_{i} <= 8'd0;",
-        "        end else if (job_start) begin",
-        f"            fused_err_{i} <= 1'b0;",
-        f"            fused_err_code_{i} <= 8'd0;",
-        f"        end else if (!fused_err_{i}) begin",
+        f"        end else if (!fused_err_{i} && ({raising})) begin",
+        f"            fused_err_{i} <= 1'b1;",
     ]
     for index, j in enumerate(draining):
         keyword = "if" if index == 0 else "else if"
         lines.append(f"            {keyword} (chain{j}_status_valid_{i} && chain{j}_status_error_{i}) begin")
-        lines.append(f"                fused_err_{i} <= 1'b1;")
         lines.append(f"                fused_err_code_{i} <= chain{j}_status_error_code_{i};")
         lines.append("            end")
+    lines.append("        end else if (job_start) begin")
+    lines.append(f"            fused_err_{i} <= 1'b0;")
+    lines.append(f"            fused_err_code_{i} <= 8'd0;")
     lines.append("        end")
     lines.append("    end")
 

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -47,6 +47,15 @@ class TileInstance(BaseModel):
     module: str
     config: dict[str, str] = {}  # noqa: RUF012  # pydantic deep-copies field defaults per instance
     params: dict[str, int] = {}  # noqa: RUF012  # pydantic deep-copies field defaults per instance
+    # a CHAIN STAGE that emits a success close-out per batch (a terminal-shaped
+    # tile fused mid-lane: the as-of join, the grouped aggregator). The lane
+    # status mux allows exactly one close-out, so such a stage's status is
+    # DRAINED (accepted immediately) and only its ERRORS are latched into the
+    # lane status — the fused-chain protocol. False for the silent-on-success
+    # stages (filters, maps, key rewrites), which keep the byte-identical
+    # upstream-first mux. The private bridge sets this from the registry; this
+    # public generator cannot consult it.
+    closes_out: bool = False
 
 
 class LaneTile(TileInstance):
@@ -557,6 +566,71 @@ def _lane_front_sv(composition: ScanComposition, i: int, *, clk: str = "s_axi_ac
 """
 
 
+def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: list[int]) -> str:
+    """Status glue for a lane whose chain fuses terminal-shaped stages.
+
+    Each draining stage's status is accepted unconditionally (``ready`` tied
+    high), so its success close-out is consumed the cycle it appears and the
+    stage rearms for the next job — the lane still presents exactly ONE
+    close-out (the terminal's), which is what the record writer's done waits
+    on. A draining stage's ERROR is latched into a per-lane register and
+    overrides the lane status, so a fused-away failure is never silently
+    swallowed; the latch clears on the job-start pulse the register block
+    already drives (``job_start``), making the protocol multi-job safe.
+    Silent stages keep the ordinary upstream-first mux beneath the latch."""
+    lane = composition.lanes[i]
+    front_filtered = not composition.wide_lane and (lane.partition is not None or composition.partitioner is not None)
+    silent = [j for j in range(len(lane.chain)) if j not in draining]
+    stems = (["filt"] if front_filtered else []) + [f"chain{j}" for j in silent]
+
+    lines = [
+        f"    reg fused_err_{i};",
+        f"    reg [7:0] fused_err_code_{i};",
+        "    always @(posedge s_axi_aclk) begin",
+        "        if (!s_axi_aresetn) begin",
+        f"            fused_err_{i} <= 1'b0;",
+        f"            fused_err_code_{i} <= 8'd0;",
+        "        end else if (job_start) begin",
+        f"            fused_err_{i} <= 1'b0;",
+        f"            fused_err_code_{i} <= 8'd0;",
+        f"        end else if (!fused_err_{i}) begin",
+    ]
+    for index, j in enumerate(draining):
+        keyword = "if" if index == 0 else "else if"
+        lines.append(f"            {keyword} (chain{j}_status_valid_{i} && chain{j}_status_error_{i}) begin")
+        lines.append(f"                fused_err_{i} <= 1'b1;")
+        lines.append(f"                fused_err_code_{i} <= chain{j}_status_error_code_{i};")
+        lines.append("            end")
+    lines.append("        end")
+    lines.append("    end")
+
+    # the draining stages accept their own status immediately
+    for j in draining:
+        lines.append(f"    assign chain{j}_status_ready_{i} = 1'b1;")
+
+    # beneath the latch, the silent stages and the terminal keep the
+    # upstream-first mux (the pending-order rule the chain contract defines)
+    valids = " || ".join(f"{stem}_status_valid_{i}" for stem in stems)
+    base_valid = f"tile_status_valid_{i}" + (f" || {valids}" if stems else "")
+    error_mux = f"tile_status_error_{i}"
+    code_mux = f"tile_status_error_code_{i}"
+    for stem in reversed(stems):
+        error_mux = f"{stem}_status_valid_{i} ? {stem}_status_error_{i} : {error_mux}"
+        code_mux = f"{stem}_status_valid_{i} ? {stem}_status_error_code_{i} : {code_mux}"
+    lines.append(f"    assign unit_status_valid_{i} = fused_err_{i} || ({base_valid});")
+    lines.append(f"    assign unit_status_error_{i} = fused_err_{i} ? 1'b1 : ({error_mux});")
+    lines.append(f"    assign unit_status_error_code_{i} = fused_err_{i} ? fused_err_code_{i} : ({code_mux});")
+
+    upstream: list[str] = []
+    for stem in stems:
+        gate = "".join(f" && !{name}_status_valid_{i}" for name in upstream)
+        lines.append(f"    assign {stem}_status_ready_{i} = unit_status_ready_{i}{gate} && {stem}_status_valid_{i};")
+        upstream.append(stem)
+    gate = "".join(f" && !{name}_status_valid_{i}" for name in upstream)
+    lines.append(f"    assign tile_status_ready_{i} = unit_status_ready_{i}{gate};")
+    return "\n".join(lines) + "\n"
+
+
 def _lane_status_glue_sv(composition: ScanComposition, i: int) -> str:
     """The per-unit status mux for lane ``i``: a filterless lane forwards
     the tile status; a filtered lane muxes the partition status (which
@@ -566,6 +640,15 @@ def _lane_status_glue_sv(composition: ScanComposition, i: int) -> str:
     lane = composition.lanes[i]
     if lane.chain:
         front_filtered = not composition.wide_lane and (lane.partition is not None or composition.partitioner is not None)
+        # the FUSED-CHAIN protocol: a chain stage that closes out on success is
+        # terminal-shaped fused mid-lane (as-of join, grouped aggregator). Its
+        # status is drained every batch (accepted the cycle it is raised, so it
+        # rearms for the next job) and only its ERRORS latch into the lane
+        # status; the terminal tile remains the lane's one close-out. Silent
+        # stages keep the byte-identical upstream-first mux.
+        draining = [j for j, stage in enumerate(lane.chain) if stage.closes_out]
+        if draining:
+            return _fused_chain_status_glue_sv(composition, i, draining)
         stems = (["filt"] if front_filtered else []) + [f"chain{j}" for j in range(len(lane.chain))]
         valids = " || ".join(f"{stem}_status_valid_{i}" for stem in stems)
         error_mux = f"tile_status_error_{i}"

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -566,7 +566,7 @@ def _lane_front_sv(composition: ScanComposition, i: int, *, clk: str = "s_axi_ac
 """
 
 
-def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: list[int]) -> str:
+def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: list[int], *, clk: str, rst: str, start: str) -> str:
     """Status glue for a lane whose chain fuses terminal-shaped stages.
 
     Each draining stage's status is accepted unconditionally (``ready`` tied
@@ -589,11 +589,21 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
     # carried into the new job's status rather than silently dropped — a loud
     # failure on the next job beats a clean report over a corrupt one.
     raising = " || ".join(f"(chain{j}_status_valid_{i} && chain{j}_status_error_{i})" for j in draining)
+    # THE EMPTY-BATCH CLOSE. A draining stage that produced NO output (an
+    # all-miss as-of join, a filter that kept nothing) starves everything
+    # downstream: no row means no output_last, so no downstream stage — and
+    # not the terminal — ever closes, and the record writer would wait
+    # forever. That stage's own close-out is the only end-of-batch evidence
+    # in the lane, so when it closes empty the lane closes with it. Tracked
+    # per stage: `saw_out` sets on the stage's first output beat and clears
+    # per job. Only the most upstream empty stage can fire (a starved
+    # downstream stage never closes at all), so the lane still presents one
+    # close-out.
     lines = [
         f"    reg fused_err_{i};",
         f"    reg [7:0] fused_err_code_{i};",
-        "    always @(posedge s_axi_aclk) begin",
-        "        if (!s_axi_aresetn) begin",
+        f"    always @(posedge {clk}) begin",
+        f"        if ({rst}) begin",
         f"            fused_err_{i} <= 1'b0;",
         f"            fused_err_code_{i} <= 8'd0;",
         f"        end else if (!fused_err_{i} && ({raising})) begin",
@@ -604,7 +614,7 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
         lines.append(f"            {keyword} (chain{j}_status_valid_{i} && chain{j}_status_error_{i}) begin")
         lines.append(f"                fused_err_code_{i} <= chain{j}_status_error_code_{i};")
         lines.append("            end")
-    lines.append("        end else if (job_start) begin")
+    lines.append(f"        end else if ({start}) begin")
     lines.append(f"            fused_err_{i} <= 1'b0;")
     lines.append(f"            fused_err_code_{i} <= 8'd0;")
     lines.append("        end")
@@ -613,6 +623,35 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
     # the draining stages accept their own status immediately
     for j in draining:
         lines.append(f"    assign chain{j}_status_ready_{i} = 1'b1;")
+
+    # per-stage output-seen tracking and the empty-close pulse
+    for j in draining:
+        lines.append(f"    reg saw_out_{i}_{j};")
+        lines.append(f"    reg empty_close_{i}_{j};")
+    lines.append(f"    always @(posedge {clk}) begin")
+    lines.append(f"        if ({rst}) begin")
+    for j in draining:
+        lines.append(f"            saw_out_{i}_{j} <= 1'b0;")
+        lines.append(f"            empty_close_{i}_{j} <= 1'b0;")
+    lines.append(f"        end else if ({start}) begin")
+    for j in draining:
+        lines.append(f"            saw_out_{i}_{j} <= 1'b0;")
+        lines.append(f"            empty_close_{i}_{j} <= 1'b0;")
+    lines.append("        end else begin")
+    for j in draining:
+        lines.append(f"            if (chain{j}_out_valid_{i} && chain{j}_out_ready_{i}) begin")
+        lines.append(f"                saw_out_{i}_{j} <= 1'b1;")
+        lines.append("            end")
+        lines.append(
+            f"            if (chain{j}_status_valid_{i} && !chain{j}_status_error_{i} && !saw_out_{i}_{j}"
+            f" && !(chain{j}_out_valid_{i} && chain{j}_out_ready_{i})) begin"
+        )
+        lines.append(f"                empty_close_{i}_{j} <= 1'b1;")
+        lines.append("            end")
+    lines.append("        end")
+    lines.append("    end")
+    empty_close = " || ".join(f"empty_close_{i}_{j}" for j in draining)
+    lines.append(f"    wire fused_empty_close_{i} = {empty_close};")
 
     # beneath the latch, the silent stages and the terminal keep the
     # upstream-first mux (the pending-order rule the chain contract defines)
@@ -623,7 +662,7 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
     for stem in reversed(stems):
         error_mux = f"{stem}_status_valid_{i} ? {stem}_status_error_{i} : {error_mux}"
         code_mux = f"{stem}_status_valid_{i} ? {stem}_status_error_code_{i} : {code_mux}"
-    lines.append(f"    assign unit_status_valid_{i} = fused_err_{i} || ({base_valid});")
+    lines.append(f"    assign unit_status_valid_{i} = fused_err_{i} || fused_empty_close_{i} || ({base_valid});")
     lines.append(f"    assign unit_status_error_{i} = fused_err_{i} ? 1'b1 : ({error_mux});")
     lines.append(f"    assign unit_status_error_code_{i} = fused_err_{i} ? fused_err_code_{i} : ({code_mux});")
 
@@ -637,7 +676,9 @@ def _fused_chain_status_glue_sv(composition: ScanComposition, i: int, draining: 
     return "\n".join(lines) + "\n"
 
 
-def _lane_status_glue_sv(composition: ScanComposition, i: int) -> str:
+def _lane_status_glue_sv(
+    composition: ScanComposition, i: int, *, clk: str = "s_axi_aclk", rst: str = "!s_axi_aresetn", start: str = "job_start"
+) -> str:
     """The per-unit status mux for lane ``i``: a filterless lane forwards
     the tile status; a filtered lane muxes the partition status (which
     wins) over the tile status; a chained lane muxes every stage's status
@@ -654,7 +695,7 @@ def _lane_status_glue_sv(composition: ScanComposition, i: int) -> str:
         # stages keep the byte-identical upstream-first mux.
         draining = [j for j, stage in enumerate(lane.chain) if stage.closes_out]
         if draining:
-            return _fused_chain_status_glue_sv(composition, i, draining)
+            return _fused_chain_status_glue_sv(composition, i, draining, clk=clk, rst=rst, start=start)
         stems = (["filt"] if front_filtered else []) + [f"chain{j}" for j in range(len(lane.chain))]
         valids = " || ".join(f"{stem}_status_valid_{i}" for stem in stems)
         error_mux = f"tile_status_error_{i}"
@@ -826,7 +867,7 @@ def _lane_tile_upstream(composition: ScanComposition, i: int) -> str:
     return "filt_out" if not chain else f"chain{len(chain) - 1}_out"
 
 
-def _lane_units_sv(composition: ScanComposition, *, clk: str, writer_rst: str) -> str:
+def _lane_units_sv(composition: ScanComposition, *, clk: str, writer_rst: str, start: str = "job_start") -> str:
     """Every lane unit: front (partitioner tap / broadcast tap / partition
     filter), chain stages, operator tile, status glue, and record writer."""
     addr_width = composition.addr_width
@@ -851,7 +892,7 @@ def _lane_units_sv(composition: ScanComposition, *, clk: str, writer_rst: str) -
         .{composition.lanes[i].count_port}(tile_bar_count_{i})
     );
 
-{_lane_status_glue_sv(composition, i)}
+{_lane_status_glue_sv(composition, i, clk=clk, rst=writer_rst, start=start)}
     dau_axi_record_writer #(
         .ADDR_WIDTH({addr_width}),
         .BURST_BEATS({burst_beats})
@@ -1512,7 +1553,7 @@ def generate_scan_composition_sim_sv(
     length_align_bits = 3 if composition.front_unpack is not None else 4
     grid_bytes = 1 << length_align_bits
     length_ok_check = f"input_length_bytes[{length_align_bits - 1}:0] == {length_align_bits}'d0"
-    lane_instances = _lane_units_sv(composition, clk="clk", writer_rst="rst")
+    lane_instances = _lane_units_sv(composition, clk="clk", writer_rst="rst", start="start")
     all_writers_done = " && ".join(f"writer_done_{i}" for i in lanes)
     any_writer_busy = " || ".join(f"writer_busy_{i}" for i in lanes)
     error_priority = _writer_error_priority_sv(num_lanes, error="error", error_code="error_code")

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -146,6 +146,15 @@ class ScanComposition(BaseModel):
     # read never forces narrow writes on a wide bus.
     data_width: int = 64
     wide_lane: bool = False
+    # the byte size of ONE record the composition's first consumer reads.
+    # 16 is the standard quad row; a fused chain whose head takes a wider
+    # record (the as-of join's 24-byte 3-word record) must say so or the
+    # length gate rejects an odd number of perfectly good records. The
+    # register can only enforce power-of-two alignment, so the gate uses
+    # the largest power of two dividing this — a length that is on the
+    # word grid but tears a record is the head tile's ERR_STREAM job (the
+    # same division of labour the packed front already uses).
+    input_row_bytes: int = 16
     # capability words the identity block advertises (register map 0.2).
     # These are caller-computed data — the walker never guesses them: the
     # bitmaps default to zero ("advertise nothing") so a composition only
@@ -158,6 +167,17 @@ class ScanComposition(BaseModel):
 
     def model_post_init(self, _context) -> None:
         _validate_composition_shape(self)
+
+
+def _largest_power_of_two_divisor_bits(row_bytes: int) -> int:
+    """The alignment the length gate can enforce for a record of
+    ``row_bytes``: the exponent of the largest power of two dividing it
+    (16 -> 4, 24 -> 3, 8 -> 3). A 24-byte record is not power-of-two
+    sized, so the gate admits every 8-byte-aligned length and leaves a
+    torn record to the head tile's ERR_STREAM path."""
+    if row_bytes <= 0 or row_bytes % 8:
+        raise ScanCompositionError(f"input_row_bytes must be a positive multiple of 8, got {row_bytes}")
+    return (row_bytes & -row_bytes).bit_length() - 1
 
 
 def _validate_composition_shape(composition: ScanComposition) -> None:
@@ -1248,7 +1268,7 @@ def generate_scan_composition_top_sv(
     # the input length must be a whole number of rows AND of reader beats: at
     # a wide bus (data_width > 64) a beat spans several rows, so beat
     # alignment (log2(data_width/8)) dominates the row grid (3 packed / 4 quad)
-    _row_align = 3 if composition.front_unpack is not None else 4
+    _row_align = 3 if composition.front_unpack is not None else _largest_power_of_two_divisor_bits(composition.input_row_bytes)
     _beat_align = (data_width // 8).bit_length() - 1
     length_align_bits = max(_row_align, _beat_align)
     grid_bytes = 1 << length_align_bits

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -952,7 +952,12 @@ def test_fused_chain_drains_mid_stage_close_outs_and_latches_their_errors() -> N
     assert sv.index(capture) < sv.index("end else if (job_start) begin"), "the per-job clear must not outrank error capture"
     assert "if (chain0_status_valid_0 && chain0_status_error_0) begin" in sv
     assert "else if (chain2_status_valid_0 && chain2_status_error_0) begin" in sv
-    assert "assign unit_status_valid_0 = fused_err_0 || (tile_status_valid_0 || chain1_status_valid_0);" in sv
+    assert "assign unit_status_valid_0 = fused_err_0 || fused_empty_close_0 || (tile_status_valid_0 || chain1_status_valid_0);" in sv
+    # an all-miss upstream stage produces no rows, so nothing downstream ever
+    # sees output_last: its own close-out is the lane's only end-of-batch
+    # evidence and must reach the writer instead of being drained away
+    assert "reg saw_out_0_0;" in sv and "reg empty_close_0_0;" in sv
+    assert "wire fused_empty_close_0 = empty_close_0_0 || empty_close_0_2;" in sv
     assert "assign unit_status_error_0 = fused_err_0 ? 1'b1 : (chain1_status_valid_0 ? chain1_status_error_0 : tile_status_error_0);" in sv
     # the terminal still closes the lane out
     assert "assign tile_status_ready_0 = unit_status_ready_0 && !chain1_status_valid_0;" in sv

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -981,3 +981,31 @@ def test_a_chain_without_closing_stages_is_byte_identical() -> None:
     sv = generate_scan_composition_top_sv(silent)
     assert "fused_err_0" not in sv
     assert "assign chain0_status_ready_0 = unit_status_ready_0 && chain0_status_valid_0;" in sv
+
+
+def test_the_length_gate_follows_the_head_record_size() -> None:
+    """A fused chain whose head reads a 24-byte record was rejecting an
+    ODD number of perfectly good records, because the gate assumed the
+    16-byte quad row. The gate now takes the largest power of two
+    dividing the declared record size; a length on that grid that still
+    tears a record is the head tile's ERR_STREAM job."""
+    for row_bytes, grid in ((16, 16), (24, 8), (8, 8), (32, 32)):
+        composition = ScanComposition(
+            name="gate",
+            module_name="dau_mm_gate_job",
+            input_row_bytes=row_bytes,
+            lanes=(LaneTile(module="dau_int32_field_sum_aggregation", count_port="aggregated_count"),),
+        )
+        sv = generate_scan_composition_top_sv(composition)
+        bits = grid.bit_length() - 1
+        assert f"input_length_bytes[{bits - 1}:0] == {bits}'d0" in sv, f"{row_bytes}B record wants a {grid}B grid"
+
+    with pytest.raises(ScanCompositionError, match="positive multiple of 8"):
+        generate_scan_composition_top_sv(
+            ScanComposition(
+                name="bad",
+                module_name="m",
+                input_row_bytes=12,
+                lanes=(LaneTile(module="t", count_port="c"),),
+            )
+        )

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -910,3 +910,62 @@ def test_wide_packed_reader_is_a_named_followup() -> None:
             partitioner=TileInstance(module="dau_int32_key_mask_dispatcher", params={"IN_WIDTH": 128}),
             data_width=256,
         )
+
+
+def test_fused_chain_drains_mid_stage_close_outs_and_latches_their_errors() -> None:
+    """The fused-chain protocol: a chain stage marked ``closes_out`` is a
+    terminal-shaped tile fused mid-lane (as-of join, grouped aggregator).
+    Its status is accepted unconditionally so the lane still presents ONE
+    close-out (the terminal's), while its errors latch into a per-lane
+    register that overrides the lane status and clears per job."""
+    composition = ScanComposition(
+        name="fused",
+        module_name="dau_mm_fused_job",
+        lanes=(
+            LaneTile(
+                module="dau_int32_rolling_moments",
+                count_port="moment_count",
+                chain=(
+                    TileInstance(module="dau_int32_asof_backward", closes_out=True),
+                    TileInstance(module="dau_int32_time_bucket_key"),
+                    TileInstance(module="dau_int32_grouped_field_aggregation", closes_out=True),
+                ),
+            ),
+        ),
+    )
+    sv = generate_scan_composition_top_sv(composition)
+
+    # the closing stages accept their own status the cycle it appears
+    assert "assign chain0_status_ready_0 = 1'b1;" in sv
+    assert "assign chain2_status_ready_0 = 1'b1;" in sv
+    # the silent stage keeps the ordinary upstream-first gating
+    assert "assign chain1_status_ready_0 = unit_status_ready_0 && chain1_status_valid_0;" in sv
+    # errors latch, override the lane status, and clear per job (multi-job safe)
+    assert "reg fused_err_0;" in sv and "reg [7:0] fused_err_code_0;" in sv
+    assert "end else if (job_start) begin" in sv
+    assert "if (chain0_status_valid_0 && chain0_status_error_0) begin" in sv
+    assert "else if (chain2_status_valid_0 && chain2_status_error_0) begin" in sv
+    assert "assign unit_status_valid_0 = fused_err_0 || (tile_status_valid_0 || chain1_status_valid_0);" in sv
+    assert "assign unit_status_error_0 = fused_err_0 ? 1'b1 : (chain1_status_valid_0 ? chain1_status_error_0 : tile_status_error_0);" in sv
+    # the terminal still closes the lane out
+    assert "assign tile_status_ready_0 = unit_status_ready_0 && !chain1_status_valid_0;" in sv
+
+
+def test_a_chain_without_closing_stages_is_byte_identical() -> None:
+    """The protocol is opt-in per stage: a chain of silent stages emits
+    exactly what it did before the field existed (the goldens prove the
+    same thing; this pins the intent)."""
+    silent = ScanComposition(
+        name="plain",
+        module_name="dau_mm_plain_job",
+        lanes=(
+            LaneTile(
+                module="dau_int32_field_sum_aggregation",
+                count_port="aggregated_count",
+                chain=(TileInstance(module="dau_int32_row_predicate_filter"), TileInstance(module="dau_int32_row_map_alu")),
+            ),
+        ),
+    )
+    sv = generate_scan_composition_top_sv(silent)
+    assert "fused_err_0" not in sv
+    assert "assign chain0_status_ready_0 = unit_status_ready_0 && chain0_status_valid_0;" in sv

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -942,7 +942,14 @@ def test_fused_chain_drains_mid_stage_close_outs_and_latches_their_errors() -> N
     assert "assign chain1_status_ready_0 = unit_status_ready_0 && chain1_status_valid_0;" in sv
     # errors latch, override the lane status, and clear per job (multi-job safe)
     assert "reg fused_err_0;" in sv and "reg [7:0] fused_err_code_0;" in sv
-    assert "end else if (job_start) begin" in sv
+    # a drained status lives for ONE cycle, so capture must outrank the
+    # per-job clear: an error coinciding with job_start would otherwise be
+    # lost and the corrupt job would report clean
+    capture = (
+        "end else if (!fused_err_0 && ((chain0_status_valid_0 && chain0_status_error_0) || (chain2_status_valid_0 && chain2_status_error_0))) begin"
+    )
+    assert capture in sv
+    assert sv.index(capture) < sv.index("end else if (job_start) begin"), "the per-job clear must not outrank error capture"
     assert "if (chain0_status_valid_0 && chain0_status_error_0) begin" in sv
     assert "else if (chain2_status_valid_0 && chain2_status_error_0) begin" in sv
     assert "assign unit_status_valid_0 = fused_err_0 || (tile_status_valid_0 || chain1_status_valid_0);" in sv


### PR DESCRIPTION
The composition contract has always allowed exactly one close-out per lane (the terminal's — the record writer's done waits on a consumed producer status), which means a terminal-shaped tile cannot be FUSED mid-lane. The temporal hero datapath needs exactly that: as-of join -> feature -> bucket key -> grouped aggregator -> rolling moments, where the as-of and the aggregator both close out, so their large intermediates never touch DDR.

`TileInstance.closes_out` marks such a stage and the walker emits the protocol the sim harness proved (dau-core `tests/sv/dau_hero_datapath.sv`): the stage's status is accepted the cycle it appears so the stage rearms, and its errors latch into a per-lane register that overrides the lane status. Silent stages are untouched and every existing golden is byte-identical.

**Review round (codex, adversarial) found three things, all fixed here:**
- **Error capture must outrank the per-job clear.** A drained status lives for one cycle, so an error coinciding with `job_start` was silently lost and the corrupt job would have reported clean. Capture now wins; a carried error fails the next job loudly instead.
- **The empty-batch hang.** A draining stage that produces NO output (an all-miss as-of join) starves everything downstream — no row means no `output_last`, so neither the downstream stages nor the terminal ever close and the writer waits forever. That stage's own close-out is the lane's only end-of-batch evidence, so when it closes empty the lane closes with it (per-stage `saw_out` tracking, cleared per job). Only the most upstream empty stage can fire, so the lane still presents one close-out.
- **Hardcoded signal names.** The glue assumed the AXI clock/reset/start; the sim generator drives `clk`/`rst`/`start` and would have emitted undeclared identifiers. Names are threaded through both paths now.

Suite: 372 passed. **Not merging until the fused shell has a cocotb proof** — the empty-batch and multi-job paths are exactly what a simulation must confirm, and this protocol should not reach silicon on emission tests alone.