### PR TITLE
Decode the high half of wide job addresses

### DIFF
--- a/dau_build/scan_composition.py
+++ b/dau_build/scan_composition.py
@@ -99,10 +99,12 @@ class RegisterLayout(BaseModel):
     load_phase: int = 0x084
     job_status: int = 0x054
     input_address_low: int = 0x058
+    input_address_high: int = 0x05C
     input_length_low: int = 0x060
     lane_base: int = 0x100
     lane_stride: int = 0x20
     lane_output_address_low: int = 0x00
+    lane_output_address_high: int = 0x14
     lane_result_length_low: int = 0x04
     lane_record_count_low: int = 0x08
     lane_record_count_high: int = 0x0C
@@ -1379,6 +1381,11 @@ def generate_scan_composition_top_sv(
         f"    localparam [11:0] ADDR_LANE{i}_RECORD_COUNT_LOW = 12'h{regs.lane_register(i, regs.lane_record_count_low):03X};\n"
         f"    localparam [11:0] ADDR_LANE{i}_RECORD_COUNT_HIGH = 12'h{regs.lane_register(i, regs.lane_record_count_high):03X};\n"
         f"    localparam [11:0] ADDR_LANE{i}_ERROR = 12'h{regs.lane_register(i, regs.lane_error):03X};"
+        + (
+            f"\n    localparam [11:0] ADDR_LANE{i}_OUTPUT_ADDRESS_HIGH = 12'h{regs.lane_register(i, regs.lane_output_address_high):03X};"
+            if addr_width > 32
+            else ""
+        )
         for i in lanes
     )
     uses_load_phase = _uses_load_phase(composition)
