### PR TITLE
Validate hardware plan executables

### DIFF
--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1050,6 +1050,7 @@ class HardwarePlanTask(BuildCallableModel):
     reset_bridge_bdf: str | None = None
     expected_endpoint_id: str | None = None
     runtime_pm_executable: str | None = None
+    deadman_executable: str | None = None
     runtime_pm_patterns: tuple[str, ...] | None = None
     rescan_bdfs: tuple[str, ...] | None = None
     privilege_prefix: tuple[str, ...] | None = None
@@ -1081,6 +1082,7 @@ class HardwarePlanTask(BuildCallableModel):
             reset_bridge_bdf=self.reset_bridge_bdf,
             expected_endpoint_id=self.expected_endpoint_id,
             runtime_pm_executable=self.runtime_pm_executable,
+            deadman_executable=self.deadman_executable,
             runtime_pm_patterns=self.runtime_pm_patterns,
             rescan_bdfs=self.rescan_bdfs,
             privilege_prefix=self.privilege_prefix,

--- a/dau_build/config/task/tasks/hardware/hardware-plan.yaml
+++ b/dau_build/config/task/tasks/hardware/hardware-plan.yaml
@@ -24,6 +24,7 @@ endpoint_bdf: null
 reset_bridge_bdf: null
 expected_endpoint_id: null
 runtime_pm_executable: null
+deadman_executable: null
 runtime_pm_patterns: null
 rescan_bdfs: null
 privilege_prefix: null

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -4,6 +4,7 @@ import base64
 import os
 import re
 import shlex
+import shutil
 import subprocess
 from collections.abc import Sequence
 from pathlib import Path
