### PR TITLE
Emit the SPI mcs from the shell build

### DIFF
--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -312,6 +312,30 @@ connect_bd_net [get_bd_pins xdma_0/axi_aresetn] [get_bd_pins job_rst/ext_reset_i
 """
 
 
+def _spi_cfgmem_tcl(platform) -> str:
+    """The SPI-flash packaging step for a board that BOOTS FROM FLASH.
+
+    Such a board never comes up from a raw JTAG bitstream write, so the
+    shell build has to emit the mcs the flasher writes. The width and rate
+    have to be set on the design and the bitstream REGENERATED -- they are
+    baked into the bitstream at write time, so a plain bit copied from the
+    run directory carries the tool defaults no matter what the flash step
+    later does with it.
+    """
+    if platform.spi_boot_buswidth is None:
+        return ""
+    rate = platform.spi_boot_configrate
+    rate_line = f"set_property BITSTREAM.CONFIG.CONFIGRATE {rate} [current_design]\n" if rate is not None else ""
+    return (
+        f"set_property BITSTREAM.CONFIG.SPI_BUSWIDTH {platform.spi_boot_buswidth} [current_design]\n"
+        f"{rate_line}"
+        'write_bitstream -force "$origin_dir/dau_mm_job_spi.bit"\n'
+        f"write_cfgmem -format mcs -interface SPIx{platform.spi_boot_buswidth} -size 32 -force "
+        '-loadbit "up 0 $origin_dir/dau_mm_job_spi.bit" -file "$origin_dir/dau_mm_job.mcs"\n'
+        'puts "DAU_MM_JOB_MCS $origin_dir/dau_mm_job.mcs"\n'
+    )
+
+
 def _lane_swizzle_verify_tcl(lane_placements: tuple[tuple[int, str], ...]) -> str:
     """Post-route verification that every swizzled lane landed on its site."""
     swizzle_pairs = " ".join(f"{lane} {channel}" for lane, channel in lane_placements)
@@ -339,6 +363,11 @@ def _build_postamble_tcl(request) -> str:
     when the platform declares lane placements."""
     placements = request.platform.lane_placements
     hook_line = 'set_property STEPS.OPT_DESIGN.TCL.PRE "$origin_dir/gt_lane_swizzle.tcl" [get_runs impl_1]\n' if placements else ""
+    # A board whose resident path is SPI flash needs the mcs the flasher
+    # actually writes, and the bitstream has to carry the SPI width/rate
+    # BEFORE it is generated -- a raw JTAG write of a plain bitstream never
+    # boots such a board. Driven by the platform fact, never hand-run.
+    spi_block = _spi_cfgmem_tcl(request.platform)
     verify_block = _lane_swizzle_verify_tcl(placements) if placements else ""
     return f"""validate_bd_design
 save_bd_design
@@ -367,6 +396,7 @@ report_timing_summary -file "$origin_dir/timing_mm.rpt"
 
 {verify_block}set wns [get_property SLACK [get_timing_paths -max_paths 1 -nworst 1 -setup]]
 file copy -force "$origin_dir/project_mm/project_mm.runs/impl_1/Top_wrapper.bit" "$origin_dir/dau_mm_job.bit"
+{spi_block}
 puts "DAU_MM_JOB_BUILD_OK wns=$wns"
 exit 0
 """

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -231,6 +231,10 @@ class PlatformDefinition(BaseModel):
     # is supported: the cfgmem generator (flash.tcl / vivado_build_tcl)
     # writes SPIx4; another width would need its own cfgmem-generation path.
     spi_boot_buswidth: Literal[4] | None = None
+    # the SPI configuration clock rate (MHz) baked into the bitstream for a
+    # self-configuring board. It sets how long the board takes to come up
+    # from flash, so it is a measured board fact rather than a tool default.
+    spi_boot_configrate: int | None = None
     # the platform's supported memory-read width tiers (the precompiled
     # bitstream catalog dimension): each entry is a legal `width=` build
     # selection on this board. Bounded by the memory system's AXI width and

--- a/dau_build/tests/fixtures/dpv1_shell/mm_ddr_job_project.tcl
+++ b/dau_build/tests/fixtures/dpv1_shell/mm_ddr_job_project.tcl
@@ -192,5 +192,10 @@ puts "lane swizzle verified"
 
 set wns [get_property SLACK [get_timing_paths -max_paths 1 -nworst 1 -setup]]
 file copy -force "$origin_dir/project_mm/project_mm.runs/impl_1/Top_wrapper.bit" "$origin_dir/dau_mm_job.bit"
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
+write_bitstream -force "$origin_dir/dau_mm_job_spi.bit"
+write_cfgmem -format mcs -interface SPIx4 -size 32 -force -loadbit "up 0 $origin_dir/dau_mm_job_spi.bit" -file "$origin_dir/dau_mm_job.mcs"
+puts "DAU_MM_JOB_MCS $origin_dir/dau_mm_job.mcs"
+
 puts "DAU_MM_JOB_BUILD_OK wns=$wns"
 exit 0

--- a/dau_build/tests/fixtures/dpv1_shell/mm_job_project.tcl
+++ b/dau_build/tests/fixtures/dpv1_shell/mm_job_project.tcl
@@ -178,5 +178,10 @@ puts "lane swizzle verified"
 
 set wns [get_property SLACK [get_timing_paths -max_paths 1 -nworst 1 -setup]]
 file copy -force "$origin_dir/project_mm/project_mm.runs/impl_1/Top_wrapper.bit" "$origin_dir/dau_mm_job.bit"
+set_property BITSTREAM.CONFIG.SPI_BUSWIDTH 4 [current_design]
+write_bitstream -force "$origin_dir/dau_mm_job_spi.bit"
+write_cfgmem -format mcs -interface SPIx4 -size 32 -force -loadbit "up 0 $origin_dir/dau_mm_job_spi.bit" -file "$origin_dir/dau_mm_job.mcs"
+puts "DAU_MM_JOB_MCS $origin_dir/dau_mm_job.mcs"
+
 puts "DAU_MM_JOB_BUILD_OK wns=$wns"
 exit 0

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -410,3 +410,29 @@ def test_wide_data_width_ddr_tcl_wires_split_masters(tmp_path) -> None:
     # the shared-master wiring is gone
     assert "[get_bd_intf_pins top_0/M_AXI]" not in text
     assert "[get_bd_addr_spaces top_0/M_AXI]" not in text
+
+
+def test_a_flash_booting_platform_emits_its_spi_mcs() -> None:
+    """dpv2's resident path IS SPI flash: it never enumerates from a raw JTAG
+    bitstream write. A shell build that emits only a .bit therefore produces
+    nothing that board can boot, so the mcs must come out of the same build."""
+    from dau_build.dpv1_shell import _spi_cfgmem_tcl
+    from dau_build.platforms import dpv1_platform
+
+    spi = dpv1_platform().model_copy(update={"spi_boot_buswidth": 4, "spi_boot_configrate": 33})
+    tcl = _spi_cfgmem_tcl(spi)
+    assert "BITSTREAM.CONFIG.SPI_BUSWIDTH 4" in tcl
+    assert "BITSTREAM.CONFIG.CONFIGRATE 33" in tcl
+    # the bitstream must be REGENERATED after the properties are set: the
+    # width is baked in at write time, so copying the run's default bit
+    # would ship the tool default however the flash step is invoked
+    assert tcl.index("SPI_BUSWIDTH") < tcl.index("write_bitstream") < tcl.index("write_cfgmem")
+    assert "-interface SPIx4" in tcl
+
+    # dpv1 declares SPIx4 too but pins no rate, so it gets the width and the
+    # mcs without a CONFIGRATE line
+    assert "CONFIGRATE" not in _spi_cfgmem_tcl(dpv1_platform())
+
+    # a board that does NOT self-configure from flash gains nothing, and its
+    # build must stay byte-identical to what it emitted before
+    assert _spi_cfgmem_tcl(dpv1_platform().model_copy(update={"spi_boot_buswidth": None})) == ""


### PR DESCRIPTION
A board whose resident path is SPI flash never enumerates from a raw JTAG
bitstream write, so a shell build that emits only a `.bit` produces
nothing that board can boot. dpv2 is such a board, and its mcs was being
produced outside the build.

The width and rate are baked into the bitstream at write time, so the
properties are set on the implemented design and the bitstream
regenerated before `write_cfgmem` — copying the run's default bit would
ship the tool defaults however the flash step is later invoked. Both are
platform facts (`spi_boot_buswidth`, and `spi_boot_configrate` added
here) rather than constants in the generator.

The dpv1 goldens move by exactly the five new lines: dpv1 declares SPIx4
too, and pins no rate, so it gets the width and the mcs without a
CONFIGRATE line.