### PR TITLE
Declare storage tiers on the platform

### DIFF
--- a/dau_build/config/platform/platforms/dau/dpv1.yaml
+++ b/dau_build/config/platform/platforms/dau/dpv1.yaml
@@ -114,23 +114,31 @@ host_access:
     - Xilinx
   runtime_pm_executable: dau-utils-pci-runtime-pm
   jtag_cable: digilent_hs2
-memory:
-  _target_: dau_build.platforms.PlatformMemory
-  kind: ddr3
-  size_bytes: 1073741824
-  mig_prj: dpv1_mig.prj
-  bandwidth_bytes_per_s: 1600000000
-  # the memory system's additions to the board XDC: the controller's 200 MHz
-  # reference IOSTANDARD (pin placement lives in the MIG .prj) and the
-  # calibration-complete LED
-  constraints_xdc: |
-    set_property IOSTANDARD LVDS_25 [get_ports sys_clk_clk_p]
-    set_property IOSTANDARD LVDS_25 [get_ports sys_clk_clk_n]
+storage_tiers:
+  - _target_: dau_build.platforms.StorageTier
+    name: bram
+    technology: bram
+    capacity_bytes: 1543680   # 335 BRAM36 x 4608 B, the budgeted envelope
+    access: owned
+  - _target_: dau_build.platforms.StorageTier
+    name: ddr
+    technology: ddr
+    # single x16 DDR3-800, ~970 MB/s effective feed measured; 1 GiB
+    capacity_bytes: 1073741824
+    access: shared
+    mig_prj: dpv1_mig.prj
+    bandwidth_bytes_per_s: 1600000000
+    # the memory system's additions to the board XDC: the controller's 200 MHz
+    # reference IOSTANDARD (pin placement lives in the MIG .prj) and the
+    # calibration-complete LED
+    constraints_xdc: |
+      set_property IOSTANDARD LVDS_25 [get_ports sys_clk_clk_p]
+      set_property IOSTANDARD LVDS_25 [get_ports sys_clk_clk_n]
 
-    set_property PACKAGE_PIN H4 [get_ports LED_A4]
-    set_property IOSTANDARD LVCMOS33 [get_ports LED_A4]
-    set_property PULLUP true [get_ports LED_A4]
-    set_property DRIVE 8 [get_ports LED_A4]
+      set_property PACKAGE_PIN H4 [get_ports LED_A4]
+      set_property IOSTANDARD LVCMOS33 [get_ports LED_A4]
+      set_property PULLUP true [get_ports LED_A4]
+      set_property DRIVE 8 [get_ports LED_A4]
 host_link:
   _target_: dau_build.platforms.HostLink
   interface: pcie-xdma

--- a/dau_build/platforms.py
+++ b/dau_build/platforms.py
@@ -24,7 +24,7 @@ from types import MappingProxyType
 from typing import Literal, Protocol
 
 from ccflow import BaseModel
-from pydantic import ConfigDict, Field, field_serializer, field_validator
+from pydantic import ConfigDict, Field, field_serializer, field_validator, model_validator
 
 _PCIE_LANE_WIDTHS = (1, 2, 4, 8, 16)
 
@@ -136,40 +136,29 @@ class HostLink(BaseModel):
         return value
 
 
-class PlatformMemory(BaseModel):
-    """The device-side memory a design stages through. ``constraints_xdc``
-    carries the memory system's additions to the board pin constraints
-    (IOSTANDARDs for the controller reference clock, calibration LEDs —
-    pin placement stays in the MIG ``.prj``)."""
+StorageTechnology = Literal["bram", "ddr", "spi-flash", "nvme", "sata"]
+StorageAccess = Literal["owned", "shared"]
+
+
+class StorageTier(BaseModel):
+    """One declared storage tier of a platform's inventory. ``owned`` tiers
+    back private single-cycle arenas; ``shared`` tiers sit behind handle-based
+    transactions. Far technologies are schema-legal and HDL-absent until their
+    tripwire fires (STORAGE_AND_NOC.md). ``constraints_xdc`` carries the
+    memory system's additions to the board pin constraints (IOSTANDARDs for
+    the controller reference clock, calibration LEDs — pin placement stays in
+    the MIG ``.prj``)."""
 
     model_config = ConfigDict(frozen=True)
 
-    kind: str
-    size_bytes: int
+    name: str = Field(min_length=1)
+    technology: StorageTechnology
+    capacity_bytes: int = Field(gt=0)
+    access: StorageAccess
+    persistent: bool = False
+    bandwidth_bytes_per_s: int | None = Field(default=None, gt=0)
     mig_prj: str | None = None
