### PR TITLE
Select drift points per board and name the effective job clock

### DIFF
--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -247,8 +247,23 @@ class PlatformDefinition(BaseModel):
     # by what has closed timing on the part — a build request outside the
     # list is refused before any tool runs.
     width_tiers: tuple[int, ...] = (64,)
+    # job_clock_mhz is a CONVERSION REQUEST, not a frequency fact: its
+    # presence makes the shell insert a clock converter and run the job logic
+    # at this rate; its absence means the job inherits the XDMA axi_aclk
+    # unconverted. dpv1 deliberately leaves it None and still runs at 125.
+    # Anything that needs the actual frequency (pricing against measured
+    # resource points, rate models) must ask effective_job_clock_mhz().
     job_clock_mhz: int | None = None
     placeholders: tuple[str, ...] = ()
+
+    def effective_job_clock_mhz(self) -> int:
+        """The frequency the job logic actually runs at: ``job_clock_mhz``
+        when a converter is requested, otherwise the XDMA ``axi_aclk`` the
+        job inherits (125 on dpv1's Gen2 x4 personality). This is the clock
+        to price and rate-model against; ``job_clock_mhz`` alone cannot
+        answer that question because ``None`` there means "unconverted", not
+        "unknown"."""
+        return self.job_clock_mhz or self.host_link.xdma_personality.axi_clock_mhz()
 
     @field_validator("name", "part")
     @classmethod

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -210,10 +210,20 @@ class SynthesizeCoresTask(BuildCallableModel):
             # an envelope is registered for the DEFAULT parameters; an
             # overridden build is a different shape, not drift
             compare=definition.name not in self.parameters,
+            part=self._part(),
+            clock_period_ns=self.clock_period_ns,
         )
 
     @staticmethod
-    def parse_reports(definition, *, output_root: Path, clocked: bool = True, compare: bool = True) -> CoreEnvelopeReport:
+    def parse_reports(
+        definition,
+        *,
+        output_root: Path,
+        clocked: bool = True,
+        compare: bool = True,
+        part: str | None = None,
+        clock_period_ns: float | None = None,
+    ) -> CoreEnvelopeReport:
         """Parse a core's utilization (and, when clocked, timing) reports into
         an envelope report, comparing against the registered envelope only
         when the build used the registered (default) parameters."""
@@ -231,10 +241,23 @@ class SynthesizeCoresTask(BuildCallableModel):
                 raise BuildStepError(f"no slack line in {definition.module}.timing.rpt")
             wns = float(slack.group(2)) if slack.group(1) == "MET" else -abs(float(slack.group(2)))
             met = slack.group(1) == "MET"
+        # Drift is checked against the point measured for THIS part and clock.
+        # A core may carry several measurement points; comparing against
+        # another part's numbers is the cross-part fallback the registry
+        # exists to prevent, so an unmeasured coordinate reports "no
+        # comparison" rather than a mismatch against the wrong board.
         registered = definition.resources
         matches = None
         if compare and registered is not None:
-            matches = (registered.lut, registered.ff, registered.bram36, registered.dsp) == (lut, ff, bram, dsp)
+            if isinstance(registered, (list, tuple)):
+                point = next(
+                    (m for m in registered if m.part == part and (clock_period_ns is None or m.clock_ns == clock_period_ns)),
+                    None,
+                )
+            else:
+                point = registered
+            if point is not None:
+                matches = (point.lut, point.ff, point.bram36, point.dsp) == (lut, ff, bram, dsp)
         return CoreEnvelopeReport(
             name=definition.name,
             module=definition.module,

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -287,3 +287,15 @@ def test_dpv1_host_access_pins_the_proven_bench_facts() -> None:
     assert access.runtime_pm_patterns == ("Thunderbolt", "JHL", "10ee:7011", "Xilinx")
     assert access.runtime_pm_executable == "dau-utils-pci-runtime-pm"
     assert access.jtag_cable == "digilent_hs2"
+
+
+def test_effective_job_clock_distinguishes_conversion_from_frequency() -> None:
+    # job_clock_mhz's PRESENCE requests a clock converter; its ABSENCE means
+    # the job inherits axi_aclk, not that the frequency is unknown. dpv1
+    # leaves it None deliberately and still runs at 125 MHz.
+    platform = dpv1_platform()
+    assert platform.job_clock_mhz is None  # no converter on dpv1
+    assert platform.effective_job_clock_mhz() == 125  # but the frequency is known
+
+    converted = platform.model_copy(update={"job_clock_mhz": 150})
+    assert converted.effective_job_clock_mhz() == 150  # a converter overrides

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -89,13 +89,13 @@ def test_parse_reports_builds_envelope_and_flags_drift(tmp_path: Path) -> None:
     definition = core("int32-streaming-top-k")
     (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT)
     (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text(_TIMING_RPT)
-    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path)
+    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, part="xc7a200tfbg484-2", clock_period_ns=8.0)
     assert (report.lut, report.ff, report.bram36, report.dsp) == (1295, 1196, 0.0, 0)
     assert report.wns_ns == 4.350 and report.met
     assert report.registered_matches is True  # the registered envelope came from this shape
 
     (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT.replace("1295", "999"))
-    drifted = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path)
+    drifted = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, part="xc7a200tfbg484-2", clock_period_ns=8.0)
     assert drifted.registered_matches is False
 
 


### PR DESCRIPTION
Two changes the measurement-point migration needs:

**Drift checks compare per board.** `synthesize-cores` read `resources` as a single envelope (crashing on list form) and compared against whatever was registered regardless of part. It now selects the point measured for the part and clock being synthesized; an unmeasured coordinate reports no-comparison rather than a mismatch against another board's numbers.

**`effective_job_clock_mhz()` separates the frequency fact from the conversion request.** `job_clock_mhz`'s presence makes the shell insert a clock converter; its absence means the job inherits the XDMA `axi_aclk` — dpv1 deliberately leaves it `None` and still runs at 125 MHz. Pricing needs the actual frequency, which that field alone cannot answer. Declaring 125 on dpv1 directly was tried and correctly rejected by the no-conversion shell test — it would have silently changed dpv1 hardware builds. The accessor resolves: converted rate when requested, else the personality's `axi_aclk`.