### PR TITLE
Deep-freeze the platform tree and single-source the swizzle

### DIFF
--- a/dau_build/dpv1_shell.py
+++ b/dau_build/dpv1_shell.py
@@ -25,11 +25,6 @@ from pydantic import ConfigDict, Field, model_validator
 
 from dau_build.platforms import PlatformDefinition
 
-DPV1_PART = "xc7a200tfbg484-2"
-
-# lane index -> GTPE2 channel site (reversed lane order on the DAU platform variant 1 (dpv1))
-GT_LANE_SWIZZLE = ((3, "GTPE2_CHANNEL_X0Y7"), (0, "GTPE2_CHANNEL_X0Y6"), (2, "GTPE2_CHANNEL_X0Y5"), (1, "GTPE2_CHANNEL_X0Y4"))
-
 
 # The platform (part, the 47 value_src=user XCI personality parameters
 # applied verbatim — a hand-picked subset is memory-dead on hardware —
@@ -40,12 +35,6 @@ def _dpv1_platform() -> PlatformDefinition:
     from dau_build.config import resolve_platform
 
     return resolve_platform("platforms/dau/dpv1")
-
-
-def _default_platform() -> PlatformDefinition:
-    """A fresh dpv1 platform per request (the resolved config is cached, the
-    instance is copied so no two requests share a mutable default)."""
-    return _dpv1_platform().model_copy(deep=True)
 
 
 def dpv1_xdma_personality():
@@ -70,7 +59,7 @@ class MmJobShellRequest(BaseModel):
     hdl_sources: tuple[Path, ...]
     generated_sources: tuple[tuple[str, str], ...]
     top_module: str
-    platform: PlatformDefinition = Field(default_factory=_default_platform)
+    platform: PlatformDefinition = Field(default_factory=_dpv1_platform)
     part: str | None = None
     input_buffer_address: int = 0x0000_0000
     output_buffer_address: int = 0x0010_0000
@@ -100,7 +89,7 @@ class MmDdrJobShellRequest(BaseModel):
     generated_sources: tuple[tuple[str, str], ...]
     top_module: str
     mig_prj: Path
-    platform: PlatformDefinition = Field(default_factory=_default_platform)
+    platform: PlatformDefinition = Field(default_factory=_dpv1_platform)
     part: str | None = None
     register_window_offset: int = 0x0000_1000
     xadc_window_offset: int = 0x0001_0000
@@ -145,7 +134,9 @@ def _gt_channel_ref_name(lane_placements: tuple[tuple[int, str], ...]) -> str:
     return lane_placements[0][1].rsplit("_X", 1)[0]
 
 
-def gt_lane_swizzle_hook_tcl(lane_placements: tuple[tuple[int, str], ...] = GT_LANE_SWIZZLE) -> str:
+def gt_lane_swizzle_hook_tcl(
+    lane_placements: tuple[tuple[int, str], ...] = _dpv1_platform().lane_placements,
+) -> str:
     """Pre-opt_design hook applying the platform's lane swizzle (default: the
     DAU platform variant 1 (dpv1) mapping), version-robust across XDMA
     internal hierarchy renames. The GT channel family (GTP/GTX) is derived

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -19,10 +19,12 @@ public/private wall.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Literal, Protocol
 
 from ccflow import BaseModel
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_serializer, field_validator
 
 _PCIE_LANE_WIDTHS = (1, 2, 4, 8, 16)
 
@@ -36,7 +38,18 @@ class XdmaPersonality(BaseModel):
     keeping it here (not inline in the shell generator) makes it reusable
     across platforms."""
 
-    params: dict[str, str] = Field(default_factory=dict)
+    model_config = ConfigDict(frozen=True)
+
+    params: Mapping[str, str] = Field(default_factory=lambda: MappingProxyType({}))
+
+    @field_validator("params")
+    @classmethod
+    def _freeze_params(cls, value: Mapping[str, str]) -> Mapping[str, str]:
+        return MappingProxyType(dict(value))
+
+    @field_serializer("params")
+    def _serialize_params(self, value: Mapping[str, str]) -> dict[str, str]:
+        return dict(value)
 
     def to_tcl_config(self, *, indent: str = "    ") -> str:
         return " \\\n".join(f"{indent}CONFIG.{key} {{{value}}}" for key, value in self.params.items())