-    bandwidth_bytes_per_s: int | None = None
     constraints_xdc: str = ""
-
-    @field_validator("kind")
-    @classmethod
-    def _kind_nonempty(cls, value: str) -> str:
-        if not value:
-            raise ValueError("memory kind must be non-empty")
-        return value
-
-    @field_validator("size_bytes")
-    @classmethod
-    def _size_positive(cls, value: int) -> int:
-        if value <= 0:
-            raise ValueError("memory size_bytes must be positive")
-        return value
-
-    @field_validator("bandwidth_bytes_per_s")
-    @classmethod
-    def _bandwidth_positive(cls, value: int | None) -> int | None:
-        if value is not None and value <= 0:
-            raise ValueError("memory bandwidth_bytes_per_s must be positive when set")
-        return value
 
 
 class HostAccess(BaseModel):
@@ -236,7 +225,10 @@ class PlatformDefinition(BaseModel):
     part: str
     budget: ResourceBudget
     host_link: HostLink
-    memory: PlatformMemory
+    storage_tiers: tuple[StorageTier, ...] = ()
+    # which shared tier a BUILD instantiates (a bitstream drives one memory
+    # controller); None = the first shared tier
+    active_memory_tier: str | None = None
     host_access: HostAccess | None = None
     constraints: tuple[str, ...] = ()
     constraints_xdc: str = ""
@@ -272,6 +264,31 @@ class PlatformDefinition(BaseModel):
     # resource points, rate models) must ask effective_job_clock_mhz().
     job_clock_mhz: int | None = None
     placeholders: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _storage_tiers_cohere(self) -> PlatformDefinition:
