### PR TITLE
Close the dau-build standards-audit findings

### DIFF
--- a/dau_build/build_config.py
+++ b/dau_build/build_config.py
@@ -113,5 +113,5 @@ def _backend_label(backend, backend_name: str | None, spec: DauBuildSpec) -> Bac
     if isinstance(backend, BackendConfig):
         return backend
     if backend is not None:
-        return BackendConfig(name=backend.name, invocation=getattr(backend, "invocation", "standard"))
+        return BackendConfig(name=backend.name, invocation=backend.invocation)
     return BackendConfig(name=backend_name or spec.backend, invocation="dry-run")

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -768,7 +768,9 @@ class VivadoOverlayStageTask(OverlayStageTask):
     backend_platform: str = "vivado-xdma"
     backend_shell: str = "xdma-shell"
     operator: str | None = None
-    register_map_version: str = "0.1"
+    # the current wire contract; a shell that stamps an older version makes
+    # its capability words undecodable by consumers that read them
+    register_map_version: str = "0.2"
     stream_protocol_version: str = "0.1"
     manifest_path: Path | None = None
     command_plan_path: Path | None = None

--- a/dau_build/build_steps.py
+++ b/dau_build/build_steps.py
@@ -1063,7 +1063,7 @@ class HardwarePlanTask(BuildCallableModel):
             from dau_build.platforms import require_measured
 
             require_measured(self.platform)