@@ -86,6 +99,8 @@ class HostLink(BaseModel):
     over Thunderbolt despite the X4 personality) — bring-up checks compare
     against these, not the electrical maximum."""
 
+    model_config = ConfigDict(frozen=True)
+
     interface: str
     pcie_lanes: int
     xdma_personality: XdmaPersonality = Field(default_factory=XdmaPersonality)
@@ -126,6 +141,8 @@ class PlatformMemory(BaseModel):
     carries the memory system's additions to the board pin constraints
     (IOSTANDARDs for the controller reference clock, calibration LEDs —
     pin placement stays in the MIG ``.prj``)."""
+
+    model_config = ConfigDict(frozen=True)
 
     kind: str
     size_bytes: int

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from pathlib import Path
 
 from dau_build.dpv1_shell import (
-    GT_LANE_SWIZZLE,
     MmDdrJobShellRequest,
     MmJobShellRequest,
     _lane_swizzle_verify_tcl,
@@ -99,8 +98,10 @@ def test_project_tcl_embeds_personality_staging_and_hook(tmp_path: Path) -> None
 
 
 def test_swizzle_hook_covers_all_lanes() -> None:
+    from dau_build.platforms import dpv1_platform
+
     text = gt_lane_swizzle_hook_tcl()
-    for lane, channel in GT_LANE_SWIZZLE:
+    for lane, channel in dpv1_platform().lane_placements:
         assert channel in text
     assert "expected 4 GTPE2_CHANNEL lane cells" in text
     assert "reset_property" in text
@@ -217,6 +218,14 @@ def _probe_platform(**overrides):
     return PlatformDefinition(**base)
 
 
+def _with_xdma_params(platform, **updates):
+    from dau_build.platforms import XdmaPersonality
+
+    personality = XdmaPersonality(params={**platform.host_link.xdma_personality.params, **updates})
+    host_link = platform.host_link.model_copy(update={"xdma_personality": personality})
+    return platform.model_copy(update={"host_link": host_link})
+
+
 def test_constraints_match_committed_goldens() -> None:
     """Moving the pin constraints from code into the dpv1 platform config
     must not change a byte of the emitted XDC."""
@@ -272,7 +281,9 @@ def test_request_part_resolves_from_the_platform(tmp_path: Path) -> None:
     assert swapped.resolved_part == "xc7k325tffg900-2"
 
 
-def test_default_platform_instances_are_not_shared(tmp_path: Path) -> None:
+def test_default_platform_is_safely_shared(tmp_path: Path) -> None:
+    import pytest as _pytest
+
     tile = tmp_path / "stream_tile.sv"
     tile.write_text("module stream_tile; endmodule\n")
     common = {
@@ -282,8 +293,10 @@ def test_default_platform_instances_are_not_shared(tmp_path: Path) -> None:
         "top_module": "my_mm_top",
     }
     first = MmJobShellRequest(**common)
-    first.platform.host_link.xdma_personality.params["plltype"] = "TAMPERED"
     second = MmJobShellRequest(**common)
+    assert first.platform is second.platform
+    with _pytest.raises(TypeError):
+        first.platform.host_link.xdma_personality.params["plltype"] = "TAMPERED"  # type: ignore[index]
     assert second.platform.host_link.xdma_personality.params["plltype"] == "QPLL1"
 
 
@@ -303,8 +316,7 @@ def test_job_clock_convert_wraps_the_bram_shell(tmp_path: Path) -> None:
     """A platform with ``job_clock_mhz`` runs the job top in its own MMCM-derived
     clock domain: the register aperture crosses inside smc_lite (NUM_CLKS 2) and
     the staging BRAMs stay on axi_aclk (the true-dual-port RAM is the crossing)."""
-    platform = _probe_platform(job_clock_mhz=125)
-    platform.host_link.xdma_personality.params["axisten_freq"] = "250"
+    platform = _with_xdma_params(_probe_platform(job_clock_mhz=125), axisten_freq="250")
     request = _request(tmp_path).model_copy(update={"platform": platform})
     text = mm_job_shell_project_tcl(request)
     # the job clock domain: MMCM from axi_aclk, synchronized reset
@@ -324,8 +336,7 @@ def test_job_clock_convert_wraps_the_bram_shell(tmp_path: Path) -> None:
 def test_job_clock_convert_wraps_the_ddr_shell(tmp_path: Path) -> None:
     """The DDR shell gains the job domain as a third smartconnect clock next
     to the memory controller's ui_clk; the XADC stays on axi_aclk."""
-    platform = _probe_platform(job_clock_mhz=125)
-    platform.host_link.xdma_personality.params["axisten_freq"] = "250"
+    platform = _with_xdma_params(_probe_platform(job_clock_mhz=125), axisten_freq="250")
     request = _ddr_request(tmp_path).model_copy(update={"platform": platform})
     text = mm_ddr_job_shell_project_tcl(request)
     assert "CONFIG.NUM_SI {2} CONFIG.NUM_MI {1} CONFIG.NUM_CLKS {3}" in text

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -43,6 +43,17 @@ def test_composed_platform_nested_config_is_frozen() -> None:
         platform.budget.lut = original_lut + 1
     assert platform.budget.lut == original_lut
 
+    with pytest.raises(ValidationError, match="frozen"):
+        platform.host_link.pcie_lanes = 8
+    with pytest.raises(ValidationError, match="frozen"):
+        platform.memory.size_bytes = 2 << 30
+    with pytest.raises(ValidationError, match="frozen"):
+        platform.host_link.xdma_personality.params = {}
+    with pytest.raises(TypeError):
+        platform.host_link.xdma_personality.params["plltype"] = "TAMPERED"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        XdmaPersonality().params["plltype"] = "TAMPERED"  # type: ignore[index]
+
     access = platform.host_access
     assert access is not None
     assert isinstance(access.rescan_bdfs, tuple)
@@ -196,12 +207,10 @@ def test_max_lanes_bram_arithmetic_is_exact() -> None:
 
 
 def test_dpv1_platform_is_the_single_source_for_the_shell() -> None:
-    from dau_build.dpv1_shell import DPV1_PART, GT_LANE_SWIZZLE, dpv1_constraints_xdc, dpv1_ddr_constraints_xdc, dpv1_xdma_personality
+    from dau_build.dpv1_shell import dpv1_constraints_xdc, dpv1_ddr_constraints_xdc, dpv1_xdma_personality, gt_lane_swizzle_hook_tcl
 
     platform = dpv1_platform()
     assert len(platform.host_link.xdma_personality.params) == 47
-    # part stays a shell constant (request default); the config must not drift
-    assert platform.part == DPV1_PART
     # lane count is consistent with the personality's link width
     assert platform.host_link.pcie_lanes == platform.host_link.xdma_personality.link_width() == 4
     # the proven host trains x2 at 5.0 GT/s over Thunderbolt
@@ -210,9 +219,8 @@ def test_dpv1_platform_is_the_single_source_for_the_shell() -> None:
     assert platform.memory.mig_prj == "dpv1_mig.prj"
     # the shell's personality accessor resolves the same config
     assert dpv1_xdma_personality() == platform.host_link.xdma_personality
-    # the lane swizzle and pin constraints are platform data; the shell
-    # constants/accessors must not drift from the config
-    assert platform.lane_placements == GT_LANE_SWIZZLE
+    # the default hook reads the lane swizzle from the platform
+    assert gt_lane_swizzle_hook_tcl() == gt_lane_swizzle_hook_tcl(platform.lane_placements)
     assert dpv1_constraints_xdc().endswith(platform.constraints_xdc)
     assert dpv1_ddr_constraints_xdc().endswith(platform.memory.constraints_xdc)
     # dpv1 is hardware-proven: no placeholder values


### PR DESCRIPTION
Two findings from the final standards audit.

**The platform tree is now immutable all the way down.** `PlatformDefinition` was frozen, but `HostLink`, `PlatformMemory`, and `XdmaPersonality` were not — and `XdmaPersonality.params` was a mutable dict regardless, since `frozen` never protects container contents. `dpv1_shell` paid for this with a defensive `model_copy(deep=True)` on every request. Frozen now, with `params` behind a read-only mapping (mutation raises `TypeError`; serialization still round-trips as a plain dict — verified `model_validate(model_dump())` equality). The deep copy is deleted and the cached platform singleton is shared safely.

**Duplicated board facts cut**: `DPV1_PART` had no production use; `GT_LANE_SWIZZLE` duplicated the composed platform's `lane_placements`, with a test verifying the two sources *agreed* rather than there being one source. The platform now is the source, and the test asserts it is used.

Verified independently: nested mutation raises on every level. 386 passed.