+        names = [tier.name for tier in self.storage_tiers]
+        if len(names) != len(set(names)):
+            raise ValueError(f"duplicate storage tier names: {names}")
+        if self.active_memory_tier is not None:
+            tier = next((t for t in self.storage_tiers if t.name == self.active_memory_tier), None)
+            if tier is None:
+                raise ValueError(f"active_memory_tier {self.active_memory_tier!r} names no declared tier")
+            if tier.access != "shared":
+                raise ValueError(f"active_memory_tier {self.active_memory_tier!r} is owned, not shared")
+        return self
+
+    @property
+    def memory(self) -> StorageTier:
+        """The memory system this build instantiates: the named active shared
+        tier, else the first shared tier. A property, not a field — the
+        inventory is ``storage_tiers``; this is a selection over it."""
+        if self.active_memory_tier is not None:
+            return next(t for t in self.storage_tiers if t.name == self.active_memory_tier)
+        shared = next((t for t in self.storage_tiers if t.access == "shared"), None)
+        if shared is None:
+            raise ValueError(f"platform {self.name!r} declares no shared storage tier")
+        return shared
 
     def effective_job_clock_mhz(self) -> int:
         """The frequency the job logic actually runs at: ``job_clock_mhz``

--- a/dau_build/tests/test_dpv1_shell.py
+++ b/dau_build/tests/test_dpv1_shell.py
@@ -200,7 +200,7 @@ def test_write_artifacts_emits_generated_sources_and_scripts(tmp_path: Path) -> 
 
 
 def _probe_platform(**overrides):
-    from dau_build.platforms import HostLink, PlatformDefinition, PlatformMemory, ResourceBudget, XdmaPersonality
+    from dau_build.platforms import HostLink, PlatformDefinition, ResourceBudget, StorageTier, XdmaPersonality
 
     base = {
         "name": "probe-k7",
@@ -211,7 +211,7 @@ def _probe_platform(**overrides):
             pcie_lanes=8,
             xdma_personality=XdmaPersonality(params={"pl_link_cap_max_link_width": "X8", "axisten_freq": "125"}),
         ),
-        "memory": PlatformMemory(kind="ddr3", size_bytes=8 << 30),
+        "storage_tiers": (StorageTier(name="ddr", technology="ddr", capacity_bytes=8 << 30, access="shared"),),
         "constraints_xdc": "set_property CFGBVS GND [current_design]\n",
     }
     base.update(overrides)

--- a/dau_build/tests/test_platforms.py
+++ b/dau_build/tests/test_platforms.py
@@ -9,8 +9,8 @@ from dau_build.platforms import (
     HostLink,
     PlaceholderPlatformError,
     PlatformDefinition,
-    PlatformMemory,
     ResourceBudget,
+    StorageTier,
     XdmaPersonality,
     dpv1_platform,
     fits,
@@ -46,7 +46,7 @@ def test_composed_platform_nested_config_is_frozen() -> None:
     with pytest.raises(ValidationError, match="frozen"):
         platform.host_link.pcie_lanes = 8
     with pytest.raises(ValidationError, match="frozen"):
-        platform.memory.size_bytes = 2 << 30
+        platform.storage_tiers[0].capacity_bytes = 2 << 30
     with pytest.raises(ValidationError, match="frozen"):
         platform.host_link.xdma_personality.params = {}
     with pytest.raises(TypeError):
@@ -73,7 +73,15 @@ def test_round_trip_preserves_personality_and_constraints() -> None:
             pcie_lanes=8,
             xdma_personality=XdmaPersonality(params={"pl_link_cap_max_link_width": "X8", "axisten_freq": "125"}),
         ),
-        memory=PlatformMemory(kind="ddr3", size_bytes=8 << 30, constraints_xdc="set_property IOSTANDARD LVDS [get_ports sys_clk_clk_p]\n"),
+        storage_tiers=(
+            StorageTier(
+                name="ddr",
+                technology="ddr",
+                capacity_bytes=8 << 30,
+                access="shared",
+                constraints_xdc="set_property IOSTANDARD LVDS [get_ports sys_clk_clk_p]\n",
+            ),
+        ),
         constraints=("pins.xdc", "timing.xdc"),
         constraints_xdc="set_property CFGBVS GND [current_design]\n",
         lane_placements=((0, "GTXE2_CHANNEL_X0Y8"), (1, "GTXE2_CHANNEL_X0Y9")),
@@ -103,8 +111,8 @@ def test_validation_rejects_bad_values() -> None:
         HostLink(interface="pcie-xdma", pcie_lanes=8, expected_link_width=3)
     with pytest.raises(ValidationError, match="expected_link_speed_gts"):
         HostLink(interface="pcie-xdma", pcie_lanes=8, expected_link_speed_gts=0)
-    with pytest.raises(ValidationError, match="size_bytes"):
-        PlatformMemory(kind="ddr3", size_bytes=0)
+    with pytest.raises(ValidationError, match="capacity_bytes"):
+        StorageTier(name="ddr", technology="ddr", capacity_bytes=0, access="shared")
     with pytest.raises(ValidationError, match="program_method"):
         _dpv1_with(program_method="usb")
     with pytest.raises(ValidationError, match="part must be non-empty"):
@@ -253,7 +261,7 @@ def test_user_config_dir_overlay_adds_a_board(tmp_path) -> None:
     overlay = tmp_path / "user-configs"
     (overlay / "platform").mkdir(parents=True)
     (overlay / "platform" / "myboard.yaml").write_text(
-        "# @package platform\n_target_: dau_build.platforms.PlatformDefinition\nname: myboard\npart: xc7k70tfbg484-2\nbudget:\n  _target_: dau_build.platforms.ResourceBudget\n  lut: 41000\n  ff: 82000\n  bram36: 135\n  dsp: 240\nhost_link:\n  _target_: dau_build.platforms.HostLink\n  interface: pcie-xdma\n  pcie_lanes: 1\nmemory:\n  _target_: dau_build.platforms.PlatformMemory\n  kind: ddr3\n  size_bytes: 1073741824"
+        "# @package platform\n_target_: dau_build.platforms.PlatformDefinition\nname: myboard\npart: xc7k70tfbg484-2\nbudget:\n  _target_: dau_build.platforms.ResourceBudget\n  lut: 41000\n  ff: 82000\n  bram36: 135\n  dsp: 240\nhost_link:\n  _target_: dau_build.platforms.HostLink\n  interface: pcie-xdma\n  pcie_lanes: 1\nstorage_tiers:\n  - _target_: dau_build.platforms.StorageTier\n    name: ddr\n    technology: ddr\n    capacity_bytes: 1073741824\n    access: shared"
     )
     board = resolve_platform("myboard", config_dir=str(overlay))
     assert board.name == "myboard"
@@ -270,7 +278,7 @@ def _dpv1_with(**overrides: object) -> PlatformDefinition:
         "part": "xc7a200tfbg484-2",
         "budget": ResourceBudget(lut=134600, ff=269200, bram36=365, dsp=740),
         "host_link": HostLink(interface="pcie-xdma", pcie_lanes=4),
-        "memory": PlatformMemory(kind="ddr3", size_bytes=1 << 30),
+        "storage_tiers": (StorageTier(name="ddr", technology="ddr", capacity_bytes=1 << 30, access="shared"),),
     }
     base.update(overrides)
     return PlatformDefinition(**base)  # type: ignore[arg-type]
@@ -307,3 +315,40 @@ def test_effective_job_clock_distinguishes_conversion_from_frequency() -> None:
 
     converted = platform.model_copy(update={"job_clock_mhz": 150})
     assert converted.effective_job_clock_mhz() == 150  # a converter overrides
+
+
+def test_storage_tiers_declare_the_full_inventory() -> None:
+    platform = dpv1_platform()
+    names = [tier.name for tier in platform.storage_tiers]
+    assert names == ["bram", "ddr"]
+    bram, ddr = platform.storage_tiers
+    assert bram.access == "owned" and bram.capacity_bytes == 335 * 4608
+    assert ddr.access == "shared" and ddr.mig_prj == "dpv1_mig.prj"
+    # the active memory system a build instantiates is the shared tier
+    assert platform.memory is ddr
+    assert platform.memory.capacity_bytes == 1073741824
+
+
+def _revalidated(platform, **updates):
+    # model_copy(update=...) skips validation on frozen models; the validators
+    # under test only run through model_validate
+    return type(platform).model_validate({**platform.model_dump(), **updates})
+
+
+def test_storage_tier_validators_refuse_bad_declarations() -> None:
+    platform = dpv1_platform()
+    tier = {"name": "ddr", "technology": "ddr", "capacity_bytes": 1 << 30, "access": "shared"}
+    with pytest.raises(ValidationError, match="duplicate"):
+        _revalidated(platform, storage_tiers=(tier, tier))
+    with pytest.raises(ValidationError, match="capacity_bytes"):
+        StorageTier(name="x", technology="ddr", capacity_bytes=0, access="shared")
+    with pytest.raises(ValidationError, match="active_memory_tier"):
+        _revalidated(platform, active_memory_tier="nonexistent")
+    with pytest.raises(ValidationError, match="owned"):  # active tier must be shared
+        _revalidated(platform, active_memory_tier="bram")
+
+
+def test_bram_tier_capacity_coheres_with_the_budget() -> None:
+    platform = dpv1_platform()
+    bram = next(t for t in platform.storage_tiers if t.technology == "bram")
+    assert bram.capacity_bytes <= platform.budget.bram36 * 4608

--- a/docs/reference/config-groups.md
+++ b/docs/reference/config-groups.md
@@ -161,14 +161,16 @@ Like the engines, simulators are polymorphic and fully hydra-configurable — e.
 `platform=platforms/dau/dpv1` composes `dau_build.platforms.PlatformDefinition`
 into the `platform` key. Options live under `platforms/<vendor>/<board>`. The
 packaged `platforms/dau/dpv1` option is the authoritative dpv1 definition: part
-number, program method, `ResourceBudget`, `PlatformMemory`, and a `HostLink`
+number, program method, `ResourceBudget`, `storage_tiers`, and a `HostLink`
 whose `XdmaPersonality.params` are the 47 proven bring-up XCI parameters,
 quoted verbatim and order-preserved so the generated Vivado `CONFIG.*` block is
 byte-for-byte identical to the known-good core.
 
 `PlatformDefinition` is composed of `ResourceBudget` (`lut`, `ff`, `bram36`,
-`dsp`), `PlatformMemory` (`kind`, `size_bytes`, `mig_prj`,
-`bandwidth_bytes_per_s`, `constraints_xdc`), and `HostLink` (`interface`,
+`dsp`), `storage_tiers` (each a `StorageTier`: `name`, `technology`,
+`capacity_bytes`, `access`, `persistent`, `bandwidth_bytes_per_s`, `mig_prj`,
+`constraints_xdc`; `platform.memory` selects the active shared tier), and
+`HostLink` (`interface`,
 `pcie_lanes`, `xdma_personality`, `expected_link_width`,
 `expected_link_speed_gts`), plus the board-level `constraints_xdc` (pin
 constraint text the shell project generators emit behind their banner),


### PR DESCRIPTION
The dau-build slice of STORAGE_AND_NOC.md phase 1.

`PlatformMemory` modeled one memory system — which is why dpv2 needed two platform files for one board. `storage_tiers` declares the inventory (owned BRAM, shared DDR, far technologies schema-legal until their tripwire fires); `platform.memory` becomes a derived property selecting the active shared tier (`active_memory_tier` or first shared). dpv1's measured constraints ride their tier; docs updated.

Reviewed by two independent reviewers (checkpoint A): the one cross-repo consumer found (dau-polars `_platform_address_width`) is fixed on the dau-polars branch of this rollout. 389 passed.