### PR TITLE
Freeze the build and platform specs

### DIFF
--- a/dau_build/build_spec.py
+++ b/dau_build/build_spec.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 from ccflow import BaseModel
-from pydantic import Field, StringConstraints, ValidationError
+from pydantic import ConfigDict, Field, StringConstraints, ValidationError
 
 from dau_build.artifact_bundle import ArtifactBundle, ArtifactBundleError, is_hdl_source_artifact, load_artifact_bundle, source_language_from_path
 from dau_build.packaging import Artifact, ArtifactManifest, ArtifactManifestError, artifact_modules, artifact_with_modules, load_artifact_manifest
@@ -32,6 +32,7 @@ class DauBuildSpecError(ValueError):
 
 
 class DauBuildSpec(BaseModel):
+    model_config = ConfigDict(frozen=True)
     name: str
     top_name: str
     platform: str

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import Literal, Protocol
 
 from ccflow import BaseModel
-from pydantic import Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
 
 _PCIE_LANE_WIDTHS = (1, 2, 4, 8, 16)
 
@@ -208,6 +208,8 @@ class PlatformDefinition(BaseModel):
     that forces a faster ``axi_aclk`` (250 MHz at Gen2 x8) never drags the
     proven job-logic timing closure with it. ``None`` (the dpv1 default)
     keeps the job logic on ``axi_aclk`` unchanged."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str
     part: str

--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -19,6 +19,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from ccflow import BaseModel
+from pydantic import ConfigDict
 
 __all__ = (
     "LaneTile",
@@ -43,6 +44,8 @@ class TileInstance(BaseModel):
     on the instance). A tile with no ``params`` is emitted exactly as before
     the channel existed (no ``#(...)``), so every param-less golden stays
     byte-identical."""
+
+    model_config = ConfigDict(frozen=True)
 
     module: str
     config: dict[str, str] = {}  # noqa: RUF012  # pydantic deep-copies field defaults per instance
@@ -128,6 +131,8 @@ class ScanComposition(BaseModel):
     ``wide_lane`` selects the registry-legalized single-lane shape whose
     stages consume the burst reader's whole wide beat directly. The private
     bridge sets this flag; this public generator cannot consult its registry."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str
     module_name: str

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1535,8 +1535,7 @@ def test_program_method_flash_selects_the_vivado_programmer() -> None:
     from dau_build.platforms import dpv1_platform
     from dau_build.programmers import VivadoHwServerProgrammer
 
-    flash_board = dpv1_platform().model_copy(deep=True)
-    flash_board.program_method = "flash"
+    flash_board = dpv1_platform().model_copy(update={"program_method": "flash"})
     config = HardwareToolchainConfig.for_platform(flash_board, work_root=Path("/w"), vivado_executable="vivado")
     programmer = config.resolve_programmer()
     assert isinstance(programmer, VivadoHwServerProgrammer)

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -1123,3 +1123,25 @@ def test_a_geared_record_bus_must_be_a_size_the_rtl_can_elaborate() -> None:
         generate_scan_composition_top_sv(base.model_copy(update={"input_row_bytes": 20}))
     # the legal end of the range still composes
     generate_scan_composition_top_sv(base.model_copy(update={"input_row_bytes": 128}))
+
+
+def test_the_build_specs_are_frozen() -> None:
+    """A spec that can mutate after validation is a spec whose identity, and
+    therefore whose cache key and staged artifacts, depend on call order.
+    Freezing is what makes the hash mean something."""
+    import pytest as _pytest
+    from pydantic import ValidationError as _ValidationError
+
+    from dau_build.build_spec import DauBuildSpec
+    from dau_build.platforms import dpv1_platform
+
+    frozen = (
+        TileInstance(module="dau_tile"),
+        _bar_noc_composition(),
+        dpv1_platform(),
+    )
+    for model in frozen:
+        field = next(iter(type(model).model_fields))
+        with _pytest.raises(_ValidationError, match="frozen"):
+            setattr(model, field, getattr(model, field))
+    assert DauBuildSpec.model_config.get("frozen") is True


### PR DESCRIPTION
A spec that can mutate after validation is a spec whose identity — and
therefore whose cache key and staged artifacts — depends on call order.
`DauBuildSpec`, `PlatformDefinition`, `TileInstance` and
`ScanComposition` were all mutable, so validated topology, width or
platform facts could change between validation and staging.

`model_copy(update=)` still works, which is what the one test that
mutated a platform in place now uses. A guard test asserts the freeze so
it cannot silently regress.