### PR TITLE
Freeze nested configuration models

### DIFF
--- a/dau_build/build_spec.py
+++ b/dau_build/build_spec.py
@@ -70,6 +70,8 @@ class BuildSpec(BaseModel):
     ``DauBuildSpec`` the build tasks consume; the two are deliberately
     separate (config vs domain object)."""
 
+    model_config = ConfigDict(frozen=True)
+
     name: _NonEmptyStr
     top_name: _NonEmptyStr
     platform: _NonEmptyStr

--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -21,7 +21,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from ccflow import BaseModel
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from dau_build.platforms import PlatformDefinition
 
@@ -63,6 +63,8 @@ class MmJobShellRequest(BaseModel):
     override; ``resolved_part`` is what the project builds with). Staging
     addresses are plain values; DAU flows pass their register-contract
     numbers."""
+
+    model_config = ConfigDict(frozen=True)
 
     output_root: Path
     hdl_sources: tuple[Path, ...]

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from ccflow import BaseModel
+from pydantic import ConfigDict
 
 from dau_build.vivado_backend import (
     VivadoBackendArtifactValidation,
@@ -71,6 +72,8 @@ class ToolStep(BaseModel):
 
 
 class HardwareToolchainConfig(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     work_root: Path
     bitstream_path: Path | None = None
     vivado_executable: str = "vivado"

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -62,6 +62,8 @@ class XdmaPersonality(BaseModel):
 class ResourceBudget(BaseModel):
     """Placeable capacity of a platform, in ``ResourceEnvelope`` units."""
 
+    model_config = ConfigDict(frozen=True)
+
     lut: int
     ff: int
     bram36: float
@@ -158,6 +160,8 @@ class HostAccess(BaseModel):
     hardware plans probe and the programming cable. These are measured
     bench facts (BDFs, bridge rescan order, runtime-PM device patterns) —
     board/host configuration, not code defaults."""
+
+    model_config = ConfigDict(frozen=True)
 
     pci_id: str
     endpoint_bdf: str

--- a/dau_build/programmers.py
+++ b/dau_build/programmers.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from ccflow import BaseModel
+from pydantic import ConfigDict
 
 from dau_build.vivado_backend import flash_script as vivado_flash_script
 
@@ -38,6 +39,8 @@ class Programmer(BaseModel):
     (``None`` when the programmer has none); ``program_step`` produces the
     configuration step (volatile by default, ``mode="persistent"`` for a
     non-volatile write)."""
+
+    model_config = ConfigDict(frozen=True)
 
     name: str
 

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1492,12 +1492,21 @@ def test_toolchain_config_composes_from_platform_host_access() -> None:
     )
 
     # a board with different access data changes the plans through config alone
-    other = dpv1_platform().model_copy(deep=True)
-    other.host_access.pci_id = "10ee:9038"
-    other.host_access.endpoint_bdf = "0000:65:00.0"
-    other.host_access.rescan_bdfs = ("0000:64:00.0",)
-    other.host_access.runtime_pm_patterns = ("Acme",)
-    other.host_access.jtag_cable = "ft4232"
+    other = dpv1_platform()
+    assert other.host_access is not None
+    other = other.model_copy(
+        update={
+            "host_access": other.host_access.model_copy(
+                update={
+                    "pci_id": "10ee:9038",
+                    "endpoint_bdf": "0000:65:00.0",
+                    "rescan_bdfs": ("0000:64:00.0",),
+                    "runtime_pm_patterns": ("Acme",),
+                    "jtag_cable": "ft4232",
+                }
+            )
+        }
+    )
     config = HardwareToolchainConfig.for_platform(other, work_root=Path("/w"))
     steps = recovery_plan(config)
     by_name = {step.name: step for step in steps}
@@ -1626,9 +1635,9 @@ def test_host_access_is_explicit_about_bdfs_and_patterns() -> None:
         HostAccess(pci_id="10ee:9038", endpoint_bdf="0000:65:00.0")
 
     # empty tuples are authoritative — never silently the dpv1 defaults
-    bare = dpv1_platform().model_copy(deep=True)
-    bare.host_access.rescan_bdfs = ()
-    bare.host_access.runtime_pm_patterns = ()
+    bare = dpv1_platform()
+    assert bare.host_access is not None
+    bare = bare.model_copy(update={"host_access": bare.host_access.model_copy(update={"rescan_bdfs": (), "runtime_pm_patterns": ()})})
     config = HardwareToolchainConfig.for_platform(bare, work_root=Path("/w"))
     steps = recovery_plan(config)
     by_name = {step.name: step for step in steps}

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -36,6 +36,22 @@ def test_dpv1_round_trips_through_model_serialization() -> None:
     assert PlatformDefinition.model_validate(platform.model_dump()) == platform
 
 
+def test_composed_platform_nested_config_is_frozen() -> None:
+    platform = dpv1_platform()
+    original_lut = platform.budget.lut
+    with pytest.raises(ValidationError, match="frozen"):
+        platform.budget.lut = original_lut + 1
+    assert platform.budget.lut == original_lut
+
+    access = platform.host_access
+    assert access is not None
+    assert isinstance(access.rescan_bdfs, tuple)
+    original_rescan_bdfs = access.rescan_bdfs
+    with pytest.raises(TypeError):
+        access.rescan_bdfs[0] = "0000:ff:00.0"  # type: ignore[index]
+    assert access.rescan_bdfs == original_rescan_bdfs
+
+
 def test_round_trip_preserves_personality_and_constraints() -> None:
     platform = PlatformDefinition(
         name="probe",

--- a/dau_build/vivado_backend.py
+++ b/dau_build/vivado_backend.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import Literal
 
 from ccflow import BaseModel
-from pydantic import field_validator
+from pydantic import ConfigDict, field_validator
 
 from dau_build.artifact_bundle import ArtifactBundle, ArtifactBundleError, load_artifact_bundle
 
@@ -38,6 +38,8 @@ DEFAULT_STAGE_TASK_NAME = "stage-vivado-overlay"
 
 
 class VivadoBackendRequest(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     dau_core_hdl_root: Path
     build_root: Path
     dau_artifact_bundle_path: Path | None = None


### PR DESCRIPTION
Top-level config and spec models were frozen, but their nested models were not — a composed platform's `ResourceBudget` could be reassigned after construction. A composed platform is shared configuration, so a task mutating a nested budget means two tasks in one process can disagree about the board.

Frozen: `ResourceBudget`, `HostAccess`, `BuildSpec`, `HardwareToolchainConfig`, `VivadoBackendRequest`, `Programmer` (and subclasses), `MmJobShellRequest`.

Freezing only blocks attribute reassignment, so the regression also asserts the nested containers: `host_access.rescan_bdfs` is a tuple and rejects item assignment. Sequence fields were already tuples throughout, so no container conversions were needed.

Two test fixtures mutated `HostAccess` after construction; they now use `model_copy(update=...)`.

Verified the regression is load-bearing by removing just the `ResourceBudget` freeze — the test fails — then reverting. `dau_build/tests/test_counter.py` fails identically on clean main (a local Verilator 5.050 issue in `counter.sv`) and is unrelated.