@@ -1420,13 +1427,29 @@ def generate_scan_composition_top_sv(
     all_writers_done = " && ".join(f"writer_done_{i}" for i in lanes)
     any_writer_busy = " || ".join(f"writer_busy_{i}" for i in lanes)
     error_priority = _writer_error_priority_sv(num_lanes, error="job_error", error_code="job_error_code")
-    write_case_items = "\n".join(f"                    ADDR_LANE{i}_OUTPUT_ADDRESS: lane_output_address_{i} <= s_axi_wdata;" for i in lanes)
+
+    def lane_high_read(i: int) -> str:
+        if addr_width <= 32:
+            return ""
+        return f"\n                    ADDR_LANE{i}_OUTPUT_ADDRESS_HIGH: s_axi_rdata <= lane_output_address_{i}[{addr_width - 1}:32];"
+
+    # the lane write address takes the same low/high treatment as the job read
+    # address: a bare 32-bit write into a wider register leaves the top bits
+    # unreachable, so a lane could only ever write below 4 GiB
+    if addr_width > 32:
+        write_case_items = "\n".join(
+            f"                    ADDR_LANE{i}_OUTPUT_ADDRESS: lane_output_address_{i}[31:0] <= s_axi_wdata;\n"
+            f"                    ADDR_LANE{i}_OUTPUT_ADDRESS_HIGH: lane_output_address_{i}[{addr_width - 1}:32] <= s_axi_wdata[{addr_width - 33}:0];"
+            for i in lanes
+        )
+    else:
+        write_case_items = "\n".join(f"                    ADDR_LANE{i}_OUTPUT_ADDRESS: lane_output_address_{i} <= s_axi_wdata;" for i in lanes)
     read_case_items = "\n".join(
         f"""                    ADDR_LANE{i}_OUTPUT_ADDRESS: s_axi_rdata <= lane_output_address_{i}[31:0];
                     ADDR_LANE{i}_RESULT_LENGTH: s_axi_rdata <= lane_result_length_{i};
                     ADDR_LANE{i}_RECORD_COUNT_LOW: s_axi_rdata <= lane_bar_count_{i}[31:0];
                     ADDR_LANE{i}_RECORD_COUNT_HIGH: s_axi_rdata <= lane_bar_count_{i}[63:32];
-                    ADDR_LANE{i}_ERROR: s_axi_rdata <= {{24'd0, writer_error_code_{i}}};"""
+                    ADDR_LANE{i}_ERROR: s_axi_rdata <= {{24'd0, writer_error_code_{i}}};{lane_high_read(i)}"""
         for i in lanes
     )
     lane_reset_items = "\n".join(f"            lane_output_address_{i} <= {addr_width}'d0;" for i in lanes)
@@ -1437,6 +1460,23 @@ def generate_scan_composition_top_sv(
             end"""
         for i in lanes
     )
+    wide_address = addr_width > 32
+    input_address_low_write = (
+        "                    ADDR_INPUT_ADDRESS_LOW: input_address[31:0] <= s_axi_wdata;\n"
+        if wide_address
+        else f"                    ADDR_INPUT_ADDRESS_LOW: input_address <= s_axi_wdata[{addr_width - 1}:0];\n"
+    )
+    input_address_high_write = (
+        f"                    ADDR_INPUT_ADDRESS_HIGH: input_address[{addr_width - 1}:32] <= s_axi_wdata[{addr_width - 33}:0];\n"
+        if wide_address
+        else ""
+    )
+    # a narrower-than-32 slice zero-extends on assignment to the 32-bit read
+    # data, so no concatenation is needed (and a 64-bit master's high half is
+    # exactly 32 bits, where a pad would be zero-width and illegal)
+    input_address_high_read = (
+        f"\n                    ADDR_INPUT_ADDRESS_HIGH: s_axi_rdata <= input_address[{addr_width - 1}:32];" if wide_address else ""
+    )
     register_names: tuple[tuple[str, int], ...] = (
         ("LAST_ERROR", regs.last_error),
         ("JOB_CONTROL", regs.job_control),
@@ -1444,6 +1484,8 @@ def generate_scan_composition_top_sv(
         ("INPUT_ADDRESS_LOW", regs.input_address_low),
         ("INPUT_LENGTH_LOW", regs.input_length_low),
     )
+    if wide_address:
+        register_names = register_names + (("INPUT_ADDRESS_HIGH", regs.input_address_high),)
     if uses_load_phase:
         register_names = register_names + (("LOAD_PHASE", regs.load_phase),)
     localparams = _register_localparams_sv(register_names)
@@ -1451,6 +1493,11 @@ def generate_scan_composition_top_sv(
     load_phase_write = "                    ADDR_LOAD_PHASE: load_phase <= s_axi_wdata[0];\n" if uses_load_phase else ""
     # leading newline so an unused register leaves the read block byte-identical
     load_phase_read = "\n                    ADDR_LOAD_PHASE: s_axi_rdata <= {31'd0, load_phase};" if uses_load_phase else ""
+    # THE HIGH HALF OF THE JOB ADDRESS. AXI-Lite carries 32 bits per access,
+    # so a job master wider than 32 bits needs a second register or its top
+    # bits are unreachable — which is exactly why a build could only ever
+    # map the low 4 GiB. Emitted ONLY when the master is actually wider, so
+    # a 32-bit design's register block stays byte-identical.
     register_process = _axi_lite_register_process_sv(
         write_default_comment="other job fields accepted and ignored",
         reset_extra=f"""            input_address <= {addr_width}'d0;
@@ -1470,11 +1517,10 @@ def generate_scan_composition_top_sv(
             end
 {front_stage_error_latch}{lane_count_latch_items}
 """,
-        write_cases_extra=f"""                    ADDR_INPUT_ADDRESS_LOW: input_address <= s_axi_wdata[{addr_width - 1}:0];
-                    ADDR_INPUT_LENGTH_LOW: input_length_bytes <= s_axi_wdata;
+        write_cases_extra=f"""{input_address_low_write}{input_address_high_write}                    ADDR_INPUT_LENGTH_LOW: input_length_bytes <= s_axi_wdata;
 {load_phase_write}{write_case_items}
 """,
-        read_cases_extra=f"""                    ADDR_INPUT_ADDRESS_LOW: s_axi_rdata <= input_address[31:0];
+        read_cases_extra=f"""                    ADDR_INPUT_ADDRESS_LOW: s_axi_rdata <= input_address[31:0];{input_address_high_read}
                     ADDR_INPUT_LENGTH_LOW: s_axi_rdata <= input_length_bytes;{load_phase_read}
                     12'hFC0: s_axi_rdata <= dbg_first_stream_word[31:0];
                     12'hFC4: s_axi_rdata <= dbg_first_stream_word[63:32];

--- a/dau_build/tests/test_scan_composition.py
+++ b/dau_build/tests/test_scan_composition.py
@@ -1145,3 +1145,48 @@ def test_the_build_specs_are_frozen() -> None:
         with _pytest.raises(_ValidationError, match="frozen"):
             setattr(model, field, getattr(model, field))
     assert DauBuildSpec.model_config.get("frozen") is True
+
+
+def test_a_wide_job_master_can_actually_reach_its_high_address_bits() -> None:
+    """AXI-Lite carries 32 bits per access, so a job master wider than 32
+    bits needs a SECOND register or its top bits are unreachable — which is
+    exactly why a build could only ever map the low 4 GiB of an 8 GB module.
+
+    The narrow case must stay byte-identical: a 32-bit design's register
+    block is proven silicon and must not move.
+    """
+    narrow = _bar_noc_composition()
+    wide = narrow.model_copy(update={"addr_width": 64})
+
+    narrow_sv = generate_scan_composition_top_sv(narrow)
+    wide_sv = generate_scan_composition_top_sv(wide)
+
+    # the narrow design decodes only the low register, exactly as before
+    assert "ADDR_INPUT_ADDRESS_LOW: input_address <= s_axi_wdata[31:0];" in narrow_sv
+    assert "ADDR_INPUT_ADDRESS_HIGH" not in narrow_sv
+    assert "OUTPUT_ADDRESS_HIGH" not in narrow_sv
+
+    # the wide design splits the job read address across both halves
+    assert "ADDR_INPUT_ADDRESS_LOW: input_address[31:0] <= s_axi_wdata;" in wide_sv
+    assert "ADDR_INPUT_ADDRESS_HIGH: input_address[63:32] <= s_axi_wdata[31:0];" in wide_sv
+    assert "ADDR_INPUT_ADDRESS_HIGH: s_axi_rdata <= input_address[63:32];" in wide_sv
+
+    # ...and every lane's WRITE address too, or a lane could only write low
+    for lane in range(len(narrow.lanes)):
+        assert f"ADDR_LANE{lane}_OUTPUT_ADDRESS: lane_output_address_{lane}[31:0] <= s_axi_wdata;" in wide_sv
+        assert f"ADDR_LANE{lane}_OUTPUT_ADDRESS_HIGH: lane_output_address_{lane}[63:32] <= s_axi_wdata[31:0];" in wide_sv
+        assert f"ADDR_LANE{lane}_OUTPUT_ADDRESS_HIGH = 12'h" in wide_sv
+
+
+def test_the_wide_address_registers_sit_where_dau_core_says() -> None:
+    """The walker's offsets mirror `dau_core.registers`; a drift here means
+    the host writes one address and the design decodes another."""
+    from dau_core.registers import NocLaneRegisterOffset, RegisterOffset
+
+    from dau_build.scan_composition import RegisterLayout
+
+    regs = RegisterLayout()
+    assert regs.input_address_high == int(RegisterOffset.INPUT_ADDRESS_HIGH)
+    assert regs.lane_output_address_high == int(NocLaneRegisterOffset.OUTPUT_ADDRESS_HIGH)
+    # and the lane high register stays inside the lane stride
+    assert regs.lane_output_address_high < regs.lane_stride


### PR DESCRIPTION
THE reason a build could only map 4 GiB of the installed 8 GB SODIMM. It
was never the AXI: `addr_width` already flowed through to the burst
reader and the M_AXI ports. The register block simply never wired the top
bits.

At `addr_width=64` the generated decode read
`input_address <= s_axi_wdata[63:0]` from a 32-bit AXI-Lite bus, and each
lane took a bare `lane_output_address_N <= s_axi_wdata` into a 64-bit
register — Verilator flags four WIDTHEXPAND warnings for exactly that.
The high bits were unreachable, so every design addressed below 4 GiB no
matter how wide the master.

Both the job read address and every lane write address now split across
LOW/HIGH registers when the master is wider than 32 bits, and Verilator is
clean on the 64-bit top.

The narrow path emits the ORIGINAL text byte for byte — the 32-bit
register block is proven silicon and the committed goldens match
unchanged. A test pins both directions; a second pins the walker's offsets
against `dau_core.registers` so host and design cannot drift.

Needs dau-core#126 for the lane high register.