### PR TITLE
Let the record bus past the row-width check

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -208,6 +208,8 @@ def _validate_composition_shape(composition: ScanComposition) -> None:
     # widens packed rows; a front gearbox emits one input record; without either
     # front stage the feed IS the reader stream.
     _WIDTHS = (64, 128, 256, 512)
+    # both the gearbox and the record dispatcher elaboration-guard RECORD_WORDS
+    _MAX_RECORD_WORDS = 16
     data_width = composition.data_width
     if data_width not in _WIDTHS:
         raise ScanCompositionError(f"data_width must be one of {_WIDTHS}, got {data_width}")
@@ -258,9 +260,18 @@ def _validate_composition_shape(composition: ScanComposition) -> None:
         feed_width = data_width
     # behind a gearbox the router's bus carries one whole RECORD, not a row,
     # so its width is a record size (a 3-word record is 192 bits) and the
-    # 64/128/256/512 row ladder does not apply
-    if composition.front_gearbox is None and fanout_width not in _WIDTHS:
-        raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be one of {_WIDTHS}, got {fanout_width}")
+    # 64/128/256/512 row ladder does not apply. The record still has to be a
+    # size the RTL can elaborate: both the gearbox and the dispatcher guard
+    # RECORD_WORDS to [1, 16], and a $fatal is a far worse failure than a
+    # composition error — it surfaces mid-synthesis with no attribution.
+    if composition.front_gearbox is None:
+        if fanout_width not in _WIDTHS:
+            raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be one of {_WIDTHS}, got {fanout_width}")
+    elif not (64 <= fanout_width <= _MAX_RECORD_WORDS * 64) or fanout_width % 64:
+        raise ScanCompositionError(
+            f"a geared record bus must be a whole number of 64-bit words, at most {_MAX_RECORD_WORDS}; got {fanout_width} bits "
+            f"({composition.input_row_bytes}-byte records)"
+        )
     if feed_width > 64 and not composition.wide_lane:
         if composition.partitioner is None:
             raise ScanCompositionError(

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -256,6 +256,9 @@ def _validate_composition_shape(composition: ScanComposition) -> None:
         feed_width = composition.input_row_bytes * 8
     else:
         feed_width = data_width
+    # behind a gearbox the router's bus carries one whole RECORD, not a row,
+    # so its width is a record size (a 3-word record is 192 bits) and the
+    # 64/128/256/512 row ladder does not apply
     if composition.front_gearbox is None and fanout_width not in _WIDTHS:
         raise ScanCompositionError(f"the shared partitioner's IN_WIDTH must be one of {_WIDTHS}, got {fanout_width}")
     if feed_width > 64 and not composition.wide_lane:

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -1107,3 +1107,19 @@ def test_the_length_gate_follows_the_head_record_size() -> None:
                 lanes=(LaneTile(module="t", count_port="c"),),
             )
         )
+
+
+def test_a_geared_record_bus_must_be_a_size_the_rtl_can_elaborate() -> None:
+    """Skipping the row-width ladder for geared compositions must not admit
+    record sizes the gearbox and dispatcher elaboration-guard to [1, 16]
+    words: a $fatal surfaces mid-synthesis with no attribution, so the
+    composition has to refuse first."""
+    base = _front_gearbox_composition()
+    with pytest.raises(ScanCompositionError, match="geared record bus"):
+        generate_scan_composition_top_sv(base.model_copy(update={"input_row_bytes": 136}))  # 17 words
+    # a size that is not whole words is already refused upstream, by the rule
+    # that owns the invariant rather than by the record-range check
+    with pytest.raises(ScanCompositionError, match="positive multiple of 8"):
+        generate_scan_composition_top_sv(base.model_copy(update={"input_row_bytes": 20}))
+    # the legal end of the range still composes
+    generate_scan_composition_top_sv(base.model_copy(update={"input_row_bytes": 128}))


### PR DESCRIPTION
A composition with a front gearbox routes whole RECORDS, not rows. Its
router bus width is a record size — 192 bits for a three-word record —
which is legitimately outside the 64/128/256/512 row ladder, so the
row-width gate now only applies when there is no gearbox in front.