@@ -43,9 +44,26 @@ SHELL_STAGE_EXCLUDES = (
 class ToolStep(BaseModel):
     name: str
     argv: tuple[str, ...]
+    required_executable: str | None = None
+    executable_override: str | None = None
+    executable_requires_absolute: bool = False
 
-    def __init__(self, name: str, argv: tuple[str, ...] = ()) -> None:
-        super().__init__(name=name, argv=argv)
+    def __init__(
+        self,
+        name: str,
+        argv: tuple[str, ...] = (),
+        *,
+        required_executable: str | None = None,
+        executable_override: str | None = None,
+        executable_requires_absolute: bool = False,
+    ) -> None:
+        super().__init__(
+            name=name,
+            argv=argv,
+            required_executable=required_executable,
+            executable_override=executable_override,
+            executable_requires_absolute=executable_requires_absolute,
+        )
 
     @property
     def command_line(self) -> str:
@@ -429,7 +447,12 @@ def thunderbolt_release_plan(config: HardwareToolchainConfig) -> tuple[ToolStep,
 
 
 def vivado_build_step(config: HardwareToolchainConfig) -> ToolStep:
-    return ToolStep("vivado-build", (config.vivado_executable, "-mode", "batch", "-source", str(config.project_tcl)))
+    return ToolStep(
+        "vivado-build",
+        (config.vivado_executable, "-mode", "batch", "-source", str(config.project_tcl)),
+        required_executable=config.vivado_executable,
+        executable_override="model.vivado",
+    )
 
 
 def stage_shell_step(*, source_shell_root: Path, work_root: Path) -> ToolStep:
@@ -508,7 +531,14 @@ def vivado_overlay_build_step(
         vivado_invocation=config.vivado_invocation,
         vivado_mount_root=config.vivado_mount_root,
     )
-    return ToolStep("vivado-overlay-build", ("bash", "-lc", script))
+    return ToolStep(
+        "vivado-overlay-build",
+        ("bash", "-lc", script),
+        required_executable=(
+            config.vivado_executable if config.vivado_invocation == "source-only" or Path(config.vivado_executable).is_absolute() else None
+        ),
+        executable_override="model.vivado",
+    )
 
 
 def validate_vivado_artifacts_step(
@@ -566,6 +596,8 @@ def thunderbolt_hold_step(config: HardwareToolchainConfig, *, dau_utils_root: Pa
         _runtime_pm_argv(config, "hold")
         if dau_utils_root is None
         else ("sh", "-c", _local_runtime_pm_script(config, "hold", dau_utils_root, python)),
+        required_executable=config.runtime_pm_executable if dau_utils_root is None else python,
+        executable_override="model.runtime_pm_executable" if dau_utils_root is None else "plan.python",
     )
 
 
@@ -575,6 +607,8 @@ def thunderbolt_release_step(config: HardwareToolchainConfig, *, dau_utils_root:
         _runtime_pm_argv(config, "release")
         if dau_utils_root is None
         else ("sh", "-c", _local_runtime_pm_script(config, "release", dau_utils_root, python)),
+        required_executable=config.runtime_pm_executable if dau_utils_root is None else python,
+        executable_override="model.runtime_pm_executable" if dau_utils_root is None else "plan.python",
     )
 
 
@@ -628,7 +662,13 @@ def pm_hold_device_step(config: HardwareToolchainConfig) -> ToolStep:
     # failure with the device present propagates — proceeding into a
     # reprogram without the PM hold is exactly the wedge class this guards
     script = f"if [ -e /sys/bus/pci/devices/{quoted_bdf} ]; then {hold}; else echo 'pm hold skipped (device absent)'; fi"
-    return _privileged_sh(config, "pm-hold-device", script)
+    return ToolStep(
+        "pm-hold-device",
+        (*config.privilege_prefix, "sh", "-c", script),
+        required_executable=config.runtime_pm_executable,
+        executable_override="model.runtime_pm_executable",
+        executable_requires_absolute=bool(config.privilege_prefix),
+    )
 
 
 def deadman_arm_step(config: HardwareToolchainConfig, *, timeout_s: int = 180) -> ToolStep:
@@ -636,13 +676,23 @@ def deadman_arm_step(config: HardwareToolchainConfig, *, timeout_s: int = 180) -
     matching disarm step runs ONLY on plan success: the executor stops on
     the first failure and never reaches it, so a wedge self-recovers by
     reboot to the SPI-resident design (timeout is SECONDS)."""
-    return ToolStep("deadman-arm", (config.deadman_executable, "arm", "--timeout", str(timeout_s)))
+    return ToolStep(
+        "deadman-arm",
+        (config.deadman_executable, "arm", "--timeout", str(timeout_s)),
+        required_executable=config.deadman_executable,
+        executable_override="model.deadman_executable",
+    )
 
 
 def deadman_disarm_step(config: HardwareToolchainConfig) -> ToolStep:
     # deliberately NOT named *release: the failure path's cleanup pass runs
     # only *release steps, and the deadman must stay armed on failure
-    return ToolStep("deadman-disarm", (config.deadman_executable, "disarm"))
+    return ToolStep(
+        "deadman-disarm",
+        (config.deadman_executable, "disarm"),
+        required_executable=config.deadman_executable,
+        executable_override="model.deadman_executable",
+    )
 
 
 def secondary_bus_reset_step(config: HardwareToolchainConfig) -> ToolStep:
@@ -773,12 +823,30 @@ def _run_plan_steps(steps: Sequence[ToolStep]) -> int:
     return 0
 
 
+def _require_step_executables(steps: Sequence[ToolStep]) -> None:
+    for step in steps:
+        executable = step.required_executable
+        if executable is None:
+            continue
+        if step.executable_requires_absolute and not Path(executable).is_absolute():
+            raise RuntimeError(
+                f"required executable {executable!r} for plan step {step.name!r} cannot be safely resolved "
+                f"through its privileged command prefix; set {step.executable_override}=<absolute-path>"
+            )
+        if shutil.which(executable) is None:
+            raise RuntimeError(
+                f"required executable {executable!r} for plan step {step.name!r} could not be resolved; "
+                f"set {step.executable_override}=<absolute-path>"
+            )
+
+
 def execute_plan_steps(steps: Sequence[ToolStep], *, endpoint_bdf: str | None = None) -> int:
     """Run a hardware plan's steps in order. When ``endpoint_bdf`` is given,
     the whole run is serialized under an advisory lock keyed on that device
     (a board is one exclusive resource: no two plan runs from the operator's
     processes may remove/reset/program the same endpoint at once). Without it
     (a device-less plan) the steps run unserialized."""
+    _require_step_executables(steps)
     if endpoint_bdf is None:
         return _run_plan_steps(steps)
     import fcntl

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -66,7 +66,12 @@ class OpenFpgaLoaderProgrammer(Programmer):
     def detect_step(self, config: HardwareToolchainConfig) -> ToolStep:
         from dau_build.hardware_plan import ToolStep
 
-        return ToolStep("jtag-detect", (self.executable, "-c", self._cable(config), "--detect"))
+        return ToolStep(
+            "jtag-detect",
+            (self.executable, "-c", self._cable(config), "--detect"),
+            required_executable=self.executable,
+            executable_override="programmer.executable" if config.programmer is self else "model.openfpgaloader",
+        )
 
     def program_step(self, config: HardwareToolchainConfig, *, mode: Literal["volatile", "persistent"] = "volatile") -> ToolStep:
         from dau_build.hardware_plan import ToolStep
@@ -78,8 +83,18 @@ class OpenFpgaLoaderProgrammer(Programmer):
                     "configuration memory-dead (the boot sequence needs the cfgmem-written image); use the "
                     "vivado cfgmem path (the flash plan's flash.tcl) or a volatile SRAM program"
                 )
-            return ToolStep("program-persistent", (self.executable, "-c", self._cable(config), "-f", str(config.bitstream)))
-        return ToolStep("program-volatile", (self.executable, "-c", self._cable(config), str(config.bitstream)))
+            return ToolStep(
+                "program-persistent",
+                (self.executable, "-c", self._cable(config), "-f", str(config.bitstream)),
+                required_executable=self.executable,
+                executable_override="programmer.executable" if config.programmer is self else "model.openfpgaloader",
+            )
+        return ToolStep(
+            "program-volatile",
+            (self.executable, "-c", self._cable(config), str(config.bitstream)),
+            required_executable=self.executable,
+            executable_override="programmer.executable" if config.programmer is self else "model.openfpgaloader",
+        )
 
 
 class VivadoHwServerProgrammer(Programmer):
@@ -115,7 +130,14 @@ class VivadoHwServerProgrammer(Programmer):
             vivado_executable=config.vivado_executable,
             vivado_invocation=config.vivado_invocation,
         )
-        return ToolStep("flash", ("bash", "-lc", script))
+        return ToolStep(
+            "flash",
+            ("bash", "-lc", script),
+            required_executable=(
+                config.vivado_executable if config.vivado_invocation == "source-only" or Path(config.vivado_executable).is_absolute() else None
+            ),
+            executable_override="model.vivado",
+        )
 
 
 for _programmer_cls in (Programmer, OpenFpgaLoaderProgrammer, VivadoHwServerProgrammer):

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1760,6 +1760,65 @@ def test_sram_program_plan_composes_from_the_config_group(tmp_path: Path) -> Non
     assert "deadman-arm" in result.message and "secondary-bus-reset" not in result.message.split("deadman-arm")[0]
 
 
+def test_hardware_plan_task_deadman_executable_is_cli_overridable(tmp_path: Path) -> None:
+    result = run_request_config(
+        "task",
+        "tasks/hardware/hardware-plan",
+        overrides=["plan=plans/sram-program", "platform=platforms/dau/dpv1", "model.deadman_executable=/opt/dau/bin/deadman"],
+        model_values={"work_root": str(tmp_path), "bitstream": "/tmp/design.bit"},
+    )
+    assert "deadman-arm\t/opt/dau/bin/deadman arm --timeout 180" in result.message
+    assert "deadman-disarm\t/opt/dau/bin/deadman disarm" in result.message
+
+
+def test_execute_refuses_missing_deadman_before_any_step(monkeypatch, tmp_path: Path) -> None:
+    missing = "/missing/dau-utils-deadman"
+    config = _bench_config(
+        work_root=tmp_path,
+        bitstream_path=Path("/tmp/design.bit"),
+        deadman_executable=missing,
+    )
+    steps = hardware_plan.SramProgramPlan().compose(config)
+
+    monkeypatch.setattr("shutil.which", lambda executable: None if executable == missing else f"/resolved/{executable}")
+
+    def fail_run(*args, **kwargs):
+        pytest.fail("no plan step may run before executable preflight succeeds")
+
+    monkeypatch.setattr(hardware_plan.subprocess, "run", fail_run)
+    with pytest.raises(RuntimeError) as exc_info:
+        hardware_plan.execute_plan_steps(steps)
+
+    message = str(exc_info.value)
+    assert missing in message
+    assert "deadman-arm" in message
+    assert "model.deadman_executable" in message
+
+
+def test_execute_refuses_bare_runtime_pm_executable_under_sudo(monkeypatch, tmp_path: Path) -> None:
+    executable = "dau-utils-pci-runtime-pm"
+    config = _bench_config(
+        work_root=tmp_path,
+        bitstream_path=Path("/tmp/design.bit"),
+        runtime_pm_executable=executable,
+        privilege_prefix=("sudo",),
+    )
+    steps = hardware_plan.SramProgramPlan().compose(config)
+
+    # Finding the script in the user's virtualenv does not make it visible
+    # under sudo's secure_path.
+    monkeypatch.setattr("shutil.which", lambda candidate: f"/home/operator/.venv/bin/{candidate}")
+    monkeypatch.setattr(hardware_plan.subprocess, "run", lambda *args, **kwargs: pytest.fail("no plan step may run"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        hardware_plan.execute_plan_steps(steps)
+
+    message = str(exc_info.value)
+    assert executable in message
+    assert "pm-hold-device" in message
+    assert "model.runtime_pm_executable" in message
+
+
 def test_hardware_plan_task_privilege_prefix_is_cli_overridable(tmp_path: Path) -> None:
     """`model.privilege_prefix` must be declared in the packaged task config so
     Hydra's struct mode accepts the override (e.g. clear it to run as root)."""


### PR DESCRIPTION
Hit for real on nuc2: the sanctioned volatile flash failed twice with a
bare exit 127. The plan invokes console scripts by name, several inside
`sudo sh -c`, and sudo resets PATH to secure_path — so a venv-installed
script is not found. Prepending the venv to PATH does not help the sudo'd
steps.

Worse, `deadman_executable` was not exposed on the task at all (while
`runtime_pm_executable` was), so on a host where the deadman is not on the
root PATH there was NO way to configure the SAFETY mechanism through the
composed task. A user who hits 127 at deadman-arm and works around it by
hand does the destructive part unprotected.

Steps now declare the executable they need and the override that sets it,
and a preflight refuses before ANY step runs — distinguishing "bare
executable under a privileged prefix" from "not resolvable at all", and
naming the executable, the step, and the override in both cases.

Plan step ORDER is unchanged: deadman-arm still precedes the destructive
steps, which is what made the original failure safe, and a test pins it.