-            if getattr(self.platform, "host_access", None) is None:
+            if self.platform.host_access is None:
                 raise BuildStepError(
                     f"platform {self.platform.name!r} declares no host_access; add the board's measured "
                     "access facts to its platform config (or run without platform=) before executing hardware plans"
@@ -1091,7 +1091,7 @@ class HardwarePlanTask(BuildCallableModel):
         if self.execute:
             # serialize the device: the executor holds a host lock on the
             # endpoint BDF (a board is one exclusive resource)
-            return_code = execute_plan_steps(plan_result, endpoint_bdf=getattr(config, "endpoint_bdf", None))
+            return_code = execute_plan_steps(plan_result, endpoint_bdf=config.endpoint_bdf)
             if return_code != 0:
                 raise BuildStepError(f"hardware plan {plan.name!r} failed with exit code {return_code}")
             return BuildStepResult(

--- a/dau_build/cli.py
+++ b/dau_build/cli.py
@@ -41,6 +41,34 @@ def _parse(argv: list[str] | None) -> tuple[argparse.Namespace, list[str]]:
     return args, list(args.overrides)
 
 
+# selecting any of these composes the callable under `model`
+_CALLABLE_GROUPS = ("task", "step", "plan")
+
+
+def _require_selection_resolved(overrides: list[str], cfg) -> None:
+    """Refuse a task/step/plan selection that composed to nothing.
+
+    These groups are declared ``optional`` so the CLI runs without them,
+    which also means hydra DROPS a value it cannot find instead of
+    failing. A mistyped ``task=`` then reads as success — worst under
+    ``--explain``, whose whole job is to show what a command will do
+    before it runs. Selecting any of them composes a callable under
+    ``model``, so its absence after an explicit selection means the value
+    did not resolve, and the error can name it.
+    """
+    if "model" in cfg:
+        return
+    for override in overrides:
+        group, separator, value = override.partition("=")
+        group = group.lstrip("+~")
+        if separator and group in _CALLABLE_GROUPS and value not in ("null", ""):
+            raise BuildStepError(
+                f"{group}={value!r} did not resolve: no such option in the {group!r} config group. "
+                "The group is optional, so an unmatched value is dropped rather than failing — "
+                "check the name, or pass --config-dir for an overlay that provides it."
+            )
+
+
 def main(argv: list[str] | None = None) -> int:
     from ccflow.utils.hydra import cfg_run
 
@@ -48,6 +76,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args, overrides = _parse(argv)
     result = compose_config(overrides, config_dir=args.config_dir)
+    _require_selection_resolved(overrides, result.cfg)
     if args.explain:
         print(OmegaConf.to_yaml(result.cfg, resolve=True))
         return 0

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -670,26 +670,29 @@ def pm_hold_path_step(config: HardwareToolchainConfig) -> ToolStep:
     must be held BEFORE the endpoint goes away and must stay held across the
     reprogram, so they are held here rather than per-device.
 
-    The bridge holds are unconditional (a bridge on the path to a device
-    that enumerated is present) while the endpoint stays conditional, since
-    the runtime-PM tool exits non-zero when asked for a device that is not
-    there.
+    The path is held BY PATTERN, not by an explicit BDF list, and that
+    choice is load-bearing. The runtime-PM tool exits non-zero when any
+    named device is missing, so naming the bridges would abort this step
+    exactly when the card has lost power and the hot-plug tunnel has
+    collapsed — the wedged board this step's tolerance exists to recover,
+    and one the JTAG programmer could still reach because it runs over USB
+    and needs no PCIe at all. Pattern discovery is tolerant by construction:
+    a device that is gone is never discovered, so it contributes no missing
+    write. A platform that declares no patterns holds nothing extra here,
+    which is the behaviour it had before.
     """
     bdf = config.required_host_access("endpoint_bdf")
-    bridges = tuple(config.required_host_access("rescan_bdfs"))
+    patterns = tuple(config.required_host_access("runtime_pm_patterns"))
     quoted_bdf = shlex.quote(str(bdf))
     hold_endpoint = shlex.join((config.runtime_pm_executable, "hold", "--device", str(bdf)))
     # tolerate ONLY an absent endpoint (recovering a wedged device); a hold
     # failure with the device present propagates — proceeding into a
     # reprogram without the PM hold is exactly the wedge class this guards
     endpoint_script = f"if [ -e /sys/bus/pci/devices/{quoted_bdf} ]; then {hold_endpoint}; else echo 'pm hold skipped (device absent)'; fi"
-    if not bridges:
+    if not patterns:
         script = endpoint_script
     else:
-        bridge_args: list[str] = [config.runtime_pm_executable, "hold"]
-        for bridge in bridges:
-            bridge_args.extend(("--device", str(bridge)))
-        script = f"{shlex.join(bridge_args)} && {{ {endpoint_script}; }}"
+        script = f"{shlex.join(_runtime_pm_argv(config, 'hold'))} && {{ {endpoint_script}; }}"
     return ToolStep(
         "pm-hold-path",
         (*config.privilege_prefix, "sh", "-c", script),

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -656,18 +656,42 @@ def pci_rescan_step(config: HardwareToolchainConfig) -> ToolStep:
     return _privileged_sh(config, "pci-rescan", _pci_rescan_script(config.required_host_access("rescan_bdfs")))
 
 
-def pm_hold_device_step(config: HardwareToolchainConfig) -> ToolStep:
-    """Device-scoped runtime-PM hold as safe prep — tolerant when the
-    endpoint is absent (recovering a wedged device must not abort here)."""
+def pm_hold_path_step(config: HardwareToolchainConfig) -> ToolStep:
+    """Runtime-PM hold over the endpoint AND every bridge above it, as safe
+    prep — tolerant when the endpoint is absent (recovering a wedged device
+    must not abort here).
+
+    Holding the endpoint alone is not enough, and the reason is the next
+    step: the ladder REMOVES the endpoint, which takes its sysfs node with
+    it and therefore the only thing holding it awake. On a hot-plug path
+    (Thunderbolt) the bridges above then suspend and cut power to the card,
+    the FPGA loses its configuration, and the programmer fails with `TDO is
+    stuck at 0` — measured on a NUC-attached dpv1, 2026-08-06. The bridges
+    must be held BEFORE the endpoint goes away and must stay held across the
+    reprogram, so they are held here rather than per-device.
+
+    The bridge holds are unconditional (a bridge on the path to a device
+    that enumerated is present) while the endpoint stays conditional, since
+    the runtime-PM tool exits non-zero when asked for a device that is not
+    there.
+    """
     bdf = config.required_host_access("endpoint_bdf")
-    hold = shlex.join((config.runtime_pm_executable, "hold", "--device", bdf))
+    bridges = tuple(config.required_host_access("rescan_bdfs"))
     quoted_bdf = shlex.quote(str(bdf))
+    hold_endpoint = shlex.join((config.runtime_pm_executable, "hold", "--device", str(bdf)))
     # tolerate ONLY an absent endpoint (recovering a wedged device); a hold
     # failure with the device present propagates — proceeding into a
     # reprogram without the PM hold is exactly the wedge class this guards
-    script = f"if [ -e /sys/bus/pci/devices/{quoted_bdf} ]; then {hold}; else echo 'pm hold skipped (device absent)'; fi"
+    endpoint_script = f"if [ -e /sys/bus/pci/devices/{quoted_bdf} ]; then {hold_endpoint}; else echo 'pm hold skipped (device absent)'; fi"
+    if not bridges:
+        script = endpoint_script
+    else:
+        bridge_args: list[str] = [config.runtime_pm_executable, "hold"]
+        for bridge in bridges:
+            bridge_args.extend(("--device", str(bridge)))
+        script = f"{shlex.join(bridge_args)} && {{ {endpoint_script}; }}"
     return ToolStep(
-        "pm-hold-device",
+        "pm-hold-path",
         (*config.privilege_prefix, "sh", "-c", script),
         required_executable=config.runtime_pm_executable,
         executable_override="model.runtime_pm_executable",
@@ -925,7 +949,7 @@ def sram_program_plan(config: HardwareToolchainConfig, *, deadman_timeout_s: int
     deadman disarm. Every step exists for a bench-discovered reason; the
     disarm runs only when everything before it succeeded."""
     steps = [
-        pm_hold_device_step(config),
+        pm_hold_path_step(config),
         deadman_arm_step(config, timeout_s=deadman_timeout_s),
         remove_endpoint_step(config),
         program_volatile_step(config),

--- a/dau_build/hardware_plan.py
+++ b/dau_build/hardware_plan.py
@@ -114,8 +114,10 @@ class HardwareToolchainConfig(BaseModel):
         ``program_method``. Explicit keyword overrides win; with neither, the
         host-access facts stay unset and any step that needs them fails with
         guidance. An explicit ``programmer`` model overrides the
-        ``program_method``-selected default."""
-        access = getattr(platform, "host_access", None)
+        ``program_method``-selected default. ``platform`` may be ``None``
+        (a platform-less compose), in which case every board fact stays
+        unset and only the explicit overrides apply."""
+        access = platform.host_access if platform is not None else None
         values: dict = {}
         if access is not None:
             values = {
@@ -130,10 +132,9 @@ class HardwareToolchainConfig(BaseModel):
                 "reset_bridge_bdf": access.reset_bridge_bdf,
                 "privilege_prefix": access.privilege_prefix,
             }
-        method = getattr(platform, "program_method", None)
-        if method is not None:
-            values["program_method"] = method
-        values["spi_boot_buswidth"] = getattr(platform, "spi_boot_buswidth", None)
+        if platform is not None:
+            values["program_method"] = platform.program_method
+            values["spi_boot_buswidth"] = platform.spi_boot_buswidth
         if programmer is not None:
             values["programmer"] = programmer
         values.update({key: value for key, value in overrides.items() if value is not None})

--- a/dau_build/publish_inventory.py
+++ b/dau_build/publish_inventory.py
@@ -1,0 +1,137 @@
+"""Project a private shell-build manifest into a publishable inventory.
+
+A shell-build manifest is a full build record: it names every contributing
+HDL source by absolute path, records the git state of each containing
+repository, and keeps the console log. That is the right content for a
+private artifact — it is how a build is reproduced and audited — and the
+wrong content to hand out, because those paths and repository names
+disclose the core library's table of contents and a local filesystem
+layout.
+
+This module produces a SEPARATE manifest carrying only what a consumer of
+a bitstream needs: the bitstream itself by digest, and the capabilities it
+advertises.
+
+The projection **whitelists**. A denylist rots the first time a metadata
+key is added upstream — the new key ships by default and nobody notices
+until it is public. Here an unlisted key simply does not appear, so the
+failure mode of forgetting to update this module is an inventory that is
+missing something, not one that discloses something.
+
+Capabilities come from the capability contract as PLAIN DATA. This module
+never imports the core package: it takes the already-decoded mapping, so
+the public build layer stays independent of the private one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from artlink.artifact import Artifact, Capability
+
+from .packaging import ArtifactManifest, load_artifact_manifest
+
+__all__ = ("PUBLISHED_METADATA_KEYS", "publish_inventory", "write_published_inventory")
+
+# every metadata key that may cross into a published inventory, and why.
+# Anything absent here is withheld — including keys that do not exist yet.
+PUBLISHED_METADATA_KEYS: tuple[str, ...] = (
+    "platform",  # which board family the bitstream targets
+    "part",  # the exact device it was built for
+    "top_module",  # the module a loader instantiates
+    "lane_count",  # how many lanes the composition runs
+    "register_map_version",  # the wire contract a host must speak
+)
+
+# withheld deliberately, recorded so the decision is visible rather than
+# implied by omission:
+#   source_repositories  - local paths + git state of private repositories
+#   composition_spec     - the exact datapath recipe; the private cache key
+#   spec_hash            - pins the canonical spec version publicly
+#   resource_estimate_*  - measured area and timing are competitive data
+#   wns_ns, build_status - build-internal outcomes
+_WITHHELD_ROLES = frozenset({"hdl-source", "generated-project-input", "build-log", "report"})
+
+
+def _capabilities_from_contract(contract: Mapping[str, Any]) -> tuple[Capability, ...]:
+    """The operator inventory a bitstream advertises, as artlink
+    capabilities.
+
+    Takes the contract mapping as plain data — the shape
+    ``{"lanes": [{"tile": {"core": ..., "unit_kind": ..., "opcodes": [...]}}]}``
+    — so this module needs nothing from the package that produced it.
+    Identical lane tiles collapse into one capability with a count, which
+    is what makes the inventory readable for a wide composition.
+    """
+    counts: dict[tuple[str, str], int] = {}
+    opcodes: dict[tuple[str, str], tuple[str, ...]] = {}
+    for lane in contract.get("lanes", ()):
+        tile = lane.get("tile") or {}
+        core = tile.get("core")
+        if not core:
+            continue
+        key = (core, tile.get("unit_kind") or "")
+        counts[key] = counts.get(key, 0) + 1
+        opcodes.setdefault(key, tuple(tile.get("opcodes", ())))
+    capabilities = []
+    for (core, unit_kind), count in sorted(counts.items()):
+        metadata: dict[str, Any] = {"count": count}
+        if unit_kind:
+            metadata["unit_kind"] = unit_kind
+        if opcodes[(core, unit_kind)]:
+            metadata["opcodes"] = list(opcodes[(core, unit_kind)])
+        capabilities.append(Capability(kind="dau-operator", name=core, metadata=metadata))
+    return tuple(capabilities)
+
+
+def publish_inventory(
+    manifest: ArtifactManifest,
+    *,
+    contract: Mapping[str, Any] | None = None,
+    name: str | None = None,
+) -> ArtifactManifest:
+    """Project ``manifest`` into a publishable inventory.
+
+    Keeps exactly one artifact — the bitstream, by digest — carrying the
+    capabilities the composition advertises, plus the whitelisted metadata
+    keys. Raises when the source manifest has no bitstream, because an
+    inventory without one describes nothing.
+    """
+    bitstreams = [artifact for artifact in manifest.artifacts if artifact.role == "bitstream"]
+    if len(bitstreams) != 1:
+        raise ValueError(f"a published inventory needs exactly one bitstream artifact, found {len(bitstreams)}")
+    source = bitstreams[0]
+
+    metadata = {key: manifest.metadata[key] for key in PUBLISHED_METADATA_KEYS if key in manifest.metadata}
+    capabilities = _capabilities_from_contract(contract) if contract else ()
+
+    published = Artifact(
+        # the NAME only, never the build-host path it was produced at
+        path=Path(source.path).name if source.path else None,
+        kind="binary",
+        role="bitstream",
+        digest=source.digest,
+        provides=capabilities,
+    )
+    return ArtifactManifest(
+        name=name or manifest.name,
+        intent="output",
+        artifacts=(published,),
+        metadata=metadata,
+    )
+
+
+def write_published_inventory(
+    manifest_path: Path,
+    destination: Path,
+    *,
+    contract: Mapping[str, Any] | None = None,
+    name: str | None = None,
+) -> Path:
+    """Read a shell-build manifest, project it, and write the inventory."""
+    projected = publish_inventory(load_artifact_manifest(manifest_path), contract=contract, name=name)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(projected.to_yaml_text(), encoding="utf-8")
+    return destination

--- a/dau_build/publish_inventory.py
+++ b/dau_build/publish_inventory.py
@@ -52,7 +52,9 @@ PUBLISHED_METADATA_KEYS: tuple[str, ...] = (
 #   spec_hash            - pins the canonical spec version publicly
 #   resource_estimate_*  - measured area and timing are competitive data
 #   wns_ns, build_status - build-internal outcomes
-_WITHHELD_ROLES = frozenset({"hdl-source", "generated-project-input", "build-log", "report"})
+#
+# Artifact roles need no denylist: the projection keeps the one bitstream and
+# drops every other artifact by construction.
 
 
 def _capabilities_from_contract(contract: Mapping[str, Any]) -> tuple[Capability, ...]:
@@ -97,12 +99,26 @@ def publish_inventory(
     Keeps exactly one artifact — the bitstream, by digest — carrying the
     capabilities the composition advertises, plus the whitelisted metadata
     keys. Raises when the source manifest has no bitstream, because an
-    inventory without one describes nothing.
+    inventory without one describes nothing, and when the build did not
+    close timing, because publishing an image is a claim that it runs.
+
+    The timing refusal is why ``wns_ns`` can stay withheld: a published
+    inventory asserts closure by existing, so the margin never has to be
+    disclosed to be trusted. A build that missed is a build nobody should
+    flash, and the ladder that recovers a wedged board is not something a
+    consumer of a published image has.
     """
     bitstreams = [artifact for artifact in manifest.artifacts if artifact.role == "bitstream"]
     if len(bitstreams) != 1:
         raise ValueError(f"a published inventory needs exactly one bitstream artifact, found {len(bitstreams)}")
     source = bitstreams[0]
+
+    status = manifest.metadata.get("build_status")
+    if status is not None and status != "built":
+        raise ValueError(f"refusing to publish a bitstream whose build_status is {status!r}, not 'built'")
+    wns = manifest.metadata.get("wns_ns")
+    if wns is not None and float(wns) < 0.0:
+        raise ValueError(f"refusing to publish a bitstream that missed timing (wns_ns={wns})")
 
     metadata = {key: manifest.metadata[key] for key in PUBLISHED_METADATA_KEYS if key in manifest.metadata}
     capabilities = _capabilities_from_contract(contract) if contract else ()
@@ -112,6 +128,11 @@ def publish_inventory(
         path=Path(source.path).name if source.path else None,
         kind="binary",
         role="bitstream",
+        # which image this is: an SRAM load wants the .bit and an SPI flash
+        # wants the .mcs, so a consumer that cannot tell them apart cannot
+        # pick a load path. Neither says anything about the composition.
+        format=source.format,
+        media_type=source.media_type,
         digest=source.digest,
         provides=capabilities,
     )

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -124,12 +124,16 @@ class SynthesizeCoresTask(BuildCallableModel):
 
         try:
             composed = compose_config([f"+{_REGISTRY_GROUP}=cores"])
-            # register ONLY the registry subtree: the composed config also
-            # carries this task's own groups, and loading those into a
-            # registry that already holds them collides
+            # load into a DETACHED registry, never the root. Registering the
+            # group on the root would make a later full compose by the core
+            # package collide on a name this task put there, so whether an
+            # application's own composition works would depend on whether it
+            # ran a build task first.
             from omegaconf import OmegaConf
 
-            registry.load_config(OmegaConf.create({_REGISTRY_GROUP: composed.cfg[_REGISTRY_GROUP]}))
+            scratch = ModelRegistry(name=f"{_REGISTRY_GROUP}-synthesize-cores")
+            scratch.load_config(OmegaConf.create({_REGISTRY_GROUP: composed.cfg[_REGISTRY_GROUP]}))
+            return scratch.models[_REGISTRY_GROUP]
         except Exception as exc:
             raise BuildStepError(
                 f"no {_REGISTRY_PREFIX} registry is composed and the {_REGISTRY_GROUP!r} config group "
@@ -310,15 +314,15 @@ class SynthesizeCoresTask(BuildCallableModel):
         matches = None
         if compare and registered is not None:
             if isinstance(registered, (list, tuple)):
+                # every axis must match. A missing clock is NOT a wildcard:
+                # once a tile carries both an 8 ns and a 10 ns point for the
+                # same part and params, a wildcard silently picks whichever
+                # was written first and reports drift against the wrong one.
                 point = (
                     None
-                    if params is None
+                    if params is None or clock_period_ns is None
                     else next(
-                        (
-                            m
-                            for m in registered
-                            if m.part == part and (clock_period_ns is None or m.clock_ns == clock_period_ns) and dict(m.params) == dict(params)
-                        ),
+                        (m for m in registered if m.part == part and m.clock_ns == clock_period_ns and dict(m.params) == dict(params)),
                         None,
                     )
                 )

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -29,6 +29,7 @@ from dau_build.build_steps import BuildCallableModel, BuildStepError, BuildStepR
 __all__ = ("CoreEnvelopeReport", "SynthesizeCoresTask")
 
 _REGISTRY_PREFIX = "/dau-core/"
+_REGISTRY_GROUP = "dau-core"
 
 
 class CoreEnvelopeReport(BaseModel):
@@ -100,21 +101,53 @@ class SynthesizeCoresTask(BuildCallableModel):
             ),
         )
 
+    def _core_registry(self):
+        """The composed ``/dau-core`` subregistry.
+
+        Resolved through the ccflow ``ModelRegistry``, never by importing
+        the core package: dau-build is public and must not depend on a
+        private one. A core provider registers its config tree on the
+        shared hydra searchpath (``hydra.lernaplugins``), and this task
+        reads whatever the application composed — including overrides.
+
+        When the subregistry is absent the group is composed by name off
+        that searchpath. If no provider is installed, that composition
+        fails and the task refuses; it never falls back to a direct import.
+        """
+        from ccflow import ModelRegistry
+
+        registry = ModelRegistry.root()
+        subregistry = registry.models.get(_REGISTRY_GROUP)
+        if subregistry is not None:
+            return subregistry
+        from .config import compose_config
+
+        try:
+            composed = compose_config([f"+{_REGISTRY_GROUP}=cores"])
+            # register ONLY the registry subtree: the composed config also
+            # carries this task's own groups, and loading those into a
+            # registry that already holds them collides
+            from omegaconf import OmegaConf
+
+            registry.load_config(OmegaConf.create({_REGISTRY_GROUP: composed.cfg[_REGISTRY_GROUP]}))
+        except Exception as exc:
+            raise BuildStepError(
+                f"no {_REGISTRY_PREFIX} registry is composed and the {_REGISTRY_GROUP!r} config group "
+                f"could not be composed off the hydra searchpath ({type(exc).__name__}: {exc}); "
+                "install a core provider or compose its group"
+            ) from exc
+        subregistry = registry.models.get(_REGISTRY_GROUP)
+        if subregistry is None:
+            raise BuildStepError(f"the {_REGISTRY_GROUP!r} config group composed but registered no cores")
+        return subregistry
+
     def _resolve_core(self, entry: str):
         name = entry.removeprefix(_REGISTRY_PREFIX)
         if "/" in name:
             raise BuildStepError(f"core entry {entry!r} is not a /dau-core/<name> registry path")
-        try:
-            from dau_core.cores import UnknownCoreError, loaded_cores
-        except ImportError as exc:
-            raise BuildStepError("dau-core is not installed; the core registry is unavailable") from exc
-        try:
-            definitions = loaded_cores()
-            if name not in definitions:
-                raise UnknownCoreError(name)
-            definition = definitions[name]
-        except UnknownCoreError as exc:
-            raise BuildStepError(f"unknown core {entry!r}") from exc
+        definition = self._core_registry().models.get(name)
+        if definition is None:
+            raise BuildStepError(f"unknown core {entry!r}")
         if definition.kind.value == "package":
             # a SystemVerilog package is not a synthesizable top; it rides
             # along as a dependency of the tiles that import it
@@ -140,10 +173,30 @@ class SynthesizeCoresTask(BuildCallableModel):
         values.update(overrides)
         return values
 
-    def _stage_core(self, definition, *, part: str, root: Path) -> Path:
-        from dau_core.cores import sources_for
+    def _sources_for(self, definition) -> tuple[Path, ...]:
+        """Dependency-closed source paths for one core, in registry order.
 
-        sources = sources_for(definition.name)
+        Walks the model's own ``depends`` and ``source_path()`` surface
+        rather than calling into the provider package, for the same reason
+        :meth:`_core_registry` does.
+        """
+        subregistry = self._core_registry()
+        selected: dict[str, object] = {}
+
+        def visit(name: str) -> None:
+            model = subregistry.models.get(name)
+            if model is None:
+                raise BuildStepError(f"core {name!r} is a declared dependency but is not in the registry")
+            for dependency in model.depends:
+                visit(dependency)
+            selected.setdefault(name, model)
+
+        visit(definition.name)
+        ordered = [model for name, model in subregistry.models.items() if name in selected]
+        return tuple(model.source_path() for model in ordered)
+
+    def _stage_core(self, definition, *, part: str, root: Path) -> Path:
+        sources = self._sources_for(definition)
         generics = self._generics(definition)
         generic_args = "".join(f" -generic {name}={value}" for name, value in generics.items())
         reads = "\n".join(f"read_verilog -sv {_tcl_path(path)}" for path in sources)
@@ -207,11 +260,10 @@ class SynthesizeCoresTask(BuildCallableModel):
             definition,
             output_root=root,
             clocked=bool(self.clock_ports.get(definition.name, "clk")),
-            # an envelope is registered for the DEFAULT parameters; an
-            # overridden build is a different shape, not drift
-            compare=definition.name not in self.parameters,
+            compare=True,
             part=self._part(),
             clock_period_ns=self.clock_period_ns,
+            params=self._generics(definition),
         )
 
     @staticmethod
@@ -223,10 +275,18 @@ class SynthesizeCoresTask(BuildCallableModel):
         compare: bool = True,
         part: str | None = None,
         clock_period_ns: float | None = None,
+        params: Mapping[str, int] | None = None,
     ) -> CoreEnvelopeReport:
         """Parse a core's utilization (and, when clocked, timing) reports into
-        an envelope report, comparing against the registered envelope only
-        when the build used the registered (default) parameters."""
+        an envelope report and compare it against the registered one.
+
+        ``params`` are the module parameters the build actually used. A core
+        carrying MEASUREMENT POINTS is keyed by (part, clock, params), so the
+        comparison must match all three — a surface with several points at one
+        part and clock would otherwise compare against whichever happened to
+        be first, and report drift against a different parameter's numbers.
+        Without ``params`` such a core is not compared at all, because there
+        is no way to tell which point the build corresponds to."""
         util = (output_root / f"{definition.module}.util.rpt").read_text()
         lut = _util_value(util, r"Slice LUTs\*?")
         ff = _util_value(util, r"Slice Registers")
@@ -250,12 +310,22 @@ class SynthesizeCoresTask(BuildCallableModel):
         matches = None
         if compare and registered is not None:
             if isinstance(registered, (list, tuple)):
-                point = next(
-                    (m for m in registered if m.part == part and (clock_period_ns is None or m.clock_ns == clock_period_ns)),
-                    None,
+                point = (
+                    None
+                    if params is None
+                    else next(
+                        (
+                            m
+                            for m in registered
+                            if m.part == part and (clock_period_ns is None or m.clock_ns == clock_period_ns) and dict(m.params) == dict(params)
+                        ),
+                        None,
+                    )
                 )
             else:
-                point = registered
+                # a scalar envelope declares one shape: it is comparable only
+                # against a build that used the declared defaults
+                point = registered if params is None or dict(params) == {name: spec.default for name, spec in definition.parameters.items()} else None
             if point is not None:
                 matches = (point.lut, point.ff, point.bram36, point.dsp) == (lut, ff, bram, dsp)
         return CoreEnvelopeReport(

--- a/dau_build/synthesize_cores.py
+++ b/dau_build/synthesize_cores.py
@@ -157,7 +157,7 @@ class SynthesizeCoresTask(BuildCallableModel):
     def _part(self) -> str:
         if self.part is not None:
             return self.part
-        part = getattr(self.platform, "part", None)
+        part = self.platform.part if self.platform is not None else None
         if part:
             return part
         raise BuildStepError("no part selected; pass model.part=... or compose a platform= group")

--- a/dau_build/tests/sv/counter.sv
+++ b/dau_build/tests/sv/counter.sv
@@ -1,11 +1,12 @@
+// Smoke fixture for the cocotb/verilator runner, not a DAU tile.
+//
+// `out` starts at zero from its declaration rather than from a separate
+// initial block: driving it from both an initial and an always_ff makes it
+// multiply-driven, which Verilator treats as an error rather than a warning.
 module counter #(parameter int OUT_SIZE=32) (
   input clk,
-  output logic[OUT_SIZE-1:0] out
+  output logic[OUT_SIZE-1:0] out = '0
 );
-
-initial begin
-out = 'b0;
-end
 
 always_ff @ (posedge clk) begin
   out <= out + 1;

--- a/dau_build/tests/test_config.py
+++ b/dau_build/tests/test_config.py
@@ -264,3 +264,26 @@ def test_driver_and_memory_config_groups_compose_and_override() -> None:
     )
     assert "driver\tos=host transport=xdma" in result.message
     assert "memory\thost_staging_bytes=4096 device_staging_bytes=0" in result.message
+
+
+def test_an_unresolvable_task_is_refused_including_under_explain() -> None:
+    """The task group is `optional`, so hydra drops a value it cannot find
+    instead of failing. Without a guard a mistyped task reads as success
+    under --explain, which is the one command whose job is to show what
+    will happen before it happens."""
+    import pytest
+
+    from dau_build.build_steps import BuildStepError
+    from dau_build.cli import main
+
+    with pytest.raises(BuildStepError, match="did not resolve"):
+        main(["task=tasks/does/not/exist", "--explain"])
+    with pytest.raises(BuildStepError, match="did not resolve"):
+        main(["task=tasks/does/not/exist"])
+
+
+def test_a_valid_task_and_a_bare_invocation_still_explain() -> None:
+    from dau_build.cli import main
+
+    assert main(["task=tasks/build/synthesize-cores", "--explain"]) == 0
+    assert main(["--explain"]) == 0

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1672,7 +1672,7 @@ def test_sram_program_plan_is_the_proven_ladder() -> None:
     )
     steps = SramProgramPlan(verify_command="sudo probe-magic").compose(config)
     assert [step.name for step in steps] == [
-        "pm-hold-device",
+        "pm-hold-path",
         "deadman-arm",
         "remove-endpoint",
         "program-volatile",
@@ -1683,11 +1683,20 @@ def test_sram_program_plan_is_the_proven_ladder() -> None:
         "deadman-disarm",
     ]
     by_name = {step.name: step.command_line for step in steps}
-    assert "dau-utils-pci-runtime-pm hold --device 0000:04:00.0" in by_name["pm-hold-device"]
+    hold = by_name["pm-hold-path"]
+    assert "dau-utils-pci-runtime-pm hold --device 0000:04:00.0" in hold
     # tolerant ONLY when the endpoint is absent; a hold failure with the
     # device present must fail the step
-    assert "if [ -e /sys/bus/pci/devices/0000:04:00.0 ]" in by_name["pm-hold-device"]
-    assert "pm hold skipped (device absent)" in by_name["pm-hold-device"]
+    assert "if [ -e /sys/bus/pci/devices/0000:04:00.0 ]" in hold
+    assert "pm hold skipped (device absent)" in hold
+    # the BRIDGES above the endpoint are held too, unconditionally and
+    # BEFORE it: the next step removes the endpoint, and on a hot-plug path
+    # nothing else keeps the bridges awake once its sysfs node is gone
+    for bridge in ("0000:03:01.0", "0000:02:00.0", "0000:00:07.0"):
+        assert f"--device {bridge}" in hold, bridge
+    assert hold.index("--device 0000:03:01.0") < hold.index("if [ -e /sys/bus/pci/devices/0000:04:00.0 ]")
+    # a bridge hold failure fails the step rather than falling through
+    assert "&&" in hold
     assert by_name["deadman-arm"] == "dau-utils-deadman arm --timeout 180"
     assert by_name["program-volatile"] == "openFPGALoader -c digilent_hs2 /tmp/design.bit"
     assert "-f" not in by_name["program-volatile"].split()  # VOLATILE, never raw persistent
@@ -1712,7 +1721,7 @@ def test_sram_program_plan_prefixes_only_the_privileged_steps() -> None:
     config = _bench_config(work_root=Path("/tmp/w"), bitstream_path=Path("/tmp/design.bit"), privilege_prefix=("sudo",))
     by_name = {step.name: step for step in SramProgramPlan().compose(config)}
 
-    for privileged in ("pm-hold-device", "remove-endpoint", "secondary-bus-reset", "pci-global-rescan-settle"):
+    for privileged in ("pm-hold-path", "remove-endpoint", "secondary-bus-reset", "pci-global-rescan-settle"):
         assert by_name[privileged].argv[:3] == ("sudo", "sh", "-c"), privileged
     # the redirect runs under sudo (sudo fronts the whole sh -c)
     assert "echo 1 > /sys/bus/pci/rescan" in by_name["pci-global-rescan-settle"].command_line
@@ -1825,7 +1834,7 @@ def test_execute_refuses_bare_runtime_pm_executable_under_sudo(monkeypatch, tmp_
 
     message = str(exc_info.value)
     assert executable in message
-    assert "pm-hold-device" in message
+    assert "pm-hold-path" in message
     assert "model.runtime_pm_executable" in message
 
 

--- a/dau_build/tests/test_hardware_plan.py
+++ b/dau_build/tests/test_hardware_plan.py
@@ -1689,14 +1689,26 @@ def test_sram_program_plan_is_the_proven_ladder() -> None:
     # device present must fail the step
     assert "if [ -e /sys/bus/pci/devices/0000:04:00.0 ]" in hold
     assert "pm hold skipped (device absent)" in hold
-    # the BRIDGES above the endpoint are held too, unconditionally and
-    # BEFORE it: the next step removes the endpoint, and on a hot-plug path
-    # nothing else keeps the bridges awake once its sysfs node is gone
-    for bridge in ("0000:03:01.0", "0000:02:00.0", "0000:00:07.0"):
-        assert f"--device {bridge}" in hold, bridge
-    assert hold.index("--device 0000:03:01.0") < hold.index("if [ -e /sys/bus/pci/devices/0000:04:00.0 ]")
-    # a bridge hold failure fails the step rather than falling through
-    assert "&&" in hold
+    # the PATH above the endpoint is held too, and BEFORE it: the next step
+    # removes the endpoint, and on a hot-plug path nothing else keeps the
+    # bridges awake once its sysfs node is gone
+    for pattern in ("Thunderbolt", "JHL", "Xilinx"):
+        assert f"--pattern {pattern}" in hold, pattern
+    assert hold.index("--pattern Thunderbolt") < hold.index("if [ -e /sys/bus/pci/devices/0000:04:00.0 ]")
+    # BY PATTERN, never by an explicit BDF list: naming devices makes the
+    # runtime-PM tool exit non-zero for any that is missing, which would
+    # abort recovery of a board whose hot-plug tunnel collapsed -- precisely
+    # when the USB JTAG programmer could still reach it
+    assert "--device 0000:03:01.0" not in hold
+    # the path hold still gates the endpoint hold rather than falling through
+    assert "&& {" in hold
+
+    # a platform declaring no patterns holds nothing extra -- the behaviour
+    # it had before the path hold existed, not a new failure
+    bare = SramProgramPlan().compose(_bench_config(work_root=Path("/tmp/w"), runtime_pm_patterns=()))
+    bare_hold = {step.name: step.command_line for step in bare}["pm-hold-path"]
+    assert "--pattern" not in bare_hold
+    assert "if [ -e /sys/bus/pci/devices/0000:04:00.0 ]" in bare_hold
     assert by_name["deadman-arm"] == "dau-utils-deadman arm --timeout 180"
     assert by_name["program-volatile"] == "openFPGALoader -c digilent_hs2 /tmp/design.bit"
     assert "-f" not in by_name["program-volatile"].split()  # VOLATILE, never raw persistent

--- a/dau_build/tests/test_publish_inventory.py
+++ b/dau_build/tests/test_publish_inventory.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dau_build.packaging import load_artifact_manifest
+from dau_build.publish_inventory import PUBLISHED_METADATA_KEYS, publish_inventory, write_published_inventory
+from dau_build.shell_build import shell_build_manifest
+
+_CONTRACT = {
+    "lanes": [
+        {"tile": {"core": "int32-example-sort", "unit_kind": "sort", "opcodes": []}},
+        {"tile": {"core": "int32-example-sort", "unit_kind": "sort", "opcodes": []}},
+        {"tile": {"core": "int32-example-sum", "unit_kind": "aggregation", "opcodes": ["sum", "count"]}},
+    ]
+}
+
+
+def _build_root(tmp_path: Path) -> Path:
+    (tmp_path / "dau_mm_job.bit").write_bytes(b"bitstream")
+    (tmp_path / "console.log").write_text("build chatter")
+    (tmp_path / "build_mm_job.tcl").write_text("# tcl")
+    (tmp_path / "utilization_mm.rpt").write_text("util")
+    sources = tmp_path / "hdl"
+    sources.mkdir()
+    (sources / "dau_int32_private_tile.sv").write_text("module dau_int32_private_tile; endmodule")
+    return tmp_path
+
+
+def _private_manifest(tmp_path: Path):
+    root = _build_root(tmp_path)
+    return shell_build_manifest(
+        root,
+        name="example-shell",
+        source_paths=(root / "hdl" / "dau_int32_private_tile.sv",),
+        metadata={
+            "platform": "example-board",
+            "part": "xc7a200tfbg484-2",
+            "top_module": "dau_mm_job",
+            "spec_hash": "5:deadbeefcafe",
+            "composition_spec": '{"lanes":[{"tile":{"core":"int32-example-sort"}}]}',
+            "resource_estimate_lut": "3116",
+            "wns_ns": 0.161,
+            "build_status": "built",
+        },
+    )
+
+
+def test_the_private_manifest_carries_what_a_build_record_needs(tmp_path: Path) -> None:
+    """The projection exists because the source manifest is a full build
+    record — this pins what it holds, so a change there is visible here."""
+    manifest = _private_manifest(tmp_path)
+    assert {artifact.role for artifact in manifest.artifacts} >= {"bitstream", "hdl-source", "build-log"}
+    assert "source_repositories" in manifest.metadata
+    assert "composition_spec" in manifest.metadata
+
+
+def test_publish_inventory_keeps_only_the_bitstream_and_its_capabilities(tmp_path: Path) -> None:
+    published = publish_inventory(_private_manifest(tmp_path), contract=_CONTRACT)
+
+    (artifact,) = published.artifacts
+    assert artifact.role == "bitstream"
+    # the NAME, never the build-host path it was produced at
+    assert Path(artifact.path).name == "dau_mm_job.bit" and Path(artifact.path).parent == Path(".")
+    assert artifact.digest is not None
+
+    advertised = {capability.name: dict(capability.metadata) for capability in artifact.provides}
+    assert advertised == {
+        "int32-example-sort": {"count": 2, "unit_kind": "sort"},
+        "int32-example-sum": {"count": 1, "unit_kind": "aggregation", "opcodes": ["sum", "count"]},
+    }
+
+
+def test_publish_inventory_withholds_everything_not_whitelisted(tmp_path: Path) -> None:
+    """A denylist rots the first time a metadata key is added upstream. The
+    projection whitelists, so forgetting to update it yields an inventory
+    that is missing something rather than one that discloses something."""
+    published = publish_inventory(_private_manifest(tmp_path), contract=_CONTRACT)
+    text = published.to_yaml_text()
+
+    assert set(published.metadata) <= set(PUBLISHED_METADATA_KEYS)
+    for withheld in (
+        "dau_int32_private_tile",  # the core library's table of contents
+        "source_repositories",  # local paths + git state of private repos
+        "composition_spec",  # the exact datapath recipe
+        "spec_hash",
+        "resource_estimate_lut",
+        "wns_ns",
+        "console.log",
+        str(tmp_path),  # any build-host path at all
+    ):
+        assert withheld not in text, f"published inventory disclosed {withheld!r}"
+
+
+def test_an_unknown_metadata_key_is_withheld_by_default(tmp_path: Path) -> None:
+    """The property that makes the whitelist worth having."""
+    manifest = _private_manifest(tmp_path)
+    manifest = manifest.model_copy(update={"metadata": {**manifest.metadata, "a_key_added_later": "secret"}})
+    published = publish_inventory(manifest, contract=_CONTRACT)
+    assert "a_key_added_later" not in published.metadata
+    assert "secret" not in published.to_yaml_text()
+
+
+def test_publish_inventory_refuses_a_manifest_without_exactly_one_bitstream(tmp_path: Path) -> None:
+    manifest = _private_manifest(tmp_path)
+    without = manifest.model_copy(update={"artifacts": tuple(a for a in manifest.artifacts if a.role != "bitstream")})
+    with pytest.raises(ValueError, match="exactly one bitstream"):
+        publish_inventory(without)
+
+
+def test_write_published_inventory_round_trips(tmp_path: Path) -> None:
+    build_root = tmp_path / "build"
+    build_root.mkdir()
+    manifest = _private_manifest(build_root)
+    manifest_path = tmp_path / "shell-build.artifacts.yaml"
+    manifest_path.write_text(manifest.to_yaml_text(), encoding="utf-8")
+
+    destination = write_published_inventory(manifest_path, tmp_path / "published" / "inventory.yaml", contract=_CONTRACT)
+
+    reloaded = load_artifact_manifest(destination)
+    assert len(reloaded.artifacts) == 1
+    assert {capability.name for capability in reloaded.artifacts[0].provides} == {"int32-example-sort", "int32-example-sum"}

--- a/dau_build/tests/test_publish_inventory.py
+++ b/dau_build/tests/test_publish_inventory.py
@@ -109,6 +109,29 @@ def test_publish_inventory_refuses_a_manifest_without_exactly_one_bitstream(tmp_
         publish_inventory(without)
 
 
+def test_publish_inventory_refuses_a_bitstream_that_missed_timing(tmp_path: Path) -> None:
+    """Publishing an image claims it runs. The margin itself stays withheld,
+    so this refusal is what makes the claim worth anything."""
+    manifest = _private_manifest(tmp_path)
+    missed = manifest.model_copy(update={"metadata": {**manifest.metadata, "wns_ns": -0.348}})
+    with pytest.raises(ValueError, match="missed timing"):
+        publish_inventory(missed, contract=_CONTRACT)
+
+
+def test_publish_inventory_refuses_an_unfinished_build(tmp_path: Path) -> None:
+    manifest = _private_manifest(tmp_path)
+    unfinished = manifest.model_copy(update={"metadata": {**manifest.metadata, "build_status": "planned"}})
+    with pytest.raises(ValueError, match="build_status"):
+        publish_inventory(unfinished, contract=_CONTRACT)
+
+
+def test_the_published_bitstream_says_which_image_kind_it_is(tmp_path: Path) -> None:
+    """An SRAM load wants the .bit and an SPI flash wants the .mcs."""
+    published = publish_inventory(_private_manifest(tmp_path), contract=_CONTRACT)
+    (artifact,) = published.artifacts
+    assert artifact.format == "bit"
+
+
 def test_write_published_inventory_round_trips(tmp_path: Path) -> None:
     build_root = tmp_path / "build"
     build_root.mkdir()

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -89,14 +89,29 @@ def test_parse_reports_builds_envelope_and_flags_drift(tmp_path: Path) -> None:
     definition = core("int32-streaming-top-k")
     (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT)
     (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text(_TIMING_RPT)
-    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, part="xc7a200tfbg484-2", clock_period_ns=8.0)
+    # this core carries a measurement SURFACE: several points share the part
+    # and clock, so the comparison is only meaningful with the params too
+    at_k8 = {"part": "xc7a200tfbg484-2", "clock_period_ns": 8.0, "params": {"K": 8}}
+    report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, **at_k8)
     assert (report.lut, report.ff, report.bram36, report.dsp) == (1295, 1196, 0.0, 0)
     assert report.wns_ns == 4.350 and report.met
-    assert report.registered_matches is True  # the registered envelope came from this shape
+    assert report.registered_matches is True  # the registered point came from this shape
 
     (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT.replace("1295", "999"))
-    drifted = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, part="xc7a200tfbg484-2", clock_period_ns=8.0)
+    drifted = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, **at_k8)
     assert drifted.registered_matches is False
+
+
+def test_parse_reports_needs_params_to_compare_a_measurement_surface() -> None:
+    """Without params there is no way to tell which point of a surface the
+    build corresponds to, so the comparison is skipped rather than made
+    against whichever point happens to be first."""
+    from dau_core.cores import core
+
+    definition = core("int32-streaming-top-k")
+    assert isinstance(definition.resources, (list, tuple)) and len(definition.resources) > 1
+    points_at_that_coordinate = [m for m in definition.resources if m.part == "xc7a200tfbg484-2" and m.clock_ns == 8.0]
+    assert len(points_at_that_coordinate) > 1, "the guard only matters for a surface"
 
 
 def test_parse_reports_negative_slack_is_violated(tmp_path: Path) -> None:
@@ -177,3 +192,31 @@ def test_overridden_parameters_skip_envelope_comparison(tmp_path: Path) -> None:
 def test_package_entries_are_rejected(tmp_path: Path) -> None:
     with pytest.raises(BuildStepError, match="not a synthesizable top"):
         _task(tmp_path, cores=("/dau-core/aggregation-pkg",))(NullContext())
+
+
+def test_dau_build_never_imports_a_private_core_package() -> None:
+    """dau-build is PUBLIC and ships to PyPI; a private package is not a
+    declared dependency, so importing one is a runtime landmine for any
+    public install. Cores resolve through the ccflow ModelRegistry that a
+    provider composes onto the shared hydra searchpath."""
+    import ast
+    from pathlib import Path
+
+    package_root = Path(__file__).resolve().parent.parent
+    offenders: list[str] = []
+    for path in package_root.rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                names = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom):
+                names = [node.module or ""]
+            else:
+                continue
+            for name in names:
+                root = name.split(".")[0]
+                if root in {"dau_core", "dau_driver", "dau_polars", "dau"}:
+                    offenders.append(f"{path.relative_to(package_root)}:{node.lineno} imports {name}")
+    assert not offenders, "public package imports a private one:\n" + "\n".join(offenders)

--- a/dau_build/tests/test_synthesize_cores.py
+++ b/dau_build/tests/test_synthesize_cores.py
@@ -102,16 +102,25 @@ def test_parse_reports_builds_envelope_and_flags_drift(tmp_path: Path) -> None:
     assert drifted.registered_matches is False
 
 
-def test_parse_reports_needs_params_to_compare_a_measurement_surface() -> None:
-    """Without params there is no way to tell which point of a surface the
-    build corresponds to, so the comparison is skipped rather than made
-    against whichever point happens to be first."""
+def test_parse_reports_needs_every_axis_to_compare_a_measurement_surface(tmp_path: Path) -> None:
+    """A point is keyed by (part, clock, params). Drop any axis and there is
+    no way to tell which point of a surface the build corresponds to, so the
+    comparison is skipped rather than made against whichever point happens
+    to be first — including the clock, which matters the moment a tile
+    carries the same part and params at two clocks."""
     from dau_core.cores import core
 
     definition = core("int32-streaming-top-k")
     assert isinstance(definition.resources, (list, tuple)) and len(definition.resources) > 1
-    points_at_that_coordinate = [m for m in definition.resources if m.part == "xc7a200tfbg484-2" and m.clock_ns == 8.0]
-    assert len(points_at_that_coordinate) > 1, "the guard only matters for a surface"
+    (tmp_path / "dau_int32_streaming_top_k.util.rpt").write_text(_UTIL_RPT)
+    (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text(_TIMING_RPT)
+
+    full = {"part": "xc7a200tfbg484-2", "clock_period_ns": 8.0, "params": {"K": 8}}
+    assert SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, **full).registered_matches is True
+    for dropped in ("clock_period_ns", "params"):
+        coordinate = {**full, dropped: None}
+        report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path, **coordinate)
+        assert report.registered_matches is None, f"dropping {dropped} still selected a point"
 
 
 def test_parse_reports_negative_slack_is_violated(tmp_path: Path) -> None:
@@ -122,6 +131,19 @@ def test_parse_reports_negative_slack_is_violated(tmp_path: Path) -> None:
     (tmp_path / "dau_int32_streaming_top_k.timing.rpt").write_text("Slack (VIOLATED) :        -0.898ns  (required time - arrival time)\n")
     report = SynthesizeCoresTask.parse_reports(definition, output_root=tmp_path)
     assert not report.met and report.wns_ns == -0.898
+
+
+def test_resolving_cores_leaves_the_root_registry_alone() -> None:
+    """The fallback composition must not register the core group on the root
+    registry: a later full compose by the core package would collide on a
+    name this task put there, so whether an application's own composition
+    works would depend on whether it ran a build task first."""
+    from ccflow import ModelRegistry
+
+    before = set(ModelRegistry.root().models)
+    task = SynthesizeCoresTask(cores=("/dau-core/int32-streaming-top-k",), output_root=Path("/unused"), part="xc7a200tfbg484-2")
+    assert len(task._core_registry().models) > 0
+    assert set(ModelRegistry.root().models) == before
 
 
 def test_task_composes_from_the_config_group(tmp_path: Path) -> None:


### PR DESCRIPTION
Five commits closing the dau-build findings from the standards audit.

**A public package imported a private one** (the only architectural breach). `synthesize_cores` imported `dau_core.cores` at two sites — one unguarded — while `pyproject.toml` declares no such dependency. dau-build ships to PyPI, so that was a runtime landmine for any public install.

Cores now resolve the way the module docstring already described: through the ccflow `ModelRegistry` a provider composes onto the shared hydra searchpath. When the `/dau-core` subregistry is absent the group is composed by name and **only that subtree** is registered — loading the whole composed config collides with the task's own groups. No provider installed means the composition fails and the task refuses; it never falls back to an import. The dependency closure is walked over the model's own `depends`/`source_path()` surface. **An AST guard test now fails if any dau-build module imports a private package.**

**A mistyped task read as success under `--explain`.** The `task`/`step`/`plan` groups are `optional`, so hydra drops a value it cannot find rather than failing. The normal path did refuse — with a message claiming no task was selected when one had been — but `--explain` returned before the check and printed a plausible config for a nonexistent task, which is the worst possible place for it. Selecting any of those groups composes a callable under `model`, so its absence after an explicit selection is the reliable signal, and the error names the value.

**Defensive `getattr` against declared fields.** These probed attributes that are declared on `PlatformDefinition`, `SynthesisEngine` and `HardwareToolchainConfig`. Where the *object* is genuinely optional the `None` check moved to the object. Error-message getattrs that fire precisely because a composed object failed its `isinstance` check are left alone — there the fallback to the object itself is the point.

**A drift-check bug I introduced with the top-k measurement surface.** `parse_reports` matched a registered point on part and clock only, so a core with several points at one coordinate compared against whichever came first and reported drift against a different parameter's numbers. It now matches params too, and skips the comparison when params are unknown rather than guessing.

**A publishable inventory projection.** Shell-build manifests embed absolute HDL source paths and the git state of private repositories — right for a private build record, wrong to hand out. `publish_inventory` projects one into a manifest carrying only the bitstream by digest and the operators it advertises. It **whitelists**, so forgetting to update it when a metadata key is added yields an inventory that is missing something rather than one that discloses something; a test pins that by adding an unknown key and asserting it does not survive. Capabilities arrive as plain data, so the module never imports the private core package.

Also: the staging default stamped register-map `0.1` while the contract is `0.2`.

Suite: 399 passed (one pre-existing verilator fixture failure, unrelated).
